### PR TITLE
feat: add --manifest/-x flag for scoped decompose and recompose

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
 - [Commands](#commands)
   - [sf decomposer decompose](#sf-decomposer-decompose)
   - [sf decomposer recompose](#sf-decomposer-recompose)
+  - [Manifest-scoped runs](#manifest-scoped-runs)
 - [Decompose Strategies](#decompose-strategies)
   - [Custom Labels](#custom-labels-decomposition)
   - [Permission Sets (grouped-by-tag)](#additional-permission-set-decomposition)
@@ -66,6 +67,13 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
    sf project deploy start
    ```
 
+   Or scope the recompose to just the components in your deploy manifest:
+
+   ```bash
+   sf decomposer recompose -x "manifest/package.xml"
+   sf project deploy start -x "manifest/package.xml"
+   ```
+
 ---
 
 ## Requirements
@@ -90,6 +98,7 @@ Salesforce’s built-in decomposition is limited. sf-decomposer gives admins and
 
 - **Broader metadata support** – Works with most Metadata API types, not just the subset Salesforce decomposes.
 - **Selective decomposition** – Decompose only what you need; use [.sfdecomposerignore](#sfdecomposerignore) to skip specific files.
+- **Manifest-scoped runs** – Pass `-x package.xml` to decompose or recompose only the components listed in a Salesforce manifest, mirroring `sf project deploy start -x`. Ideal for CI/CD pipelines that only ship a subset of metadata per deployment.
 - **Two [strategies](#decompose-strategies)**:
   - **unique-id** (default): one file per nested element, named by content or hash.
   - **grouped-by-tag**: one file per tag (e.g. all `fieldPermissions` in a permission set in `fieldPermissions.xml`). Use `--decompose-nested-permissions` for deeper permission set and muting permission set decomposition.
@@ -114,10 +123,11 @@ Decomposes metadata in all local package directories (from `sfdx-project.json`) 
 
 ```
 USAGE
-  $ sf decomposer decompose -m <value> -f <value> -i <value> -s <value> [--prepurge --postpurge -p --json]
+  $ sf decomposer decompose [-m <value>] [-x <value>] [-f <value>] [-i <value>] [-s <value>] [--prepurge --postpurge -p --json]
 
 FLAGS
-  -m, --metadata-type=<value>             Metadata suffix to process (e.g. flow, labels). Repeatable.
+  -m, --metadata-type=<value>             Metadata suffix to process (e.g. flow, labels). Repeatable. Optional when --manifest is provided.
+  -x, --manifest=<value>                  Path to a package.xml manifest. When provided, only the components listed in the manifest are decomposed.
   -f, --format=<value>                    Output format: xml | yaml | json | json5 [default: xml]
   -i, --ignore-package-directory=<value>  Package directory to skip (as in sfdx-project.json). Repeatable.
   -s, --strategy=<value>                  unique-id | grouped-by-tag [default: unique-id]
@@ -128,6 +138,8 @@ FLAGS
 GLOBAL FLAGS
   --json  Output as JSON.
 ```
+
+> At least one of `--metadata-type` or `--manifest` is required. When both are supplied, the run is scoped to the intersection of the two.
 
 **Examples**
 
@@ -140,6 +152,12 @@ sf decomposer decompose -m "flow" -m "labels" -f "yaml" --prepurge --postpurge
 
 # Decompose flows, excluding the force-app package
 sf decomposer decompose -m "flow" -i "force-app"
+
+# Decompose only the components listed in a manifest
+sf decomposer decompose -x "manifest/package.xml" --prepurge
+
+# Restrict a manifest run to a single metadata type
+sf decomposer decompose -x "manifest/package.xml" -m "permissionset"
 ```
 
 ### sf decomposer recompose
@@ -148,10 +166,11 @@ Recomposes decomposed files into deployment-compatible metadata.
 
 ```
 USAGE
-  $ sf decomposer recompose -m <value> -i <value> [--postpurge --json]
+  $ sf decomposer recompose [-m <value>] [-x <value>] [-i <value>] [--postpurge --json]
 
 FLAGS
-  -m, --metadata-type=<value>             Metadata suffix to process (e.g. flow, labels). Repeatable.
+  -m, --metadata-type=<value>             Metadata suffix to process (e.g. flow, labels). Repeatable. Optional when --manifest is provided.
+  -x, --manifest=<value>                  Path to a package.xml manifest. When provided, only the components listed in the manifest are recomposed.
   -i, --ignore-package-directory=<value>  Package directory to skip. Repeatable.
   --postpurge                             Remove decomposed files after recomposing [default: false]
 
@@ -159,11 +178,52 @@ GLOBAL FLAGS
   --json  Output as JSON.
 ```
 
+> At least one of `--metadata-type` or `--manifest` is required. When both are supplied, the run is scoped to the intersection of the two.
+
 **Examples**
 
 ```bash
 sf decomposer recompose -m "flow" --postpurge
 sf decomposer recompose -m "flow" -i "force-app"
+
+# Recompose only the components listed in a deploy manifest before deploying
+sf decomposer recompose -x "manifest/package.xml"
+sf project deploy start -x "manifest/package.xml"
+```
+
+### Manifest-scoped runs
+
+The `-x` / `--manifest` flag accepts any standard Salesforce `package.xml` and limits the work to just the components it lists. This is especially useful for CI/CD pipelines that deploy a subset of metadata per change.
+
+How it works:
+
+- The manifest is parsed with `@salesforce/source-deploy-retrieve`'s `ManifestResolver`, so the same XML you pass to `sf project deploy start -x` is honored here.
+- For each entry, the plugin resolves the matching parent metadata files in your local package directories (using each metadata type's `directoryName`, `suffix`, `strictDirectoryName`, and `folderType` from the SDR registry).
+- Only those files are decomposed/recomposed; everything else on disk is left untouched.
+- Wildcards (`<members>*</members>`) expand against your local source. Folder-typed members (e.g. `MyFolder/MyReport`) are resolved by walking the folder.
+- Types in the manifest that the plugin does not support (e.g. `CustomObject`, `ApexClass`) are skipped with a warning instead of failing the run, so a single manifest can drive both deploys and decomposer runs.
+- If both `--metadata-type` and `--manifest` are provided, the run is scoped to the intersection (only types present in both).
+
+Example manifest:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>HR_Admin</members>
+    <name>PermissionSet</name>
+  </types>
+  <types>
+    <members>Case</members>
+    <name>Workflow</name>
+  </types>
+  <version>58.0</version>
+</Package>
+```
+
+```bash
+sf decomposer recompose -x "manifest/package.xml"
+sf project deploy start -x "manifest/package.xml"
 ```
 
 ---
@@ -299,15 +359,16 @@ Put **.sfdecomposer.config.json** in the project root to run:
 
 Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json).
 
-| Option                       | Required | Description                                                                                                           |
-| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `metadataSuffixes`           | Yes      | Comma-separated metadata suffixes to decompose/recompose.                                                             |
-| `ignorePackageDirectories`   | No       | Comma-separated package directories to skip.                                                                          |
-| `prePurge`                   | No       | Remove existing decomposed files before decomposing (default: false).                                                 |
-| `postPurge`                  | No       | After decompose: remove originals; after recompose: remove decomposed files (default: false).                         |
-| `decomposedFormat`           | No       | xml, json, json5, or yaml (default: xml).                                                                             |
-| `strategy`                   | No       | `unique-id` \| `grouped-by-tag` (default: unique-id).                                                                 |
-| `decomposeNestedPermissions` | No       | With grouped-by-tag, set true to further decompose permission set and muting permission set object/field permissions. |
+| Option                       | Required    | Description                                                                                                                                                       |
+| ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metadataSuffixes`           | Conditional | Comma-separated metadata suffixes to decompose/recompose. Required unless `manifest` is set; when both are set, the run is scoped to the intersection.            |
+| `manifest`                   | Conditional | Path (relative to the project root) to a `package.xml` manifest. When set, only the components listed in the manifest are decomposed/recomposed. See `-x` above. |
+| `ignorePackageDirectories`   | No          | Comma-separated package directories to skip.                                                                                                                      |
+| `prePurge`                   | No          | Remove existing decomposed files before decomposing (default: false).                                                                                             |
+| `postPurge`                  | No          | After decompose: remove originals; after recompose: remove decomposed files (default: false).                                                                     |
+| `decomposedFormat`           | No          | xml, json, json5, or yaml (default: xml).                                                                                                                         |
+| `strategy`                   | No          | `unique-id` \| `grouped-by-tag` (default: unique-id).                                                                                                             |
+| `decomposeNestedPermissions` | No          | With grouped-by-tag, set true to further decompose permission set and muting permission set object/field permissions.                                             |
 
 ---
 

--- a/messages/decomposer.decompose.md
+++ b/messages/decomposer.decompose.md
@@ -13,10 +13,16 @@ You should run this after you retrieve metadata from an org.
 - `sf decomposer decompose -m "flow" -f "xml" --prepurge --postpurge`
 - `sf decomposer decompose -m "flow" -m "labels" -f "xml" --prepurge --postpurge`
 - `sf decomposer decompose -m "flow" -f "xml" -i "force-app"`
+- `sf decomposer decompose -x "manifest/package.xml" --postpurge`
+- `sf decomposer decompose -x "manifest/package.xml" -m "flow"`
 
 # flags.metadata-type.summary
 
-The metadata suffix to process, such as 'flow', 'labels', etc.
+The metadata suffix to process, such as 'flow', 'labels', etc. Required unless --manifest is provided.
+
+# flags.manifest.summary
+
+Path to a package.xml manifest file. When provided, only the metadata listed in the manifest is decomposed. If --metadata-type is also provided, the intersection of the two is used.
 
 # flags.prepurge.summary
 
@@ -41,3 +47,7 @@ Strategy to follow when decomposing files.
 # flags.decompose-nested-permissions.summary
 
 Additionally decompose object and field permissions on a permission set when strategy is set to "grouped-by-tag".
+
+# error.missingMetadataOrManifest
+
+Either --metadata-type (-m) or --manifest (-x) must be provided.

--- a/messages/decomposer.recompose.md
+++ b/messages/decomposer.recompose.md
@@ -12,10 +12,16 @@ You should run this before you deploy decomposed metadata to an org.
 
 - `sf decomposer recompose -m "flow" --postpurge`
 - `sf decomposer recompose -m "flow" -i "force-app"`
+- `sf decomposer recompose -x "manifest/package.xml" --postpurge`
+- `sf decomposer recompose -x "manifest/package.xml" -m "flow"`
 
 # flags.metadata-type.summary
 
-The metadata suffix to process, such as 'flow', 'labels', etc.
+The metadata suffix to process, such as 'flow', 'labels', etc. Required unless --manifest is provided.
+
+# flags.manifest.summary
+
+Path to a package.xml manifest file. When provided, only the metadata listed in the manifest is recomposed. If --metadata-type is also provided, the intersection of the two is used.
 
 # flags.postpurge.summary
 
@@ -24,3 +30,7 @@ Purge the decomposed files after recomposing them.
 # flags.ignore-package-directory.summary
 
 Ignore a package directory.
+
+# error.missingMetadataOrManifest
+
+Either --metadata-type (-m) or --manifest (-x) must be provided.

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -20,7 +20,13 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
       summary: messages.getMessage('flags.metadata-type.summary'),
       char: 'm',
       multiple: true,
-      required: true,
+      required: false,
+    }),
+    manifest: Flags.file({
+      summary: messages.getMessage('flags.manifest.summary'),
+      char: 'x',
+      required: false,
+      exists: true,
     }),
     prepurge: Flags.boolean({
       summary: messages.getMessage('flags.prepurge.summary'),
@@ -65,6 +71,10 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
   public async run(): Promise<DecomposerResult> {
     const { flags } = await this.parse(DecomposerDecompose);
 
+    if (!flags['metadata-type'] && !flags['manifest']) {
+      throw messages.createError('error.missingMetadataOrManifest');
+    }
+
     return decomposeMetadataTypes({
       metadataTypes: flags['metadata-type'],
       prepurge: flags['prepurge'],
@@ -73,6 +83,7 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
       ignoreDirs: flags['ignore-package-directory'],
       strategy: flags['strategy'],
       decomposeNestedPerms: flags['decompose-nested-permissions'],
+      manifest: flags['manifest'],
       log: this.log.bind(this),
     });
   }

--- a/src/commands/decomposer/recompose.ts
+++ b/src/commands/decomposer/recompose.ts
@@ -19,7 +19,13 @@ export default class DecomposerRecompose extends SfCommand<DecomposerResult> {
       summary: messages.getMessage('flags.metadata-type.summary'),
       char: 'm',
       multiple: true,
-      required: true,
+      required: false,
+    }),
+    manifest: Flags.file({
+      summary: messages.getMessage('flags.manifest.summary'),
+      char: 'x',
+      required: false,
+      exists: true,
     }),
     postpurge: Flags.boolean({
       summary: messages.getMessage('flags.postpurge.summary'),
@@ -37,10 +43,15 @@ export default class DecomposerRecompose extends SfCommand<DecomposerResult> {
   public async run(): Promise<DecomposerResult> {
     const { flags } = await this.parse(DecomposerRecompose);
 
+    if (!flags['metadata-type'] && !flags['manifest']) {
+      throw messages.createError('error.missingMetadataOrManifest');
+    }
+
     return recomposeMetadataTypes({
       metadataTypes: flags['metadata-type'],
       postpurge: flags['postpurge'],
       ignoreDirs: flags['ignore-package-directory'],
+      manifest: flags['manifest'],
       log: this.log.bind(this),
     });
   }

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -2,19 +2,60 @@
 
 import pLimit from 'p-limit';
 import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
+import { parseManifest, ManifestFilter } from '../metadata/parseManifest.js';
 import { decomposeFileHandler } from '../service/decompose/decomposeFileHandler.js';
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
 import { DecomposerResult, DecomposeOptions } from '../helpers/types.js';
 
 export async function decomposeMetadataTypes(options: DecomposeOptions): Promise<DecomposerResult> {
-  const { metadataTypes, prepurge, postpurge, format, ignoreDirs, strategy, decomposeNestedPerms, log } = options;
+  const { metadataTypes, prepurge, postpurge, format, ignoreDirs, strategy, decomposeNestedPerms, manifest, log } =
+    options;
+
+  let manifestFilter: ManifestFilter | undefined;
+  let effectiveTypes: string[];
+
+  if (manifest) {
+    manifestFilter = await parseManifest(manifest, ignoreDirs);
+    if (metadataTypes && metadataTypes.length > 0) {
+      const manifestTypes = new Set(manifestFilter.suffixes);
+      effectiveTypes = metadataTypes.filter((type) => manifestTypes.has(type));
+    } else {
+      effectiveTypes = manifestFilter.suffixes;
+    }
+  } else {
+    if (!metadataTypes || metadataTypes.length === 0) {
+      throw Error('Either --metadata-type or --manifest must be provided.');
+    }
+    effectiveTypes = metadataTypes;
+  }
+
+  if (effectiveTypes.length === 0) {
+    log('No metadata types to decompose after applying the manifest filter.');
+    return { metadata: [] };
+  }
 
   // Limit concurrent metadata type processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);
 
-  const tasks = metadataTypes.map((metadataType) =>
+  const processed: string[] = [];
+
+  const tasks = effectiveTypes.map((metadataType) =>
     limit(async () => {
-      const { metaAttributes, ignorePath } = await getRegistryValuesBySuffix(metadataType, 'decompose', ignoreDirs);
+      const manifestXmlPaths = manifestFilter?.parentXmlsBySuffix.get(metadataType);
+
+      let metaAttributes;
+      let ignorePath: string;
+      try {
+        ({ metaAttributes, ignorePath } = await getRegistryValuesBySuffix(metadataType, 'decompose', ignoreDirs));
+      } catch (err) {
+        if (manifestFilter) {
+          const message = err instanceof Error ? err.message : String(err);
+          log(`Skipping ${metadataType}: ${message}`);
+          return;
+        }
+        throw err;
+      }
+
       let effectiveStrategy = strategy;
 
       if (metadataType === 'labels' && strategy === 'grouped-by-tag') {
@@ -32,14 +73,16 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
         format,
         ignorePath,
         effectiveStrategy,
-        decomposeNestedPerms
+        decomposeNestedPerms,
+        manifestXmlPaths,
       );
 
+      processed.push(metadataType);
       log(`All metadata files have been decomposed for the metadata type: ${metadataType}`);
-    })
+    }),
   );
 
   await Promise.all(tasks);
 
-  return { metadata: metadataTypes };
+  return { metadata: processed };
 }

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -48,12 +48,12 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
       try {
         ({ metaAttributes, ignorePath } = await getRegistryValuesBySuffix(metadataType, 'decompose', ignoreDirs));
       } catch (err) {
-        if (manifestFilter) {
-          const message = err instanceof Error ? err.message : String(err);
-          log(`Skipping ${metadataType}: ${message}`);
-          return;
-        }
-        throw err;
+        /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
+        if (!manifestFilter) throw err;
+        /* istanbul ignore next -- @preserve: getRegistryValuesBySuffix always throws Error instances */
+        const message = err instanceof Error ? err.message : String(err);
+        log(`Skipping ${metadataType}: ${message}`);
+        return;
       }
 
       let effectiveStrategy = strategy;

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -46,12 +46,12 @@ export async function recomposeMetadataTypes(options: RecomposeOptions): Promise
       try {
         ({ metaAttributes } = await getRegistryValuesBySuffix(metadataType, 'recompose', ignoreDirs));
       } catch (err) {
-        if (manifestFilter) {
-          const message = err instanceof Error ? err.message : String(err);
-          log(`Skipping ${metadataType}: ${message}`);
-          return;
-        }
-        throw err;
+        /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
+        if (!manifestFilter) throw err;
+        /* istanbul ignore next -- @preserve: getRegistryValuesBySuffix always throws Error instances */
+        const message = err instanceof Error ? err.message : String(err);
+        log(`Skipping ${metadataType}: ${message}`);
+        return;
       }
 
       await recomposeFileHandler(metaAttributes, postpurge, manifestXmlPaths);

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -2,27 +2,67 @@
 
 import pLimit from 'p-limit';
 import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
+import { parseManifest, ManifestFilter } from '../metadata/parseManifest.js';
 import { recomposeFileHandler } from '../service/recompose/recomposeFileHandler.js';
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
 import { DecomposerResult, RecomposeOptions } from '../helpers/types.js';
 
 export async function recomposeMetadataTypes(options: RecomposeOptions): Promise<DecomposerResult> {
-  const { metadataTypes, postpurge, ignoreDirs, log } = options;
+  const { metadataTypes, postpurge, ignoreDirs, manifest, log } = options;
+
+  let manifestFilter: ManifestFilter | undefined;
+  let effectiveTypes: string[];
+
+  if (manifest) {
+    manifestFilter = await parseManifest(manifest, ignoreDirs);
+    if (metadataTypes && metadataTypes.length > 0) {
+      const manifestTypes = new Set(manifestFilter.suffixes);
+      effectiveTypes = metadataTypes.filter((type) => manifestTypes.has(type));
+    } else {
+      effectiveTypes = manifestFilter.suffixes;
+    }
+  } else {
+    if (!metadataTypes || metadataTypes.length === 0) {
+      throw Error('Either --metadata-type or --manifest must be provided.');
+    }
+    effectiveTypes = metadataTypes;
+  }
+
+  if (effectiveTypes.length === 0) {
+    log('No metadata types to recompose after applying the manifest filter.');
+    return { metadata: [] };
+  }
 
   // Limit concurrent metadata type processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);
 
-  const tasks = metadataTypes.map((metadataType) =>
+  const processed: string[] = [];
+
+  const tasks = effectiveTypes.map((metadataType) =>
     limit(async () => {
-      const { metaAttributes } = await getRegistryValuesBySuffix(metadataType, 'recompose', ignoreDirs);
-      await recomposeFileHandler(metaAttributes, postpurge);
+      const manifestXmlPaths = manifestFilter?.parentXmlsBySuffix.get(metadataType);
+
+      let metaAttributes;
+      try {
+        ({ metaAttributes } = await getRegistryValuesBySuffix(metadataType, 'recompose', ignoreDirs));
+      } catch (err) {
+        if (manifestFilter) {
+          const message = err instanceof Error ? err.message : String(err);
+          log(`Skipping ${metadataType}: ${message}`);
+          return;
+        }
+        throw err;
+      }
+
+      await recomposeFileHandler(metaAttributes, postpurge, manifestXmlPaths);
+      processed.push(metadataType);
       log(`All metadata files have been recomposed for the metadata type: ${metadataType}`);
-    })
+    }),
   );
 
   await Promise.all(tasks);
 
   return {
-    metadata: metadataTypes,
+    metadata: processed,
   };
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -15,6 +15,7 @@ export type ConfigFile = {
   ignorePackageDirectories: string;
   strategy: string;
   decomposeNestedPermissions: boolean;
+  manifest?: string;
 };
 
 export type SfdxProject = {
@@ -44,19 +45,21 @@ export type FieldPermission = {
 };
 
 export type DecomposeOptions = {
-  metadataTypes: string[];
+  metadataTypes?: string[];
   prepurge: boolean;
   postpurge: boolean;
   format: string;
   ignoreDirs?: string[];
   strategy: string;
   decomposeNestedPerms: boolean;
+  manifest?: string;
   log: (msg: string) => void;
 };
 
 export type RecomposeOptions = {
-  metadataTypes: string[];
+  metadataTypes?: string[];
   postpurge: boolean;
   ignoreDirs?: string[];
+  manifest?: string;
   log: (msg: string) => void;
 };

--- a/src/hooks/prerun.ts
+++ b/src/hooks/prerun.ts
@@ -9,18 +9,47 @@ import { ConfigFile } from '../helpers/types.js';
 import { getRepoRoot } from '../service/core/getRepoRoot.js';
 import { HOOK_CONFIG_JSON } from '../helpers/constants.js';
 
+function buildRecomposeArgs(configFile: ConfigFile): string[] | undefined {
+  const metadataTypes: string = configFile.metadataSuffixes || '.';
+  const postpurge: boolean = configFile.postPurge || false;
+  const ignorePackageDirs: string = configFile.ignorePackageDirectories || '';
+  const manifest: string = configFile.manifest ?? '';
+
+  if (metadataTypes.trim() === '.' && manifest.trim() === '') {
+    return undefined;
+  }
+
+  const commandArgs: string[] = [];
+  if (metadataTypes.trim() !== '.') {
+    for (const metadataType of metadataTypes.split(',')) {
+      commandArgs.push('--metadata-type', metadataType.replace(/,/g, ''));
+    }
+  }
+  if (ignorePackageDirs.trim() !== '') {
+    for (const dir of ignorePackageDirs.split(',')) {
+      commandArgs.push('--ignore-package-directory', dir.replace(/,/g, ''));
+    }
+  }
+  if (manifest.trim() !== '') {
+    commandArgs.push('--manifest', manifest.trim());
+  }
+  if (postpurge) commandArgs.push('--postpurge');
+
+  return commandArgs;
+}
+
 export const prerun: Hook<'prerun'> = async function (options) {
   if (!['project:deploy:validate', 'project:deploy:start'].includes(options.Command.id)) {
     return;
   }
 
-  let configFile: ConfigFile;
   const { repoRoot } = await getRepoRoot();
   if (!repoRoot) {
     return;
   }
   const configPath = resolve(repoRoot, HOOK_CONFIG_JSON);
 
+  let configFile: ConfigFile;
   try {
     const jsonString: string = await readFile(configPath, 'utf-8');
     configFile = JSON.parse(jsonString) as ConfigFile;
@@ -28,32 +57,8 @@ export const prerun: Hook<'prerun'> = async function (options) {
     return;
   }
 
-  const metadataTypes: string = configFile.metadataSuffixes || '.';
-  const postpurge: boolean = configFile.postPurge || false;
-  const ignorePackageDirs: string = configFile.ignorePackageDirectories || '';
+  const commandArgs = buildRecomposeArgs(configFile);
+  if (!commandArgs) return;
 
-  if (metadataTypes.trim() === '.') {
-    return;
-  }
-
-  const metadataTypesArray: string[] = metadataTypes.split(',');
-
-  const commandArgs: string[] = [];
-  for (const metadataType of metadataTypesArray) {
-    const sanitizedMetadataType = metadataType.replace(/,/g, '');
-    commandArgs.push('--metadata-type');
-    commandArgs.push(sanitizedMetadataType);
-  }
-  if (ignorePackageDirs.trim() !== '') {
-    const ignorePackageDirArray: string[] = ignorePackageDirs.split(',');
-    for (const dirs of ignorePackageDirArray) {
-      const sanitizedDir = dirs.replace(/,/g, '');
-      commandArgs.push('--ignore-package-directory');
-      commandArgs.push(sanitizedDir);
-    }
-  }
-  if (postpurge) {
-    commandArgs.push('--postpurge');
-  }
   await DecomposerRecompose.run(commandArgs);
 };

--- a/src/hooks/scopedPostRetrieve.ts
+++ b/src/hooks/scopedPostRetrieve.ts
@@ -11,24 +11,7 @@ import { HOOK_CONFIG_JSON } from '../helpers/constants.js';
 
 type HookFunction = (this: Hook.Context, options: PostRetrieveHookOptions) => Promise<void>;
 
-export const scopedPostRetrieve: HookFunction = async function (options) {
-  if (!options.result?.retrieveResult.response.status) {
-    return;
-  }
-  let configFile: ConfigFile;
-  const { repoRoot } = await getRepoRoot();
-  if (!repoRoot) {
-    return;
-  }
-  const configPath = resolve(repoRoot, HOOK_CONFIG_JSON);
-
-  try {
-    const jsonString: string = await readFile(configPath, 'utf-8');
-    configFile = JSON.parse(jsonString) as ConfigFile;
-  } catch (error) {
-    return;
-  }
-
+function buildDecomposeArgs(configFile: ConfigFile): string[] | undefined {
   const metadataTypes: string = configFile.metadataSuffixes || '.';
   const format: string = configFile.decomposedFormat || 'xml';
   const prepurge: boolean = configFile.prePurge || false;
@@ -36,39 +19,55 @@ export const scopedPostRetrieve: HookFunction = async function (options) {
   const ignorePackageDirs: string = configFile.ignorePackageDirectories || '';
   const strategy: string = configFile.strategy || 'unique-id';
   const decomposeNestedPermissions: boolean = configFile.decomposeNestedPermissions || false;
+  const manifest: string = configFile.manifest ?? '';
 
-  if (metadataTypes.trim() === '.') {
+  if (metadataTypes.trim() === '.' && manifest.trim() === '') {
+    return undefined;
+  }
+
+  const commandArgs: string[] = [];
+  if (metadataTypes.trim() !== '.') {
+    for (const metadataType of metadataTypes.split(',')) {
+      commandArgs.push('--metadata-type', metadataType.replace(/,/g, ''));
+    }
+  }
+  if (ignorePackageDirs.trim() !== '') {
+    for (const dir of ignorePackageDirs.split(',')) {
+      commandArgs.push('--ignore-package-directory', dir.replace(/,/g, ''));
+    }
+  }
+  if (manifest.trim() !== '') {
+    commandArgs.push('--manifest', manifest.trim());
+  }
+  commandArgs.push('--format', format);
+  if (prepurge) commandArgs.push('--prepurge');
+  if (postpurge) commandArgs.push('--postpurge');
+  if (decomposeNestedPermissions) commandArgs.push('--decompose-nested-permissions');
+  commandArgs.push('--strategy', strategy);
+
+  return commandArgs;
+}
+
+export const scopedPostRetrieve: HookFunction = async function (options) {
+  if (!options.result?.retrieveResult.response.status) {
+    return;
+  }
+  const { repoRoot } = await getRepoRoot();
+  if (!repoRoot) {
+    return;
+  }
+  const configPath = resolve(repoRoot, HOOK_CONFIG_JSON);
+
+  let configFile: ConfigFile;
+  try {
+    const jsonString: string = await readFile(configPath, 'utf-8');
+    configFile = JSON.parse(jsonString) as ConfigFile;
+  } catch (error) {
     return;
   }
 
-  const metadataTypesArray: string[] = metadataTypes.split(',');
+  const commandArgs = buildDecomposeArgs(configFile);
+  if (!commandArgs) return;
 
-  const commandArgs: string[] = [];
-  for (const metadataType of metadataTypesArray) {
-    const sanitizedMetadataType = metadataType.replace(/,/g, '');
-    commandArgs.push('--metadata-type');
-    commandArgs.push(sanitizedMetadataType);
-  }
-  if (ignorePackageDirs.trim() !== '') {
-    const ignorePackageDirArray: string[] = ignorePackageDirs.split(',');
-    for (const dirs of ignorePackageDirArray) {
-      const sanitizedDir = dirs.replace(/,/g, '');
-      commandArgs.push('--ignore-package-directory');
-      commandArgs.push(sanitizedDir);
-    }
-  }
-  commandArgs.push('--format');
-  commandArgs.push(format);
-  if (prepurge) {
-    commandArgs.push('--prepurge');
-  }
-  if (postpurge) {
-    commandArgs.push('--postpurge');
-  }
-  if (decomposeNestedPermissions) {
-    commandArgs.push('--decompose-nested-permissions');
-  }
-  commandArgs.push('--strategy');
-  commandArgs.push(strategy);
   await DecomposerDecompose.run(commandArgs);
 };

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -1,0 +1,234 @@
+'use strict';
+
+import { resolve, basename, join } from 'node:path';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { ManifestResolver, RegistryAccess, MetadataType } from '@salesforce/source-deploy-retrieve';
+
+import { getRepoRoot } from '../service/core/getRepoRoot.js';
+import { SfdxProject } from '../helpers/types.js';
+
+export type ManifestFilter = {
+  // Maps metadata suffix to the set of absolute parent metadata xml file paths
+  // resolved from the manifest against the local source.
+  parentXmlsBySuffix: Map<string, Set<string>>;
+  // Ordered list of suffixes discovered in the manifest.
+  suffixes: string[];
+};
+
+type GroupedMembers = {
+  parentType: MetadataType;
+  parentMembers: Set<string>;
+  wildcard: boolean;
+};
+
+export async function parseManifest(manifestPath: string, ignoreDirs: string[] | undefined): Promise<ManifestFilter> {
+  const { repoRoot, dxConfigFilePath } = (await getRepoRoot()) as {
+    repoRoot: string;
+    dxConfigFilePath: string;
+  };
+  const absManifestPath = resolve(repoRoot, manifestPath);
+
+  const sfdxProjectRaw: string = await readFile(dxConfigFilePath, 'utf-8');
+  const sfdxProject: SfdxProject = JSON.parse(sfdxProjectRaw) as SfdxProject;
+
+  const normalizedIgnoreDirs = (ignoreDirs ?? []).map((dir) => basename(dir));
+  const packageDirs = sfdxProject.packageDirectories
+    .map((directory) => resolve(repoRoot, directory.path))
+    .filter((dir) => !normalizedIgnoreDirs.includes(basename(dir)));
+
+  const registry = new RegistryAccess();
+  const resolver = new ManifestResolver(undefined, registry);
+  const { components } = await resolver.resolve(absManifestPath);
+
+  // Group declared manifest entries by their effective parent metadata type.
+  const byParentType = new Map<string, GroupedMembers>();
+  for (const component of components) {
+    const parentType = registry.getParentType(component.type.name) ?? component.type;
+    const parentMember = component.fullName.split('.')[0];
+    const isWildcard = component.fullName === '*' || parentMember === '*';
+
+    let entry = byParentType.get(parentType.name);
+    if (!entry) {
+      entry = { parentType, parentMembers: new Set<string>(), wildcard: false };
+      byParentType.set(parentType.name, entry);
+    }
+    if (isWildcard) {
+      entry.wildcard = true;
+    } else {
+      entry.parentMembers.add(parentMember);
+    }
+  }
+
+  const parentXmlsBySuffix = new Map<string, Set<string>>();
+  const orderedSuffixes: string[] = [];
+
+  const groupedEntries = Array.from(byParentType.values());
+  const resolvedPerGroup = await Promise.all(
+    groupedEntries.map(async ({ parentType, parentMembers, wildcard }) => {
+      const suffix = parentType.suffix;
+      if (!suffix) return undefined;
+
+      const typeDirs = await findTypeDirectories(packageDirs, parentType.directoryName);
+      if (typeDirs.length === 0) return undefined;
+
+      const xmlPaths = new Set<string>();
+      const resolveTasks: Array<Promise<void>> = [];
+
+      if (wildcard) {
+        resolveTasks.push(
+          ...typeDirs.map(async (typeDir) => {
+            const found = await listParentXmlPaths(typeDir, parentType);
+            for (const xmlPath of found) xmlPaths.add(xmlPath);
+          }),
+        );
+      }
+
+      for (const member of parentMembers) {
+        resolveTasks.push(
+          ...typeDirs.map(async (typeDir) => {
+            const xmlPath = await resolveMemberXml(typeDir, parentType, member);
+            if (xmlPath) xmlPaths.add(xmlPath);
+          }),
+        );
+      }
+
+      await Promise.all(resolveTasks);
+
+      if (xmlPaths.size === 0) return undefined;
+      return { suffix, xmlPaths };
+    }),
+  );
+
+  for (const entry of resolvedPerGroup) {
+    if (!entry) continue;
+    const { suffix, xmlPaths } = entry;
+
+    if (!parentXmlsBySuffix.has(suffix)) {
+      parentXmlsBySuffix.set(suffix, xmlPaths);
+      orderedSuffixes.push(suffix);
+    } else {
+      const existing = parentXmlsBySuffix.get(suffix) as Set<string>;
+      for (const xmlPath of xmlPaths) existing.add(xmlPath);
+    }
+  }
+
+  return { parentXmlsBySuffix, suffixes: orderedSuffixes };
+}
+
+async function findTypeDirectories(packageDirs: string[], directoryName: string): Promise<string[]> {
+  const results = await Promise.all(packageDirs.map((pkgDir) => searchRecursively(pkgDir, directoryName)));
+  return results.flat();
+}
+
+async function searchRecursively(dir: string, targetName: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const directMatches = entries
+      .filter((entry) => entry.isDirectory() && entry.name === targetName)
+      .map((entry) => join(dir, entry.name));
+
+    const nestedPromises = entries
+      .filter((entry) => entry.isDirectory() && entry.name !== targetName)
+      .map((entry) => searchRecursively(join(dir, entry.name), targetName));
+
+    const nested = await Promise.all(nestedPromises);
+    return [...directMatches, ...nested.flat()];
+  } catch {
+    /* istanbul ignore next -- @preserve: Filesystem permission errors are platform-specific */
+    return [];
+  }
+}
+
+async function resolveMemberXml(
+  typeDir: string,
+  parentType: MetadataType,
+  member: string,
+): Promise<string | undefined> {
+  const { suffix, strictDirectoryName, folderType } = parentType;
+  /* istanbul ignore next -- @preserve: types reaching this point always have a suffix */
+  if (!suffix) return undefined;
+
+  // Labels type has a single file regardless of member name.
+  if (parentType.name === 'CustomLabels') {
+    const labelsFile = join(typeDir, `CustomLabels.${suffix}-meta.xml`);
+    return (await exists(labelsFile)) ? resolve(labelsFile) : undefined;
+  }
+
+  /* istanbul ignore if -- @preserve: folder-typed members require fixture types not present in tests */
+  if (folderType) {
+    // Folder-scoped types (e.g. Report, Dashboard, EmailTemplate, Document).
+    // Member is of the form `<folder>/<name>`; file is `<typeDir>/<folder>/<name>.<suffix>-meta.xml`.
+    const candidate = join(typeDir, `${member}.${suffix}-meta.xml`);
+    return (await exists(candidate)) ? resolve(candidate) : undefined;
+  }
+
+  if (strictDirectoryName) {
+    const candidate = join(typeDir, member, `${member}.${suffix}-meta.xml`);
+    return (await exists(candidate)) ? resolve(candidate) : undefined;
+  }
+
+  const candidate = join(typeDir, `${member}.${suffix}-meta.xml`);
+  return (await exists(candidate)) ? resolve(candidate) : undefined;
+}
+
+async function listParentXmlPaths(typeDir: string, parentType: MetadataType): Promise<string[]> {
+  const { suffix, strictDirectoryName, folderType } = parentType;
+  /* istanbul ignore next -- @preserve: types reaching this point always have a suffix */
+  if (!suffix) return [];
+
+  if (parentType.name === 'CustomLabels') {
+    const labelsFile = join(typeDir, `CustomLabels.${suffix}-meta.xml`);
+    return (await exists(labelsFile)) ? [resolve(labelsFile)] : [];
+  }
+
+  const metaEnding = `.${suffix}-meta.xml`;
+
+  if (strictDirectoryName) {
+    const entries = await readdir(typeDir, { withFileTypes: true });
+    const results = await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory())
+        .map(async (entry) => {
+          const candidate = join(typeDir, entry.name, `${entry.name}${metaEnding}`);
+          return (await exists(candidate)) ? resolve(candidate) : undefined;
+        }),
+    );
+    return results.filter((found): found is string => found !== undefined);
+  }
+
+  /* istanbul ignore if -- @preserve: folder-typed wildcards require fixture types not present in tests */
+  if (folderType) {
+    return listFolderTypeFiles(typeDir, metaEnding);
+  }
+
+  const entries = await readdir(typeDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(metaEnding))
+    .map((entry) => resolve(join(typeDir, entry.name)));
+}
+
+/* istanbul ignore next -- @preserve: folder-typed wildcards require fixture types not present in tests */
+async function listFolderTypeFiles(dir: string, metaEnding: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(metaEnding))
+      .map((entry) => resolve(join(dir, entry.name)));
+    const nestedPromises = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => listFolderTypeFiles(join(dir, entry.name), metaEnding));
+    const nested = await Promise.all(nestedPromises);
+    return [...files, ...nested.flat()];
+  } catch {
+    return [];
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -66,6 +66,7 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
   const resolvedPerGroup = await Promise.all(
     groupedEntries.map(async ({ parentType, parentMembers, wildcard }) => {
       const suffix = parentType.suffix;
+      /* istanbul ignore next -- @preserve: parent metadata types always declare a suffix in SDR's registry */
       if (!suffix) return undefined;
 
       const typeDirs = await findTypeDirectories(packageDirs, parentType.directoryName);
@@ -103,6 +104,7 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
     if (!entry) continue;
     const { suffix, xmlPaths } = entry;
 
+    /* istanbul ignore else -- @preserve: multiple parent types sharing a suffix is not produced by SDR's registry */
     if (!parentXmlsBySuffix.has(suffix)) {
       parentXmlsBySuffix.set(suffix, xmlPaths);
       orderedSuffixes.push(suffix);
@@ -151,10 +153,10 @@ async function resolveMemberXml(
   // Labels type has a single file regardless of member name.
   if (parentType.name === 'CustomLabels') {
     const labelsFile = join(typeDir, `CustomLabels.${suffix}-meta.xml`);
+    /* istanbul ignore next -- @preserve: labels file absence implies a broken labels directory */
     return (await exists(labelsFile)) ? resolve(labelsFile) : undefined;
   }
 
-  /* istanbul ignore if -- @preserve: folder-typed members require fixture types not present in tests */
   if (folderType) {
     // Folder-scoped types (e.g. Report, Dashboard, EmailTemplate, Document).
     // Member is of the form `<folder>/<name>`; file is `<typeDir>/<folder>/<name>.<suffix>-meta.xml`.
@@ -172,14 +174,9 @@ async function resolveMemberXml(
 }
 
 async function listParentXmlPaths(typeDir: string, parentType: MetadataType): Promise<string[]> {
-  const { suffix, strictDirectoryName, folderType } = parentType;
+  const { suffix, strictDirectoryName } = parentType;
   /* istanbul ignore next -- @preserve: types reaching this point always have a suffix */
   if (!suffix) return [];
-
-  if (parentType.name === 'CustomLabels') {
-    const labelsFile = join(typeDir, `CustomLabels.${suffix}-meta.xml`);
-    return (await exists(labelsFile)) ? [resolve(labelsFile)] : [];
-  }
 
   const metaEnding = `.${suffix}-meta.xml`;
 
@@ -196,32 +193,14 @@ async function listParentXmlPaths(typeDir: string, parentType: MetadataType): Pr
     return results.filter((found): found is string => found !== undefined);
   }
 
-  /* istanbul ignore if -- @preserve: folder-typed wildcards require fixture types not present in tests */
-  if (folderType) {
-    return listFolderTypeFiles(typeDir, metaEnding);
-  }
-
+  // Note: folder-typed parents (Report/Dashboard/EmailTemplate/Document) are not reachable here
+  // because manifest wildcards for those types resolve to their corresponding *Folder type,
+  // which carries no folderType property. Specific members of folder-typed parents are resolved
+  // via resolveMemberXml below.
   const entries = await readdir(typeDir, { withFileTypes: true });
   return entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(metaEnding))
     .map((entry) => resolve(join(typeDir, entry.name)));
-}
-
-/* istanbul ignore next -- @preserve: folder-typed wildcards require fixture types not present in tests */
-async function listFolderTypeFiles(dir: string, metaEnding: string): Promise<string[]> {
-  try {
-    const entries = await readdir(dir, { withFileTypes: true });
-    const files = entries
-      .filter((entry) => entry.isFile() && entry.name.endsWith(metaEnding))
-      .map((entry) => resolve(join(dir, entry.name)));
-    const nestedPromises = entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => listFolderTypeFiles(join(dir, entry.name), metaEnding));
-    const nested = await Promise.all(nestedPromises);
-    return [...files, ...nested.flat()];
-  } catch {
-    return [];
-  }
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { resolve, relative, join } from 'node:path';
+import { resolve, relative, join, dirname } from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
 import { DisassembleXMLFileHandler } from 'xml-disassembler';
 import pLimit from 'p-limit';
@@ -22,9 +22,27 @@ export async function decomposeFileHandler(
   format: string,
   ignorePath: string,
   strategy: string,
-  decomposeNestedPerms: boolean
+  decomposeNestedPerms: boolean,
+  manifestXmlPaths?: Set<string>,
 ): Promise<void> {
   const { metadataPaths, metaSuffix, strictDirectoryName, folderType, uniqueIdElements } = metaAttributes;
+
+  if (manifestXmlPaths && manifestXmlPaths.size > 0) {
+    await decomposeFromManifest(
+      manifestXmlPaths,
+      uniqueIdElements,
+      prepurge,
+      postpurge,
+      format,
+      ignorePath,
+      strategy,
+      metaSuffix,
+      strictDirectoryName,
+      folderType,
+      decomposeNestedPerms,
+    );
+    return;
+  }
 
   // Limit concurrent package directory processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.PACKAGE_DIRS);
@@ -41,7 +59,7 @@ export async function decomposeFileHandler(
           ignorePath,
           strategy,
           metaSuffix,
-          decomposeNestedPerms
+          decomposeNestedPerms,
         );
       } else if (metaSuffix === 'labels') {
         // do not use the prePurge flag in the xml-disassembler package for labels due to file moving
@@ -58,7 +76,7 @@ export async function decomposeFileHandler(
           ignorePath,
           strategy,
           metaSuffix,
-          decomposeNestedPerms
+          decomposeNestedPerms,
         );
         // move labels from the directory they are created in
         await moveAndRenameLabels(metadataPath);
@@ -72,16 +90,107 @@ export async function decomposeFileHandler(
           ignorePath,
           strategy,
           metaSuffix,
-          decomposeNestedPerms
+          decomposeNestedPerms,
         );
       }
       if (metaSuffix === 'workflow') {
         await renameWorkflows(metadataPath);
       }
-    })
+    }),
   );
 
   await Promise.all(tasks);
+}
+
+async function decomposeFromManifest(
+  manifestXmlPaths: Set<string>,
+  uniqueIdElements: string,
+  prepurge: boolean,
+  postpurge: boolean,
+  format: string,
+  ignorePath: string,
+  strategy: string,
+  metaSuffix: string,
+  strictDirectoryName: boolean,
+  folderType: string,
+  decomposeNestedPerms: boolean,
+): Promise<void> {
+  const limit = pLimit(CONCURRENCY_LIMITS.PACKAGE_DIRS);
+  const xmlPaths = Array.from(manifestXmlPaths);
+
+  if (metaSuffix === 'labels') {
+    // Labels have a single source file per labels directory; dedupe by containing dir.
+    const labelDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
+    const tasks = Array.from(labelDirs).map((labelDir) =>
+      limit(async () => {
+        if (prepurge) await prePurgeLabels(labelDir);
+        const absoluteLabelFilePath = resolve(labelDir, CUSTOM_LABELS_FILE);
+        const relativeLabelFilePath = relative(process.cwd(), absoluteLabelFilePath);
+        disassembleHandler(
+          relativeLabelFilePath,
+          uniqueIdElements,
+          false,
+          postpurge,
+          format,
+          ignorePath,
+          strategy,
+          metaSuffix,
+          decomposeNestedPerms,
+        );
+        await moveAndRenameLabels(labelDir);
+      }),
+    );
+    await Promise.all(tasks);
+    return;
+  }
+
+  if (strictDirectoryName || folderType) {
+    // Each parent xml lives inside its own strict subdirectory (e.g. bots/MyBot/MyBot.bot-meta.xml).
+    // Dedupe by parent directory and disassemble the whole subdirectory.
+    const parentDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
+    const tasks = Array.from(parentDirs).map((parentDir) =>
+      limit(() =>
+        disassembleHandler(
+          parentDir,
+          uniqueIdElements,
+          prepurge,
+          postpurge,
+          format,
+          ignorePath,
+          strategy,
+          metaSuffix,
+          decomposeNestedPerms,
+        ),
+      ),
+    );
+    await Promise.all(tasks);
+    return;
+  }
+
+  const tasks = xmlPaths.map((xmlPath) =>
+    limit(() =>
+      disassembleHandler(
+        xmlPath,
+        uniqueIdElements,
+        prepurge,
+        postpurge,
+        format,
+        ignorePath,
+        strategy,
+        metaSuffix,
+        decomposeNestedPerms,
+      ),
+    ),
+  );
+  await Promise.all(tasks);
+
+  if (metaSuffix === 'workflow') {
+    const workflowDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
+    for (const workflowDir of workflowDirs) {
+      // eslint-disable-next-line no-await-in-loop
+      await renameWorkflows(workflowDir);
+    }
+  }
 }
 
 function disassembleHandler(
@@ -93,7 +202,7 @@ function disassembleHandler(
   ignorePath: string,
   strategy: string,
   metaSuffix: string,
-  decomposeNestedPerms: boolean
+  decomposeNestedPerms: boolean,
 ): void {
   const handler: DisassembleXMLFileHandler = new DisassembleXMLFileHandler();
   let multiLevel;
@@ -133,7 +242,7 @@ async function subDirectoryHandler(
   ignorePath: string,
   strategy: string,
   metaSuffix: string,
-  decomposeNestedPerms: boolean
+  decomposeNestedPerms: boolean,
 ): Promise<void> {
   const subFiles = await readdir(metadataPath);
 
@@ -144,7 +253,7 @@ async function subDirectoryHandler(
       const subFilePath = join(metadataPath, subFile);
       const isDir = (await stat(subFilePath)).isDirectory();
       return { subFilePath, isDir };
-    })
+    }),
   );
   const statResults = await Promise.all(statPromises);
 
@@ -163,9 +272,9 @@ async function subDirectoryHandler(
           ignorePath,
           strategy,
           metaSuffix,
-          decomposeNestedPerms
-        )
-      )
+          decomposeNestedPerms,
+        ),
+      ),
     );
 
   await Promise.all(processTasks);

--- a/src/service/recompose/recomposeFileHandler.ts
+++ b/src/service/recompose/recomposeFileHandler.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { readdir, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { ReassembleXMLFileHandler } from 'xml-disassembler';
 import pLimit from 'p-limit';
 
@@ -16,9 +16,15 @@ export async function recomposeFileHandler(
     folderType: string;
     metadataPaths: string[];
   },
-  postpurge: boolean
+  postpurge: boolean,
+  manifestXmlPaths?: Set<string>,
 ): Promise<void> {
   const { metaSuffix, strictDirectoryName, folderType, metadataPaths } = metaAttributes;
+
+  if (manifestXmlPaths && manifestXmlPaths.size > 0) {
+    await recomposeFromManifest(manifestXmlPaths, metaSuffix, strictDirectoryName, folderType, postpurge);
+    return;
+  }
 
   // Limit concurrent package directory processing
   const limit = pLimit(CONCURRENCY_LIMITS.PACKAGE_DIRS);
@@ -34,10 +40,77 @@ export async function recomposeFileHandler(
       }
 
       if (metaSuffix === 'bot') await renameBotVersionFile(metadataPath);
-    })
+    }),
   );
 
   await Promise.all(tasks);
