### PR TITLE
feat: rename decomposed workflows for sfdx-git-delta detection

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -5,3 +5,12 @@ export const DEFAULT_UNIQUE_ID_ELEMENTS: string = 'fullName,name';
 export const LOG_FILE = 'disassemble.log';
 export const DECOMPOSED_FILE_TYPES: string[] = ['xml', 'json', 'yaml'];
 export const IGNORE_FILE = '.sfdecomposerignore';
+export const WORKFLOW_SUFFIX_MAPPING: { [key: string]: string } = {
+  'alerts-meta.xml': 'workflowAlert-meta.xml',
+  'fieldUpdates-meta.xml': 'workflowFieldUpdate-meta.xml',
+  'flowActions-meta.xml': 'workflowFlowAction-meta.xml',
+  'knowledgePublishes-meta.xml': 'workflowKnowledgePublish-meta.xml',
+  'outboundMessages-meta.xml': 'workflowOutboundMessage-meta.xml',
+  'rules-meta.xml': 'workflowRule-meta.xml',
+  'tasks-meta.xml': 'workflowTask-meta.xml',
+};

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -13,4 +13,5 @@ export const WORKFLOW_SUFFIX_MAPPING: { [key: string]: string } = {
   'outboundMessages-meta.xml': 'workflowOutboundMessage-meta.xml',
   'rules-meta.xml': 'workflowRule-meta.xml',
   'tasks-meta.xml': 'workflowTask-meta.xml',
+  'send-meta.xml': 'workflowSend-meta.xml',
 };


### PR DESCRIPTION
Renames the suffixes in the decomposed workflows to align with Salesforce's decomposition beta. This will allow the decomposed workflows created by this plugin to be detected by sfdx-git-delta.

This is the same update I made for Custom Labels in v5.0.0. This time for workflows. I will evaluate this type of renaming for each decomposition beta offered by Salesforce and accounted for by sfdx-git-delta.

https://github.com/forcedotcom/source-deploy-retrieve/blob/main/src/registry/metadataRegistry.json

```
    "workflow": {
      "children": {
        "directories": {
          "workflowAlerts": "workflowalert",
          "workflowFieldUpdates": "workflowfieldupdate",
          "workflowKnowledgePublishs": "workflowknowledgepublish",
          "workflowOutboundMessages": "workflowoutboundmessage",
          "workflowRules": "workflowrule",
          "workflowSends": "workflowsend",
          "workflowTasks": "workflowtask"
        },
        "suffixes": {
          "workflowAlert": "workflowalert",
          "workflowFieldUpdate": "workflowfieldupdate",
          "workflowKnowledgePublish": "workflowknowledgepublish",
          "workflowOutboundMessage": "workflowoutboundmessage",
          "workflowRule": "workflowrule",
          "workflowSend": "workflowsend",
          "workflowTask": "workflowtask"
        },
 ```
