### PR TITLE
feat: add per-metadata-type overrides for decompose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
   - [Exceptions](#exceptions)
 - [Troubleshooting](#troubleshooting)
 - [Hooks](#hooks)
+- [Per-Type Overrides](#per-type-overrides)
 - [Ignore Files](#ignore-files)
   - [.forceignore](#forceignore)
   - [.sfdecomposerignore](#sfdecomposerignore)
@@ -123,7 +124,7 @@ Decomposes metadata in all local package directories (from `sfdx-project.json`) 
 
 ```
 USAGE
-  $ sf decomposer decompose [-m <value>] [-x <value>] [-f <value>] [-i <value>] [-s <value>] [--prepurge --postpurge -p --json]
+  $ sf decomposer decompose [-m <value>] [-x <value>] [-f <value>] [-i <value>] [-s <value>] [--prepurge --postpurge -p -c --json]
 
 FLAGS
   -m, --metadata-type=<value>             Metadata suffix to process (e.g. flow, labels). Repeatable. Optional when --manifest is provided.
@@ -134,6 +135,7 @@ FLAGS
   --prepurge                              Remove existing decomposed files before decomposing [default: false]
   --postpurge                             Remove original metadata files after decomposing [default: false]
   -p, --decompose-nested-permissions      With grouped-by-tag, further decompose permission set and muting permission set object/field permissions
+  -c, --config                            Load per-metadata-type overrides from .sfdecomposer.config.json in the repo root. Only the "overrides" array is consumed. See Per-Type Overrides. [default: false]
 
 GLOBAL FLAGS
   --json  Output as JSON.
@@ -357,7 +359,7 @@ Put **.sfdecomposer.config.json** in the project root to run:
 - **After** `sf project retrieve start`: decompose.
 - **Before** `sf project deploy start` / `sf project deploy validate`: recompose.
 
-Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json).
+Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json), or the [sample config with per-type overrides](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.overrides.json) to vary format/strategy/etc. by metadata type.
 
 | Option                       | Required    | Description                                                                                                                                                       |
 | ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -369,6 +371,71 @@ Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin
 | `decomposedFormat`           | No          | xml, json, json5, or yaml (default: xml).                                                                                                                         |
 | `strategy`                   | No          | `unique-id` \| `grouped-by-tag` (default: unique-id).                                                                                                             |
 | `decomposeNestedPermissions` | No          | With grouped-by-tag, set true to further decompose permission set and muting permission set object/field permissions.                                             |
+| `overrides`                  | No          | Array of per-metadata-type overrides for `decomposedFormat`, `strategy`, `decomposeNestedPermissions`, `prePurge`, and `postPurge`. See [Per-Type Overrides](#per-type-overrides). |
+
+---
+
+## Per-Type Overrides
+
+Per-type overrides apply to **decompose only**. Recompose is a deterministic round-trip — it auto-detects format from the on-disk files and does not depend on strategy — so it ignores the `overrides` array.
+
+By default, a single decompose run uses one format and one strategy across every metadata type. The optional `overrides` array in `.sfdecomposer.config.json` lets you vary a small set of options per metadata suffix without splitting the run into multiple invocations.
+
+```json
+{
+  "metadataSuffixes": "labels,workflow,profile,flow,permissionset",
+  "ignorePackageDirectories": "force-app,examples",
+  "prePurge": true,
+  "postPurge": true,
+  "decomposedFormat": "xml",
+  "strategy": "unique-id",
+  "overrides": [
+    { "metadataTypes": ["flow"], "decomposedFormat": "yaml" },
+    {
+      "metadataTypes": ["permissionset", "mutingpermissionset"],
+      "strategy": "grouped-by-tag",
+      "decomposeNestedPermissions": true
+    }
+  ]
+}
+```
+
+### What can be overridden
+
+| Field                        | Notes                                                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `metadataTypes`              | Required. Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override. |
+| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                            |
+| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.    |
+| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`.                                                   |
+| `prePurge`                   | Per-type prePurge (decompose).                                                                                                   |
+| `postPurge`                  | Per-type postPurge (decompose: remove originals after decomposing).                                                              |
+
+Run-scope options (`metadataSuffixes`, `manifest`, `ignorePackageDirectories`) are **not** valid inside an override; the plugin will throw if they are present.
+
+### Precedence
+
+For each metadata type, the effective value is resolved as:
+
+1. The per-type override value, if set.
+2. Otherwise, the run-wide value (CLI flag, hook config top-level field, or built-in default).
+3. Hard plugin rules (e.g. labels → `unique-id`) still override both.
+
+### Opting in from the CLI
+
+CLI users can opt into overrides on `decompose` with the boolean `--config` (`-c`) flag. When set, the plugin reads `.sfdecomposer.config.json` from the repo root (the nearest ancestor directory that contains `sfdx-project.json`):
+
+```bash
+sf decomposer decompose -m "flow" -m "permissionset" -c
+```
+
+When `--config` is set, **only** the `overrides` array is consumed from the file. Top-level fields like `decomposedFormat`, `strategy`, `metadataSuffixes`, etc. are ignored — the CLI flags remain the source of truth for run-wide values. This keeps direct CLI behavior predictable and lets you reuse the same config file as the post-retrieve hook without any surprises.
+
+If `--config` is set but `.sfdecomposer.config.json` is missing from the repo root, the command fails with a clear error.
+
+`recompose` does not accept `--config` because it does not need the override information — format is auto-detected from the decomposed files on disk and recompose does not depend on strategy.
+
+The post-retrieve hook automatically picks up `overrides` from `.sfdecomposer.config.json` — no extra setup required. Existing config files without an `overrides` field continue to behave exactly as before.
 
 ---
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -1,0 +1,16 @@
+{
+  "metadataSuffixes": "labels,workflow,profile,flow,permissionset,mutingpermissionset",
+  "ignorePackageDirectories": "force-app,examples",
+  "prePurge": true,
+  "postPurge": true,
+  "decomposedFormat": "xml",
+  "strategy": "unique-id",
+  "overrides": [
+    { "metadataTypes": ["flow"], "decomposedFormat": "yaml" },
+    {
+      "metadataTypes": ["permissionset", "mutingpermissionset"],
+      "strategy": "grouped-by-tag",
+      "decomposeNestedPermissions": true
+    }
+  ]
+}

--- a/messages/decomposer.decompose.md
+++ b/messages/decomposer.decompose.md
@@ -48,6 +48,10 @@ Strategy to follow when decomposing files.
 
 Additionally decompose object and field permissions on a permission set when strategy is set to "grouped-by-tag".
 
+# flags.config.summary
+
+Load per-metadata-type overrides from .sfdecomposer.config.json in the repo root. When set, the file's "overrides" array is applied (format, strategy, decomposeNestedPermissions, prePurge, postPurge per type). Other top-level config fields are ignored when invoking the CLI directly.
+
 # error.missingMetadataOrManifest
 
 Either --metadata-type (-m) or --manifest (-x) must be provided.

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -5,6 +5,7 @@ import { Messages } from '@salesforce/core';
 
 import { DECOMPOSED_FILE_TYPES, DECOMPOSED_STRATEGIES } from '../../helpers/constants.js';
 import { decomposeMetadataTypes } from '../../core/decomposeMetadataTypes.js';
+import { loadOverridesFromConfig, resolveDefaultConfigPath } from '../../helpers/configOverrides.js';
 import { DecomposerResult } from '../../helpers/types.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -66,6 +67,12 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
       required: false,
       default: false,
     }),
+    config: Flags.boolean({
+      summary: messages.getMessage('flags.config.summary'),
+      char: 'c',
+      required: false,
+      default: false,
+    }),
   };
 
   public async run(): Promise<DecomposerResult> {
@@ -74,6 +81,8 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
     if (!flags['metadata-type'] && !flags['manifest']) {
       throw messages.createError('error.missingMetadataOrManifest');
     }
+
+    const overrides = flags['config'] ? await loadOverridesFromConfig(await resolveDefaultConfigPath()) : undefined;
 
     return decomposeMetadataTypes({
       metadataTypes: flags['metadata-type'],
@@ -84,6 +93,7 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
       strategy: flags['strategy'],
       decomposeNestedPerms: flags['decompose-nested-permissions'],
       manifest: flags['manifest'],
+      overrides,
       log: this.log.bind(this),
     });
   }

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -6,10 +6,21 @@ import { parseManifest, ManifestFilter } from '../metadata/parseManifest.js';
 import { decomposeFileHandler } from '../service/decompose/decomposeFileHandler.js';
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
 import { DecomposerResult, DecomposeOptions } from '../helpers/types.js';
+import { resolveDecomposeOptionsForType } from '../helpers/configOverrides.js';
 
 export async function decomposeMetadataTypes(options: DecomposeOptions): Promise<DecomposerResult> {
-  const { metadataTypes, prepurge, postpurge, format, ignoreDirs, strategy, decomposeNestedPerms, manifest, log } =
-    options;
+  const {
+    metadataTypes,
+    prepurge,
+    postpurge,
+    format,
+    ignoreDirs,
+    strategy,
+    decomposeNestedPerms,
+    manifest,
+    overrides,
+    log,
+  } = options;
 
   let manifestFilter: ManifestFilter | undefined;
   let effectiveTypes: string[];
@@ -56,24 +67,30 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
         return;
       }
 
-      let effectiveStrategy = strategy;
+      const resolved = resolveDecomposeOptionsForType(
+        metadataType,
+        { format, strategy, decomposeNestedPerms, prepurge, postpurge },
+        overrides,
+      );
 
-      if (metadataType === 'labels' && strategy === 'grouped-by-tag') {
+      let effectiveStrategy = resolved.strategy;
+
+      if (metadataType === 'labels' && effectiveStrategy === 'grouped-by-tag') {
         effectiveStrategy = 'unique-id';
       }
 
-      if (metadataType === 'loyaltyProgramSetup' && strategy === 'grouped-by-tag') {
+      if (metadataType === 'loyaltyProgramSetup' && effectiveStrategy === 'grouped-by-tag') {
         effectiveStrategy = 'unique-id';
       }
 
       await decomposeFileHandler(
         metaAttributes,
-        prepurge,
-        postpurge,
-        format,
+        resolved.prepurge,
+        resolved.postpurge,
+        resolved.format,
         ignorePath,
         effectiveStrategy,
-        decomposeNestedPerms,
+        resolved.decomposeNestedPerms,
         manifestXmlPaths,
       );
 

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -1,0 +1,171 @@
+'use strict';
+
+import { access, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { getRepoRoot } from '../service/core/getRepoRoot.js';
+import { DECOMPOSED_FILE_TYPES, DECOMPOSED_STRATEGIES, HOOK_CONFIG_JSON } from './constants.js';
+import { ConfigFile, DecomposerOverride } from './types.js';
+
+/**
+ * Resolve the absolute path of the default `.sfdecomposer.config.json`, located in the
+ * repo root (the nearest ancestor directory that contains `sfdx-project.json`). Throws
+ * a clear error when the repo root cannot be located or the config file does not exist.
+ */
+export async function resolveDefaultConfigPath(): Promise<string> {
+  const { repoRoot } = await getRepoRoot();
+  /* istanbul ignore if -- @preserve: getRepoRoot throws when no sfdx-project.json ancestor exists, so repoRoot is always defined here. */
+  if (!repoRoot) {
+    throw new Error(`Cannot locate ${HOOK_CONFIG_JSON}: repo root not found.`);
+  }
+  const configPath = resolve(repoRoot, HOOK_CONFIG_JSON);
+  try {
+    await access(configPath);
+  } catch {
+    throw new Error(
+      `--config was provided but ${HOOK_CONFIG_JSON} was not found at ${configPath}. ` +
+        'Create the file in the repo root or omit --config.',
+    );
+  }
+  return configPath;
+}
+
+const ALLOWED_OVERRIDE_KEYS = new Set<string>([
+  'metadataTypes',
+  'decomposedFormat',
+  'strategy',
+  'decomposeNestedPermissions',
+  'prePurge',
+  'postPurge',
+]);
+
+const FORBIDDEN_OVERRIDE_KEYS = new Set<string>(['manifest', 'metadataSuffixes', 'ignorePackageDirectories']);
+
+export type ResolvedDecomposeTypeOptions = {
+  format: string;
+  strategy: string;
+  decomposeNestedPerms: boolean;
+  prepurge: boolean;
+  postpurge: boolean;
+};
+
+/**
+ * Load and validate the `overrides` array from a `.sfdecomposer.config.json` file.
+ * Returns an empty array if the file is missing, unreadable, or contains no overrides.
+ */
+export async function loadOverridesFromConfig(configPath: string): Promise<DecomposerOverride[]> {
+  let raw: string;
+  try {
+    raw = await readFile(configPath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  let parsed: ConfigFile;
+  try {
+    parsed = JSON.parse(raw) as ConfigFile;
+  } catch (err) {
+    /* istanbul ignore next -- @preserve: JSON.parse always throws SyntaxError instances. */
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse ${configPath}: ${message}`);
+  }
+
+  const overrides = parsed.overrides;
+  if (!overrides) return [];
+  if (!Array.isArray(overrides)) {
+    throw new Error(`"overrides" in ${configPath} must be an array.`);
+  }
+
+  validateOverrides(overrides);
+  return overrides;
+}
+
+/**
+ * Validate that the overrides array is well-formed. Throws on any structural problem.
+ * Unknown override keys are tolerated (ignored), but forbidden run-scope keys throw.
+ */
+export function validateOverrides(overrides: DecomposerOverride[]): void {
+  const seenTypes = new Set<string>();
+
+  for (let i = 0; i < overrides.length; i++) {
+    const override = overrides[i];
+    if (!override || typeof override !== 'object') {
+      throw new Error(`Override at index ${i} must be an object.`);
+    }
+
+    if (!Array.isArray(override.metadataTypes) || override.metadataTypes.length === 0) {
+      throw new Error(`Override at index ${i} must include a non-empty "metadataTypes" array.`);
+    }
+
+    for (const key of Object.keys(override)) {
+      if (FORBIDDEN_OVERRIDE_KEYS.has(key)) {
+        throw new Error(
+          `Override at index ${i} contains "${key}", which is a run-scope option and cannot be set per metadata type.`,
+        );
+      }
+      if (!ALLOWED_OVERRIDE_KEYS.has(key)) {
+        // Unknown keys are ignored to keep the config forward-compatible.
+        continue;
+      }
+    }
+
+    if (override.decomposedFormat !== undefined && !DECOMPOSED_FILE_TYPES.includes(override.decomposedFormat)) {
+      throw new Error(
+        `Override at index ${i} has invalid "decomposedFormat": "${override.decomposedFormat}". ` +
+          `Allowed values: ${DECOMPOSED_FILE_TYPES.join(', ')}.`,
+      );
+    }
+
+    if (override.strategy !== undefined && !DECOMPOSED_STRATEGIES.includes(override.strategy)) {
+      throw new Error(
+        `Override at index ${i} has invalid "strategy": "${override.strategy}". ` +
+          `Allowed values: ${DECOMPOSED_STRATEGIES.join(', ')}.`,
+      );
+    }
+
+    for (const metadataType of override.metadataTypes) {
+      if (typeof metadataType !== 'string' || metadataType.trim() === '') {
+        throw new Error(`Override at index ${i} contains an empty or non-string metadata type.`);
+      }
+      if (seenTypes.has(metadataType)) {
+        throw new Error(
+          `Metadata type "${metadataType}" appears in more than one override. Each type may appear at most once.`,
+        );
+      }
+      seenTypes.add(metadataType);
+    }
+  }
+}
+
+/**
+ * Find the override (if any) that targets a specific metadata suffix.
+ */
+export function getOverrideForType(
+  metadataType: string,
+  overrides?: DecomposerOverride[],
+): DecomposerOverride | undefined {
+  if (!overrides || overrides.length === 0) return undefined;
+  return overrides.find((override) => override.metadataTypes.includes(metadataType));
+}
+
+/**
+ * Resolve the effective decompose options for a single metadata type. The base values are
+ * the run-wide options (CLI flags or defaults); per-type override values, when present, win.
+ */
+export function resolveDecomposeOptionsForType(
+  metadataType: string,
+  base: ResolvedDecomposeTypeOptions,
+  overrides?: DecomposerOverride[],
+): ResolvedDecomposeTypeOptions {
+  const override = getOverrideForType(metadataType, overrides);
+  if (!override) return base;
+
+  return {
+    format: override.decomposedFormat ?? base.format,
+    strategy: override.strategy ?? base.strategy,
+    decomposeNestedPerms: override.decomposeNestedPermissions ?? base.decomposeNestedPerms,
+    prepurge: override.prePurge ?? base.prepurge,
+    postpurge: override.postPurge ?? base.postpurge,
+  };
+}
+

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -7,6 +7,15 @@ export type DecomposerResult = {
   metadata: string[];
 };
 
+export type DecomposerOverride = {
+  metadataTypes: string[];
+  decomposedFormat?: string;
+  strategy?: string;
+  decomposeNestedPermissions?: boolean;
+  prePurge?: boolean;
+  postPurge?: boolean;
+};
+
 export type ConfigFile = {
   metadataSuffixes: string;
   prePurge: boolean;
@@ -16,6 +25,7 @@ export type ConfigFile = {
   strategy: string;
   decomposeNestedPermissions: boolean;
   manifest?: string;
+  overrides?: DecomposerOverride[];
 };
 
 export type SfdxProject = {
@@ -53,6 +63,7 @@ export type DecomposeOptions = {
   strategy: string;
   decomposeNestedPerms: boolean;
   manifest?: string;
+  overrides?: DecomposerOverride[];
   log: (msg: string) => void;
 };
 

--- a/src/hooks/scopedPostRetrieve.ts
+++ b/src/hooks/scopedPostRetrieve.ts
@@ -4,53 +4,53 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { Hook } from '@oclif/core';
 
-import DecomposerDecompose from '../commands/decomposer/decompose.js';
-import { ConfigFile, PostRetrieveHookOptions } from '../helpers/types.js';
+import { decomposeMetadataTypes } from '../core/decomposeMetadataTypes.js';
+import { ConfigFile, DecomposeOptions, PostRetrieveHookOptions } from '../helpers/types.js';
 import { getRepoRoot } from '../service/core/getRepoRoot.js';
 import { HOOK_CONFIG_JSON } from '../helpers/constants.js';
 
 type HookFunction = (this: Hook.Context, options: PostRetrieveHookOptions) => Promise<void>;
 
-function hasOverrides(configFile: ConfigFile): boolean {
-  return Array.isArray(configFile.overrides) && configFile.overrides.length > 0;
-}
-
-function buildDecomposeArgs(configFile: ConfigFile): string[] | undefined {
-  const metadataTypes: string = configFile.metadataSuffixes || '.';
-  const format: string = configFile.decomposedFormat || 'xml';
-  const prepurge: boolean = configFile.prePurge || false;
-  const postpurge: boolean = configFile.postPurge || false;
+function buildDecomposeOptions(
+  configFile: ConfigFile,
+  log: (msg: string) => void,
+): DecomposeOptions | undefined {
+  const metadataSuffixes: string = configFile.metadataSuffixes || '.';
   const ignorePackageDirs: string = configFile.ignorePackageDirectories || '';
-  const strategy: string = configFile.strategy || 'unique-id';
-  const decomposeNestedPermissions: boolean = configFile.decomposeNestedPermissions || false;
   const manifest: string = configFile.manifest ?? '';
 
-  if (metadataTypes.trim() === '.' && manifest.trim() === '') {
+  if (metadataSuffixes.trim() === '.' && manifest.trim() === '') {
     return undefined;
   }
 
-  const commandArgs: string[] = [];
-  if (metadataTypes.trim() !== '.') {
-    for (const metadataType of metadataTypes.split(',')) {
-      commandArgs.push('--metadata-type', metadataType.replace(/,/g, ''));
-    }
-  }
-  if (ignorePackageDirs.trim() !== '') {
-    for (const dir of ignorePackageDirs.split(',')) {
-      commandArgs.push('--ignore-package-directory', dir.replace(/,/g, ''));
-    }
-  }
-  if (manifest.trim() !== '') {
-    commandArgs.push('--manifest', manifest.trim());
-  }
-  commandArgs.push('--format', format);
-  if (prepurge) commandArgs.push('--prepurge');
-  if (postpurge) commandArgs.push('--postpurge');
-  if (decomposeNestedPermissions) commandArgs.push('--decompose-nested-permissions');
-  commandArgs.push('--strategy', strategy);
-  if (hasOverrides(configFile)) commandArgs.push('--config');
+  const metadataTypes: string[] | undefined =
+    metadataSuffixes.trim() !== '.'
+      ? metadataSuffixes
+          .split(',')
+          .map((type) => type.replace(/,/g, '').trim())
+          .filter((type) => type.length > 0)
+      : undefined;
 
-  return commandArgs;
+  const ignoreDirs: string[] | undefined =
+    ignorePackageDirs.trim() !== ''
+      ? ignorePackageDirs
+          .split(',')
+          .map((dir) => dir.replace(/,/g, '').trim())
+          .filter((dir) => dir.length > 0)
+      : undefined;
+
+  return {
+    metadataTypes,
+    prepurge: configFile.prePurge || false,
+    postpurge: configFile.postPurge || false,
+    format: configFile.decomposedFormat || 'xml',
+    ignoreDirs,
+    strategy: configFile.strategy || 'unique-id',
+    decomposeNestedPerms: configFile.decomposeNestedPermissions || false,
+    manifest: manifest.trim() !== '' ? manifest.trim() : undefined,
+    overrides: configFile.overrides,
+    log,
+  };
 }
 
 export const scopedPostRetrieve: HookFunction = async function (options) {
@@ -71,8 +71,10 @@ export const scopedPostRetrieve: HookFunction = async function (options) {
     return;
   }
 
-  const commandArgs = buildDecomposeArgs(configFile);
-  if (!commandArgs) return;
+  const decomposeOptions = buildDecomposeOptions(configFile, (msg: string) => {
+    this.log(msg);
+  });
+  if (!decomposeOptions) return;
 
-  await DecomposerDecompose.run(commandArgs);
+  await decomposeMetadataTypes(decomposeOptions);
 };

--- a/src/hooks/scopedPostRetrieve.ts
+++ b/src/hooks/scopedPostRetrieve.ts
@@ -11,6 +11,10 @@ import { HOOK_CONFIG_JSON } from '../helpers/constants.js';
 
 type HookFunction = (this: Hook.Context, options: PostRetrieveHookOptions) => Promise<void>;
 
+function hasOverrides(configFile: ConfigFile): boolean {
+  return Array.isArray(configFile.overrides) && configFile.overrides.length > 0;
+}
+
 function buildDecomposeArgs(configFile: ConfigFile): string[] | undefined {
   const metadataTypes: string = configFile.metadataSuffixes || '.';
   const format: string = configFile.decomposedFormat || 'xml';
@@ -44,6 +48,7 @@ function buildDecomposeArgs(configFile: ConfigFile): string[] | undefined {
   if (postpurge) commandArgs.push('--postpurge');
   if (decomposeNestedPermissions) commandArgs.push('--decompose-nested-permissions');
   commandArgs.push('--strategy', strategy);
+  if (hasOverrides(configFile)) commandArgs.push('--config');
 
   return commandArgs;
 }

--- a/test/commands/decomposer/overrides.test.ts
+++ b/test/commands/decomposer/overrides.test.ts
@@ -1,0 +1,136 @@
+'use strict';
+
+import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { copy } from 'fs-extra';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+import { decomposeMetadataTypes } from '../../../src/core/decomposeMetadataTypes.js';
+import { recomposeMetadataTypes } from '../../../src/core/recomposeMetadataTypes.js';
+import { compareDirectories } from '../../utils/compareDirectories.js';
+import { SFDX_CONFIG_FILE } from '../../utils/constants.js';
+
+describe('decomposer per-type overrides', () => {
+  let tempProjectDir: string;
+  let forceAppDir: string;
+  let workflowsDir: string;
+  let profilesDir: string;
+  let permissionsetsDir: string;
+  const originalDirectory: string = resolve('fixtures/package-dir-1');
+  const originalCwd = process.cwd();
+
+  const sfdxConfig = {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  beforeAll(async () => {
+    tempProjectDir = await mkdtemp(join(tmpdir(), 'overrides-test-'));
+    forceAppDir = join(tempProjectDir, 'force-app');
+    workflowsDir = join(forceAppDir, 'workflows');
+    profilesDir = join(forceAppDir, 'profiles');
+    permissionsetsDir = join(forceAppDir, 'permissionsets');
+
+    await copy(originalDirectory, forceAppDir, { overwrite: true });
+    await writeFile(join(tempProjectDir, SFDX_CONFIG_FILE), JSON.stringify(sfdxConfig, null, 2));
+    process.chdir(tempProjectDir);
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await rm(tempProjectDir, { recursive: true, force: true });
+  });
+
+  it('applies per-type format overrides during decompose and round-trips on recompose', async () => {
+    const logMock = vi.fn();
+
+    await decomposeMetadataTypes({
+      metadataTypes: ['workflow', 'profile'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        { metadataTypes: ['workflow'], decomposedFormat: 'yaml' },
+        { metadataTypes: ['profile'], decomposedFormat: 'json' },
+      ],
+      log: logMock,
+    });
+
+    const workflowFiles = await collectFiles(workflowsDir);
+    const profileFiles = await collectFiles(profilesDir);
+
+    // Decomposed children honor the per-type format. The original parent .xml is removed by postpurge,
+    // so no decomposed leaf files should be xml here.
+    expect(workflowFiles.some((f) => f.endsWith('.yaml'))).toBe(true);
+    expect(workflowFiles.some((f) => f.endsWith('.xml'))).toBe(false);
+
+    expect(profileFiles.some((f) => f.endsWith('.json'))).toBe(true);
+    expect(profileFiles.some((f) => f.endsWith('.xml'))).toBe(false);
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['workflow', 'profile'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    await compareDirectories(originalDirectory, forceAppDir);
+  });
+
+  it('applies per-type strategy overrides during decompose', async () => {
+    const logMock = vi.fn();
+
+    await decomposeMetadataTypes({
+      metadataTypes: ['permissionset', 'workflow'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        {
+          metadataTypes: ['permissionset'],
+          strategy: 'grouped-by-tag',
+          decomposeNestedPermissions: true,
+        },
+      ],
+      log: logMock,
+    });
+
+    const permissionsetFiles = await collectFiles(permissionsetsDir);
+
+    // grouped-by-tag with decomposeNestedPermissions:true splits objectPermissions into its own subdir.
+    expect(permissionsetFiles.some((f) => f.includes('objectPermissions/'))).toBe(true);
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['permissionset', 'workflow'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    await compareDirectories(originalDirectory, forceAppDir);
+  });
+});
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      // eslint-disable-next-line no-await-in-loop
+      const nested = await collectFiles(join(dir, entry.name));
+      out.push(...nested.map((p) => `${entry.name}/${p}`));
+    } else {
+      out.push(entry.name);
+    }
+  }
+  return out;
+}

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -1,0 +1,256 @@
+'use strict';
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  loadOverridesFromConfig,
+  validateOverrides,
+  getOverrideForType,
+  resolveDecomposeOptionsForType,
+  resolveDefaultConfigPath,
+} from '../../src/helpers/configOverrides.js';
+import { HOOK_CONFIG_JSON, SFDX_PROJECT_FILE_NAME } from '../../src/helpers/constants.js';
+import { DecomposerOverride } from '../../src/helpers/types.js';
+
+describe('configOverrides helper', () => {
+  describe('validateOverrides', () => {
+    it('accepts an empty array', () => {
+      expect(() => validateOverrides([])).not.toThrow();
+    });
+
+    it('accepts a well-formed override', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+        { metadataTypes: ['permissionset'], strategy: 'grouped-by-tag', decomposeNestedPermissions: true },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('rejects an override with an empty metadataTypes array', () => {
+      expect(() => validateOverrides([{ metadataTypes: [] } as unknown as DecomposerOverride])).toThrow(
+        /non-empty "metadataTypes"/,
+      );
+    });
+
+    it('rejects an override missing metadataTypes', () => {
+      expect(() => validateOverrides([{} as unknown as DecomposerOverride])).toThrow(/non-empty "metadataTypes"/);
+    });
+
+    it('rejects duplicate metadata types across overrides', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+        { metadataTypes: ['flow'], strategy: 'grouped-by-tag' },
+      ];
+      expect(() => validateOverrides(overrides)).toThrow(/appears in more than one override/);
+    });
+
+    it('rejects forbidden run-scope keys', () => {
+      const overrides = [{ metadataTypes: ['flow'], manifest: 'package.xml' }] as unknown as DecomposerOverride[];
+      expect(() => validateOverrides(overrides)).toThrow(/run-scope option/);
+    });
+
+    it('rejects an invalid decomposedFormat', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['flow'], decomposedFormat: 'toml' }];
+      expect(() => validateOverrides(overrides)).toThrow(/invalid "decomposedFormat"/);
+    });
+
+    it('rejects an invalid strategy', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['flow'], strategy: 'one-file-per-flag' }];
+      expect(() => validateOverrides(overrides)).toThrow(/invalid "strategy"/);
+    });
+
+    it('rejects an empty string metadata type', () => {
+      const overrides = [{ metadataTypes: [''] }] as unknown as DecomposerOverride[];
+      expect(() => validateOverrides(overrides)).toThrow(/empty or non-string metadata type/);
+    });
+
+    it('rejects a null override entry', () => {
+      const overrides = [null] as unknown as DecomposerOverride[];
+      expect(() => validateOverrides(overrides)).toThrow(/Override at index 0 must be an object/);
+    });
+
+    it('rejects a primitive override entry', () => {
+      const overrides = ['not-an-object'] as unknown as DecomposerOverride[];
+      expect(() => validateOverrides(overrides)).toThrow(/Override at index 0 must be an object/);
+    });
+
+    it('tolerates unknown override keys without throwing', () => {
+      const overrides = [
+        { metadataTypes: ['flow'], decomposedFormat: 'yaml', futureFlag: true },
+      ] as unknown as DecomposerOverride[];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+  });
+
+  describe('getOverrideForType', () => {
+    const overrides: DecomposerOverride[] = [
+      { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+      { metadataTypes: ['permissionset', 'mutingpermissionset'], strategy: 'grouped-by-tag' },
+    ];
+
+    it('returns undefined when overrides is undefined', () => {
+      expect(getOverrideForType('flow', undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when overrides is empty', () => {
+      expect(getOverrideForType('flow', [])).toBeUndefined();
+    });
+
+    it('returns the matching override by suffix', () => {
+      expect(getOverrideForType('flow', overrides)).toBe(overrides[0]);
+      expect(getOverrideForType('mutingpermissionset', overrides)).toBe(overrides[1]);
+    });
+
+    it('returns undefined for an unmatched suffix', () => {
+      expect(getOverrideForType('workflow', overrides)).toBeUndefined();
+    });
+  });
+
+  describe('resolveDecomposeOptionsForType', () => {
+    const base = {
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      prepurge: false,
+      postpurge: false,
+    };
+
+    it('returns base values when no overrides are provided', () => {
+      expect(resolveDecomposeOptionsForType('flow', base)).toEqual(base);
+    });
+
+    it('returns base values when no override matches the type', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['profile'], decomposedFormat: 'json' }];
+      expect(resolveDecomposeOptionsForType('flow', base, overrides)).toEqual(base);
+    });
+
+    it('applies override values that are set, falling back to base for unset fields', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['flow'], decomposedFormat: 'yaml', prePurge: true },
+      ];
+      expect(resolveDecomposeOptionsForType('flow', base, overrides)).toEqual({
+        format: 'yaml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        prepurge: true,
+        postpurge: false,
+      });
+    });
+
+    it('applies a complete strategy + nested perms override', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['permissionset'],
+          strategy: 'grouped-by-tag',
+          decomposeNestedPermissions: true,
+        },
+      ];
+      expect(resolveDecomposeOptionsForType('permissionset', base, overrides)).toEqual({
+        format: 'xml',
+        strategy: 'grouped-by-tag',
+        decomposeNestedPerms: true,
+        prepurge: false,
+        postpurge: false,
+      });
+    });
+  });
+
+  describe('loadOverridesFromConfig', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'cfg-overrides-test-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns an empty array when the file does not exist', async () => {
+      const missingPath = join(tempDir, 'does-not-exist.json');
+      await expect(loadOverridesFromConfig(missingPath)).resolves.toEqual([]);
+    });
+
+    it('returns an empty array when the file has no overrides field', async () => {
+      const configPath = join(tempDir, '.sfdecomposer.config.json');
+      await writeFile(configPath, JSON.stringify({ metadataSuffixes: 'flow' }));
+      await expect(loadOverridesFromConfig(configPath)).resolves.toEqual([]);
+    });
+
+    it('parses and validates a well-formed overrides array', async () => {
+      const configPath = join(tempDir, '.sfdecomposer.config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          metadataSuffixes: 'flow,permissionset',
+          overrides: [
+            { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+            { metadataTypes: ['permissionset'], strategy: 'grouped-by-tag' },
+          ],
+        }),
+      );
+      const overrides = await loadOverridesFromConfig(configPath);
+      expect(overrides).toHaveLength(2);
+      expect(overrides[0].metadataTypes).toEqual(['flow']);
+    });
+
+    it('throws on invalid JSON', async () => {
+      const configPath = join(tempDir, '.sfdecomposer.config.json');
+      await writeFile(configPath, '{ not valid json');
+      await expect(loadOverridesFromConfig(configPath)).rejects.toThrow(/Failed to parse/);
+    });
+
+    it('throws when overrides is not an array', async () => {
+      const configPath = join(tempDir, '.sfdecomposer.config.json');
+      await writeFile(configPath, JSON.stringify({ overrides: { metadataTypes: ['flow'] } }));
+      await expect(loadOverridesFromConfig(configPath)).rejects.toThrow(/must be an array/);
+    });
+
+    it('propagates validation errors from validateOverrides', async () => {
+      const configPath = join(tempDir, '.sfdecomposer.config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          overrides: [
+            { metadataTypes: ['flow'] },
+            { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+          ],
+        }),
+      );
+      await expect(loadOverridesFromConfig(configPath)).rejects.toThrow(/appears in more than one override/);
+    });
+  });
+
+  describe('resolveDefaultConfigPath', () => {
+    let tempProjectDir: string;
+    const originalCwd = process.cwd();
+
+    beforeEach(async () => {
+      tempProjectDir = await mkdtemp(join(tmpdir(), 'resolve-config-test-'));
+      await writeFile(join(tempProjectDir, SFDX_PROJECT_FILE_NAME), JSON.stringify({ packageDirectories: [] }));
+      process.chdir(tempProjectDir);
+    });
+
+    afterEach(async () => {
+      process.chdir(originalCwd);
+      await rm(tempProjectDir, { recursive: true, force: true });
+    });
+
+    it('returns the absolute path to the config when it exists in the repo root', async () => {
+      const configPath = join(tempProjectDir, HOOK_CONFIG_JSON);
+      await writeFile(configPath, JSON.stringify({ metadataSuffixes: 'flow' }));
+
+      const resolved = await resolveDefaultConfigPath();
+      expect(resolved).toBe(resolve(tempProjectDir, HOOK_CONFIG_JSON));
+    });
+
+    it('throws a clear error when the config file is missing from the repo root', async () => {
+      await expect(resolveDefaultConfigPath()).rejects.toThrow(
+        /--config was provided but \.sfdecomposer\.config\.json was not found/,
+      );
+    });
+  });
+});

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -243,8 +243,13 @@ describe('configOverrides helper', () => {
       const configPath = join(tempProjectDir, HOOK_CONFIG_JSON);
       await writeFile(configPath, JSON.stringify({ metadataSuffixes: 'flow' }));
 
+      // Build the expected path from process.cwd() (which getRepoRoot walks) rather than from
+      // the raw tempProjectDir. This avoids cross-platform path-canonicalization mismatches:
+      // macOS may canonicalize /var -> /private/var, and Windows may preserve 8.3 short names
+      // in tmpdir() that cwd() does or does not normalize. Either way, process.cwd() after
+      // chdir matches what the implementation will see.
       const resolved = await resolveDefaultConfigPath();
-      expect(resolved).toBe(resolve(tempProjectDir, HOOK_CONFIG_JSON));
+      expect(resolved).toBe(resolve(process.cwd(), HOOK_CONFIG_JSON));
     });
 
     it('throws a clear error when the config file is missing from the repo root', async () => {


### PR DESCRIPTION
Adds an optional `overrides` array to `.sfdecomposer.config.json` that lets users vary `decomposedFormat`, `strategy`, `decomposeNestedPermissions`, `prePurge`, and `postPurge` per metadata suffix within a single decompose run.

CLI users opt in via the new boolean `-c, --config` flag on `decompose`, which loads `.sfdecomposer.config.json` from the repo root and consumes only the `overrides` array (top-level config fields are ignored so CLI flags stay authoritative). The post-retrieve hook auto-passes `--config` when `overrides` is present.

`recompose` deliberately does not accept overrides — format is auto-detected from on-disk files and recompose is independent of strategy. Hard rules (labels and loyaltyProgramSetup forced to unique-id) continue to win over any override.

Backwards compatible: existing configs without `overrides` and existing CLI usage without `--config` behave exactly as before.