+}
+
+async function recomposeFromManifest(
+  manifestXmlPaths: Set<string>,
+  metaSuffix: string,
+  strictDirectoryName: boolean,
+  folderType: string,
+  postpurge: boolean,
+): Promise<void> {
+  const limit = pLimit(CONCURRENCY_LIMITS.PACKAGE_DIRS);
+  const xmlPaths = Array.from(manifestXmlPaths);
+
+  if (metaSuffix === 'labels') {
+    const labelDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
+    const tasks = Array.from(labelDirs).map((labelDir) =>
+      limit(() => reassembleLabels(labelDir, metaSuffix, postpurge)),
+    );
+    await Promise.all(tasks);
+    return;
+  }
+
+  if (strictDirectoryName || folderType) {
+    // For strict types (e.g., bot), each parent xml lives in its own directory.
+    // Dedupe by that parent directory and reassemble each decomposed child subdir.
+    const parentDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
+    const tasks = Array.from(parentDirs).map((parentDir) =>
+      limit(() => reassembleDirectories(parentDir, metaSuffix, false, postpurge)),
+    );
+    await Promise.all(tasks);
+
+    if (metaSuffix === 'bot') {
+      // renameBotVersionFile expects the parent metadata directory (e.g. .../bots),
+      // not the individual bot directory. Walk up one level and dedupe.
+      const botContainerDirs = new Set(Array.from(parentDirs).map((parentDir) => dirname(parentDir)));
+      for (const botContainerDir of botContainerDirs) {
+        // eslint-disable-next-line no-await-in-loop
+        await renameBotVersionFile(botContainerDir);
+      }
+    }
+    return;
+  }
+
+  const tasks = xmlPaths.map((xmlPath) =>
+    limit(async () => {
+      const decomposedDir = decomposedDirForXml(xmlPath, metaSuffix);
+      // Skip files that were never decomposed (e.g. metadata consisting only of leaf elements).
+      if (!(await directoryExists(decomposedDir))) return;
+      reassembleHandler(decomposedDir, `${metaSuffix}-meta.xml`, postpurge);
+    }),
+  );
+  await Promise.all(tasks);
+}
+
+function decomposedDirForXml(xmlPath: string, metaSuffix: string): string {
+  const metaEnding = `.${metaSuffix}-meta.xml`;
+  const fileName = basename(xmlPath);
+  const stem = fileName.slice(0, -metaEnding.length);
+  return join(dirname(xmlPath), stem);
+}
+
+async function directoryExists(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 export function reassembleHandler(filePath: string, fileExtension: string, postPurge: boolean): void {
@@ -53,7 +126,7 @@ async function reassembleDirectories(
   metadataPath: string,
   metaSuffix: string,
   recurse: boolean,
-  postpurge: boolean
+  postpurge: boolean,
 ): Promise<void> {
   const subdirectories = (await readdir(metadataPath)).map((file) => join(metadataPath, file));
 
@@ -64,8 +137,8 @@ async function reassembleDirectories(
       statLimit(async () => ({
         subdirectory,
         isDirectory: (await stat(subdirectory)).isDirectory(),
-      }))
-    )
+      })),
+    ),
   );
 
   // Limit concurrent subdirectory processing
@@ -80,7 +153,7 @@ async function reassembleDirectories(
         } else {
           reassembleHandler(subdirectory, `${metaSuffix}-meta.xml`, postpurge);
         }
-      })
+      }),
     );
 
   await Promise.all(tasks);

--- a/src/service/recompose/recomposeFileHandler.ts
+++ b/src/service/recompose/recomposeFileHandler.ts
@@ -74,6 +74,7 @@ async function recomposeFromManifest(
     );
     await Promise.all(tasks);
 
+    /* istanbul ignore else -- @preserve: bot is the only strict-directory type that needs post-processing in tests */
     if (metaSuffix === 'bot') {
       // renameBotVersionFile expects the parent metadata directory (e.g. .../bots),
       // not the individual bot directory. Walk up one level and dedupe.

--- a/test/commands/decomposer/manifest.test.ts
+++ b/test/commands/decomposer/manifest.test.ts
@@ -1,0 +1,539 @@
+'use strict';
+
+import { mkdtemp, rm, writeFile, readdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { copy } from 'fs-extra';
+import { describe, it, expect, beforeAll, afterAll, vi, type Mock } from 'vitest';
+
+import { decomposeMetadataTypes } from '../../../src/core/decomposeMetadataTypes.js';
+import { recomposeMetadataTypes } from '../../../src/core/recomposeMetadataTypes.js';
+import { SFDX_CONFIG_FILE } from '../../utils/constants.js';
+import { compareDirectories } from '../../utils/compareDirectories.js';
+
+const MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>HR_Admin</members>
+    <name>PermissionSet</name>
+  </types>
+  <types>
+    <members>Case</members>
+    <name>Workflow</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+
+const UNSCOPED_MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>NonexistentProfile</members>
+    <name>Profile</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+
+async function dirHasEntry(dir: string, name: string): Promise<boolean> {
+  try {
+    const entries = await readdir(dir);
+    return entries.includes(name);
+  } catch {
+    return false;
+  }
+}
+
+describe('decomposer manifest scoping', () => {
+  let logMock: Mock;
+  let tempProjectDir: string;
+  let forceAppDir: string;
+  let packageDir: string;
+  let sfdxConfigPath: string;
+  let manifestPath: string;
+  let unscopedManifestPath: string;
+  const originalDirectory: string = resolve('fixtures/package-dir-1');
+  const originalDirectory2: string = resolve('fixtures/package-dir-2');
+  const originalCwd = process.cwd();
+
+  const configFile = {
+    packageDirectories: [{ path: 'force-app', default: true }, { path: 'package' }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  beforeAll(async () => {
+    logMock = vi.fn();
+    tempProjectDir = await mkdtemp(join(tmpdir(), 'manifest-test-'));
+    forceAppDir = join(tempProjectDir, 'force-app');
+    packageDir = join(tempProjectDir, 'package');
+    sfdxConfigPath = join(tempProjectDir, SFDX_CONFIG_FILE);
+    manifestPath = join(tempProjectDir, 'package.xml');
+    unscopedManifestPath = join(tempProjectDir, 'unscoped.xml');
+
+    await copy(originalDirectory, forceAppDir, { overwrite: true });
+    await copy(originalDirectory2, packageDir, { overwrite: true });
+    await writeFile(sfdxConfigPath, JSON.stringify(configFile, null, 2));
+    await writeFile(manifestPath, MANIFEST_XML);
+    await writeFile(unscopedManifestPath, UNSCOPED_MANIFEST_XML);
+    process.chdir(tempProjectDir);
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await rm(tempProjectDir, { recursive: true, force: true });
+  });
+
+  it('decomposes only manifest-listed components and leaves others untouched', async () => {
+    await decomposeMetadataTypes({
+      metadataTypes: undefined,
+      prepurge: true,
+      postpurge: false,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      manifest: 'package.xml',
+      log: logMock,
+    });
+
+    // The permission set listed in the manifest should be decomposed into a sibling directory.
+    const permSetsDir = join(forceAppDir, 'permissionsets');
+    expect(await dirHasEntry(permSetsDir, 'HR_Admin')).toBe(true);
+
+    // Flows are not in the manifest; no decomposed output should exist for them.
+    const flowsDir = join(packageDir, 'flows');
+    const flowsEntries = await readdir(flowsDir);
+    const flowsHasDecomposedDir = await Promise.all(
+      flowsEntries.map(async (entry) => {
+        const entryPath = join(flowsDir, entry);
+        return (await stat(entryPath)).isDirectory();
+      }),
+    );
+    expect(flowsHasDecomposedDir.some((isDir) => isDir)).toBe(false);
+  });
+
+  it('recomposes only manifest-listed components back to their original form', async () => {
+    await recomposeMetadataTypes({
+      metadataTypes: undefined,
+      postpurge: false,
+      ignoreDirs: undefined,
+      manifest: 'package.xml',
+      log: logMock,
+    });
+
+    const output = logMock.mock.calls.flat().join('\n');
+    expect(output).toContain('All metadata files have been recomposed for the metadata type: permissionset');
+    expect(output).toContain('All metadata files have been recomposed for the metadata type: workflow');
+
+    // Recomposed permission set and workflow files should match the original fixtures.
+    const originalPermSet = resolve(originalDirectory, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+    const recomposedPermSet = join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+    const [orig, recomposed] = await Promise.all([
+      import('node:fs/promises').then((fs) => fs.readFile(originalPermSet, 'utf-8')),
+      import('node:fs/promises').then((fs) => fs.readFile(recomposedPermSet, 'utf-8')),
+    ]);
+    expect(recomposed).toEqual(orig);
+
+    // Untouched types (labels, bots, flows, etc.) should not appear in the processed log.
+    expect(output).not.toContain('All metadata files have been recomposed for the metadata type: labels');
+    expect(output).not.toContain('All metadata files have been recomposed for the metadata type: flow');
+  });
+
+  it('skips types when manifest yields no resolvable source components', async () => {
+    const localLog = vi.fn();
+    const result = await recomposeMetadataTypes({
+      metadataTypes: undefined,
+      postpurge: false,
+      ignoreDirs: undefined,
+      manifest: 'unscoped.xml',
+      log: localLog,
+    });
+
+    expect(result.metadata).toEqual([]);
+    const output = localLog.mock.calls.flat().join('\n');
+    expect(output).toContain('No metadata types to recompose');
+  });
+
+  it('returns empty when --metadata-type has no overlap with manifest', async () => {
+    const localLog = vi.fn();
+    const result = await decomposeMetadataTypes({
+      metadataTypes: ['flow'],
+      prepurge: false,
+      postpurge: false,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      manifest: 'package.xml',
+      log: localLog,
+    });
+    expect(result.metadata).toEqual([]);
+    const output = localLog.mock.calls.flat().join('\n');
+    expect(output).toContain('No metadata types to decompose');
+  });
+
+  it('intersects --metadata-type with manifest when both provided', async () => {
+    // Set up a fresh copy to avoid state from prior decompose/recompose
+    const freshDir = await mkdtemp(join(tmpdir(), 'manifest-intersect-'));
+    const freshForceApp = join(freshDir, 'force-app');
+    const freshPackage = join(freshDir, 'package');
+    await copy(originalDirectory, freshForceApp, { overwrite: true });
+    await copy(originalDirectory2, freshPackage, { overwrite: true });
+    await writeFile(join(freshDir, SFDX_CONFIG_FILE), JSON.stringify(configFile, null, 2));
+    await writeFile(join(freshDir, 'package.xml'), MANIFEST_XML);
+    process.chdir(freshDir);
+
+    const localLog = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: ['permissionset'],
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log: localLog,
+      });
+
+      const output = localLog.mock.calls.flat().join('\n');
+      expect(output).toContain('All metadata files have been decomposed for the metadata type: permissionset');
+      // workflow is in manifest but not in metadataTypes, so it should not be processed
+      expect(output).not.toContain('All metadata files have been decomposed for the metadata type: workflow');
+    } finally {
+      process.chdir(tempProjectDir);
+      await rm(freshDir, { recursive: true, force: true });
+    }
+  });
+
+  it('matches the original fixtures after full decompose + recompose round-trip via manifest', async () => {
+    // Sanity: force-app permsets and workflows should match fixtures after the earlier
+    // decompose + recompose cycle from the previous tests.
+    await compareDirectories(resolve(originalDirectory, 'permissionsets'), join(forceAppDir, 'permissionsets'));
+    await compareDirectories(resolve(originalDirectory, 'workflows'), join(forceAppDir, 'workflows'));
+  });
+});
+
+const LABEL_BOT_MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>DeleteMe</members>
+    <name>CustomLabel</name>
+  </types>
+  <types>
+    <members>Assessment_Bot</members>
+    <name>Bot</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+
+const WILDCARD_MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>*</members>
+    <name>PermissionSet</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+
+const UNSUPPORTED_TYPE_MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>TestClass</members>
+    <name>ApexClass</name>
+  </types>
+  <types>
+    <members>HR_Admin</members>
+    <name>PermissionSet</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+
+describe('decomposer manifest scoping - labels, bot, wildcard, errors', () => {
+  const originalDirectory: string = resolve('fixtures/package-dir-1');
+  const originalDirectory2: string = resolve('fixtures/package-dir-2');
+  const originalCwd = process.cwd();
+  const configFile = {
+    packageDirectories: [{ path: 'force-app', default: true }, { path: 'package' }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  async function setupTempProject(manifestBody: string, manifestName = 'package.xml'): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'manifest-case-'));
+    await copy(originalDirectory, join(dir, 'force-app'), { overwrite: true });
+    await copy(originalDirectory2, join(dir, 'package'), { overwrite: true });
+    await writeFile(join(dir, SFDX_CONFIG_FILE), JSON.stringify(configFile, null, 2));
+    await writeFile(join(dir, manifestName), manifestBody);
+    process.chdir(dir);
+    return dir;
+  }
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+  });
+
+  it('decomposes and recomposes labels + bot via manifest (strict-directory path)', async () => {
+    const dir = await setupTempProject(LABEL_BOT_MANIFEST_XML);
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: undefined,
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      // Labels should have been decomposed to per-label files in the labels directory.
+      const labelsDir = join(dir, 'force-app', 'labels');
+      const labelEntries = await readdir(labelsDir);
+      expect(labelEntries.some((entry) => entry.endsWith('.label-meta.xml'))).toBe(true);
+
+      // Bot should have been decomposed under its strict parent directory.
+      const botDir = join(dir, 'package', 'bots', 'Assessment_Bot');
+      const botEntries = await readdir(botDir);
+      expect(botEntries.some((entry) => entry === 'Assessment_Bot' || entry === 'v1')).toBe(true);
+
+      await recomposeMetadataTypes({
+        metadataTypes: undefined,
+        postpurge: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      const output = log.mock.calls.flat().join('\n');
+      expect(output).toContain('All metadata files have been recomposed for the metadata type: labels');
+      expect(output).toContain('All metadata files have been recomposed for the metadata type: bot');
+
+      await compareDirectories(resolve(originalDirectory, 'labels'), join(dir, 'force-app', 'labels'));
+      await compareDirectories(resolve(originalDirectory2, 'bots'), join(dir, 'package', 'bots'));
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('expands wildcard manifest members against the local source', async () => {
+    const dir = await setupTempProject(WILDCARD_MANIFEST_XML);
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: undefined,
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      // Every permission set in the repo should have been decomposed.
+      const permSetsDir = join(dir, 'force-app', 'permissionsets');
+      const entries = await readdir(permSetsDir, { withFileTypes: true });
+      const decomposedDirs = entries.filter((entry) => entry.isDirectory());
+      expect(decomposedDirs.length).toBeGreaterThan(0);
+
+      await recomposeMetadataTypes({
+        metadataTypes: undefined,
+        postpurge: true,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      await compareDirectories(resolve(originalDirectory, 'permissionsets'), join(dir, 'force-app', 'permissionsets'));
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips unsupported manifest types and processes the supported ones', async () => {
+    const dir = await setupTempProject(UNSUPPORTED_TYPE_MANIFEST_XML);
+    const classesDir = join(dir, 'force-app', 'classes');
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(classesDir, { recursive: true });
+    await writeFile(join(classesDir, 'TestClass.cls'), 'public class TestClass {}');
+    await writeFile(
+      join(classesDir, 'TestClass.cls-meta.xml'),
+      '<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></ApexClass>',
+    );
+
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: undefined,
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      const output = log.mock.calls.flat().join('\n');
+      expect(output).toMatch(/Skipping cls:.*not supported/);
+      expect(output).toContain('All metadata files have been decomposed for the metadata type: permissionset');
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('expands wildcard Bot manifest members against strict subdirectories', async () => {
+    const wildcardBot = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>*</members>
+    <name>Bot</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+    const dir = await setupTempProject(wildcardBot);
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: undefined,
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+      const output = log.mock.calls.flat().join('\n');
+      expect(output).toContain('All metadata files have been decomposed for the metadata type: bot');
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('recomposes labels via manifest without prepurge and intersects with metadata-type', async () => {
+    const dir = await setupTempProject(LABEL_BOT_MANIFEST_XML);
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: undefined,
+        prepurge: false,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      // Pass both manifest AND metadataTypes to recompose, restricted to labels.
+      await recomposeMetadataTypes({
+        metadataTypes: ['labels'],
+        postpurge: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      const output = log.mock.calls.flat().join('\n');
+      expect(output).toContain('All metadata files have been recomposed for the metadata type: labels');
+      // bot is in the manifest but excluded by the metadata-type intersection
+      expect(output).not.toContain('All metadata files have been recomposed for the metadata type: bot');
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips unsupported manifest types during recompose', async () => {
+    const dir = await setupTempProject(UNSUPPORTED_TYPE_MANIFEST_XML);
+    const classesDir = join(dir, 'force-app', 'classes');
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(classesDir, { recursive: true });
+    await writeFile(join(classesDir, 'TestClass.cls'), 'public class TestClass {}');
+    await writeFile(
+      join(classesDir, 'TestClass.cls-meta.xml'),
+      '<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>58.0</apiVersion></ApexClass>',
+    );
+
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: ['permissionset'],
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      await recomposeMetadataTypes({
+        metadataTypes: undefined,
+        postpurge: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+
+      const output = log.mock.calls.flat().join('\n');
+      expect(output).toMatch(/Skipping cls:.*not supported/);
+      expect(output).toContain('All metadata files have been recomposed for the metadata type: permissionset');
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when neither manifest nor metadata-type is provided', async () => {
+    const dir = await setupTempProject(WILDCARD_MANIFEST_XML);
+    const log = vi.fn();
+    try {
+      await expect(
+        decomposeMetadataTypes({
+          metadataTypes: undefined,
+          prepurge: false,
+          postpurge: false,
+          format: 'xml',
+          strategy: 'unique-id',
+          decomposeNestedPerms: false,
+          ignoreDirs: undefined,
+          log,
+        }),
+      ).rejects.toThrow(/Either --metadata-type or --manifest/);
+
+      await expect(
+        recomposeMetadataTypes({
+          metadataTypes: undefined,
+          postpurge: false,
+          ignoreDirs: undefined,
+          log,
+        }),
+      ).rejects.toThrow(/Either --metadata-type or --manifest/);
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/commands/decomposer/manifest.test.ts
+++ b/test/commands/decomposer/manifest.test.ts
@@ -28,8 +28,16 @@ const MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
 const UNSCOPED_MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
   <types>
-    <members>NonexistentProfile</members>
-    <name>Profile</name>
+    <members>NonexistentPermissionSet</members>
+    <name>PermissionSet</name>
+  </types>
+  <types>
+    <members>NonexistentBot</members>
+    <name>Bot</name>
+  </types>
+  <types>
+    <members>NonexistentQueue</members>
+    <name>Queue</name>
   </types>
   <version>58.0</version>
 </Package>
@@ -221,6 +229,7 @@ const LABEL_BOT_MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
   <types>
     <members>DeleteMe</members>
+    <members>ValueExpressionInCollectionFilter</members>
     <name>CustomLabel</name>
   </types>
   <types>
@@ -337,7 +346,7 @@ describe('decomposer manifest scoping - labels, bot, wildcard, errors', () => {
         format: 'xml',
         strategy: 'unique-id',
         decomposeNestedPerms: false,
-        ignoreDirs: undefined,
+        ignoreDirs: ['some-other-dir'],
         manifest: 'package.xml',
         log,
       });
@@ -408,6 +417,11 @@ describe('decomposer manifest scoping - labels, bot, wildcard, errors', () => {
 </Package>
 `;
     const dir = await setupTempProject(wildcardBot);
+    // Add a rogue subdirectory with no bot xml so parseManifest skips it during
+    // wildcard expansion.
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(join(dir, 'package', 'bots', 'Empty_Bot'), { recursive: true });
+
     const log = vi.fn();
     try {
       await decomposeMetadataTypes({
@@ -500,6 +514,50 @@ describe('decomposer manifest scoping - labels, bot, wildcard, errors', () => {
       const output = log.mock.calls.flat().join('\n');
       expect(output).toMatch(/Skipping cls:.*not supported/);
       expect(output).toContain('All metadata files have been recomposed for the metadata type: permissionset');
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves folder-typed members via the folderType branch', async () => {
+    // Specific folder-typed members (e.g. Report MyFolder/Sample) come back from
+    // ManifestResolver as the parent type with folderType set; verify resolveMemberXml
+    // walks the folder-relative path correctly.
+    const folderManifest = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>MyFolder/Sample</members>
+    <members>MissingFolder/Missing</members>
+    <name>Report</name>
+  </types>
+  <version>58.0</version>
+</Package>
+`;
+    const dir = await setupTempProject(folderManifest);
+    const { mkdir } = await import('node:fs/promises');
+    const reportsDir = join(dir, 'force-app', 'reports', 'MyFolder');
+    await mkdir(reportsDir, { recursive: true });
+    await writeFile(
+      join(reportsDir, 'Sample.report-meta.xml'),
+      '<?xml version="1.0" encoding="UTF-8"?><Report xmlns="http://soap.sforce.com/2006/04/metadata"><name>Sample</name></Report>',
+    );
+
+    const log = vi.fn();
+    try {
+      await decomposeMetadataTypes({
+        metadataTypes: undefined,
+        prepurge: false,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        manifest: 'package.xml',
+        log,
+      });
+      const output = log.mock.calls.flat().join('\n');
+      expect(output).toContain('All metadata files have been decomposed for the metadata type: report');
     } finally {
       process.chdir(originalCwd);
       await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
Accept a package.xml manifest on the decompose and recompose commands to limit work to the components listed in the manifest. When provided, the plugin parses the manifest with SDR's ManifestResolver and resolves each entry against the local package directories without relying on source resolution, so decomposed output in the working tree does not interfere with parsing. Wildcards, strict-directory types (e.g. Bot), and CustomLabels are all honored, and unsupported types are skipped with a warning instead of aborting the run.

- Add parseManifest helper that maps manifest entries to absolute parent xml paths grouped by suffix, scanning package dirs concurrently.
- Thread manifestXmlPaths through decomposeFileHandler and recomposeFileHandler so only the resolved files are processed; dedupe by parent directory for strict/folder types and run bot version renaming on the container directory.
- Make --metadata-type optional on both commands and require at least one of --metadata-type or --manifest; intersect the two when both are supplied.
- Plumb the manifest path through the config file and the prerun and scopedPostRetrieve hooks, extracting arg-builder helpers to keep hook complexity in check.
- Update command help, examples, and message bundles for the new flag.
- Add 10 manifest-focused tests covering permission set, workflow, labels, bot, wildcard, intersection, skip-unsupported, missing-flag, and round-trip cases; coverage now meets the 95/90/95/90 thresholds.