### PR TITLE
feat(decompose): add per-component overrides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Unique ID elements are used to name decomposed files for nested elements. The fi
 
 Core decompose/recompose logic lives in **[config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node)**, which uses a Rust crate to handle decomposing and recomposing files on the local disk. This plugin focuses on Salesforce metadata wiring (e.g. package dirs, SDR, strategies).
 
-- **In this plugin:** `src/service/decompose/decomposeFileHandler.ts` and `src/service/recompose/recomposeFileHandler.ts` call config-disassembler.
+- **In this plugin:** `src/service/decompose/decomposeFileHandler.ts` and `src/service/recompose/recomposeFileHandler.ts` call config-disassembler. Per-type / per-component override resolution happens in `src/helpers/configOverrides.ts` and is applied per file inside the decompose handler so different components of the same metadata type can be decomposed with different strategies/formats in one run.
 - **Changes to XML decompose/recompose behavior:** Contribute in the [config-disassembler](https://github.com/mcarvin8/config-disassembler) (Rust crate) and/or [config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node) repo.
 
 Dependabot will check for config-disassembler updates once a week.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
   - [Exceptions](#exceptions)
 - [Troubleshooting](#troubleshooting)
 - [Hooks](#hooks)
-- [Per-Type Overrides](#per-type-overrides)
+- [Per-Type & Per-Component Overrides](#per-type--per-component-overrides)
 - [Ignore Files](#ignore-files)
   - [.forceignore](#forceignore)
   - [.sfdecomposerignore](#sfdecomposerignore)
@@ -135,7 +135,7 @@ FLAGS
   --prepurge                              Remove existing decomposed files before decomposing [default: false]
   --postpurge                             Remove original metadata files after decomposing [default: false]
   -p, --decompose-nested-permissions      With grouped-by-tag, further decompose permission set and muting permission set object/field permissions
-  -c, --config                            Load per-metadata-type overrides from .sfdecomposer.config.json in the repo root. Only the "overrides" array is consumed. See Per-Type Overrides. [default: false]
+  -c, --config                            Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root. Only the "overrides" array is consumed. See Per-Type & Per-Component Overrides. [default: false]
 
 GLOBAL FLAGS
   --json  Output as JSON.
@@ -232,7 +232,7 @@ sf project deploy start -x "manifest/package.xml"
 
 ## Decompose Strategies
 
-> **Important:** Use one strategy per metadata type. To switch from `unique-id` to `grouped-by-tag`, run decompose with `--prepurge` and `-s "grouped-by-tag"` to regenerate.
+> **Tip:** A single decompose run can mix strategies and formats across metadata types — and even across components within the same type — through the `overrides` array (see [Per-Type & Per-Component Overrides](#per-type--per-component-overrides)). Recompose is deterministic from the on-disk sidecar, so any combination round-trips. When switching strategies for an existing component, pass `--prepurge` (or set `prePurge: true`) so leftover files from the previous strategy are removed before the new ones are written.
 
 - **unique-id** (default): Each nested element goes to its own file, named by unique-id fields or content hash. Leaf elements stay in a file named like the original XML.
 - **grouped-by-tag**: All elements with the same tag (e.g. `<fieldPermissions>`) go into one file named after the tag (e.g. `fieldPermissions.xml`). Leaf elements are still grouped in the original-named file.
@@ -359,27 +359,27 @@ Put **.sfdecomposer.config.json** in the project root to run:
 - **After** `sf project retrieve start`: decompose.
 - **Before** `sf project deploy start` / `sf project deploy validate`: recompose.
 
-Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json), or the [sample config with per-type overrides](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.overrides.json) to vary format/strategy/etc. by metadata type.
+Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json), or the [sample config with overrides](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.overrides.json) to vary format/strategy/etc. by metadata type or by individual component.
 
-| Option                       | Required    | Description                                                                                                                                                                        |
-| ---------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `metadataSuffixes`           | Conditional | Comma-separated metadata suffixes to decompose/recompose. Required unless `manifest` is set; when both are set, the run is scoped to the intersection.                             |
-| `manifest`                   | Conditional | Path (relative to the project root) to a `package.xml` manifest. When set, only the components listed in the manifest are decomposed/recomposed. See `-x` above.                   |
-| `ignorePackageDirectories`   | No          | Comma-separated package directories to skip.                                                                                                                                       |
-| `prePurge`                   | No          | Remove existing decomposed files before decomposing (default: false).                                                                                                              |
-| `postPurge`                  | No          | After decompose: remove originals; after recompose: remove decomposed files (default: false).                                                                                      |
-| `decomposedFormat`           | No          | xml, json, json5, or yaml (default: xml).                                                                                                                                          |
-| `strategy`                   | No          | `unique-id` \| `grouped-by-tag` (default: unique-id).                                                                                                                              |
-| `decomposeNestedPermissions` | No          | With grouped-by-tag, set true to further decompose permission set and muting permission set object/field permissions.                                                              |
-| `overrides`                  | No          | Array of per-metadata-type overrides for `decomposedFormat`, `strategy`, `decomposeNestedPermissions`, `prePurge`, and `postPurge`. See [Per-Type Overrides](#per-type-overrides). |
+| Option                       | Required    | Description                                                                                                                                                                                                                   |
+| ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metadataSuffixes`           | Conditional | Comma-separated metadata suffixes to decompose/recompose. Required unless `manifest` is set; when both are set, the run is scoped to the intersection.                                                                        |
+| `manifest`                   | Conditional | Path (relative to the project root) to a `package.xml` manifest. When set, only the components listed in the manifest are decomposed/recomposed. See `-x` above.                                                              |
+| `ignorePackageDirectories`   | No          | Comma-separated package directories to skip.                                                                                                                                                                                  |
+| `prePurge`                   | No          | Remove existing decomposed files before decomposing (default: false).                                                                                                                                                         |
+| `postPurge`                  | No          | After decompose: remove originals; after recompose: remove decomposed files (default: false).                                                                                                                                 |
+| `decomposedFormat`           | No          | xml, json, json5, or yaml (default: xml).                                                                                                                                                                                     |
+| `strategy`                   | No          | `unique-id` \| `grouped-by-tag` (default: unique-id).                                                                                                                                                                         |
+| `decomposeNestedPermissions` | No          | With grouped-by-tag, set true to further decompose permission set and muting permission set object/field permissions.                                                                                                         |
+| `overrides`                  | No          | Array of per-type and/or per-component overrides for `decomposedFormat`, `strategy`, `decomposeNestedPermissions`, `prePurge`, and `postPurge`. See [Per-Type & Per-Component Overrides](#per-type--per-component-overrides). |
 
 ---
 
-## Per-Type Overrides
+## Per-Type & Per-Component Overrides
 
-Per-type overrides apply to **decompose only**. Recompose is a deterministic round-trip — it auto-detects format from the on-disk files and does not depend on strategy — so it ignores the `overrides` array.
+Overrides apply to **decompose only**. Recompose is a deterministic round-trip — it auto-detects format from the on-disk files and does not depend on strategy — so it ignores the `overrides` array.
 
-By default, a single decompose run uses one format and one strategy across every metadata type. The optional `overrides` array in `.sfdecomposer.config.json` lets you vary a small set of options per metadata suffix without splitting the run into multiple invocations.
+By default, a single decompose run uses one format and one strategy across every metadata type. The optional `overrides` array in `.sfdecomposer.config.json` lets you vary a small set of options per metadata suffix (**type-scope**) or per individual SDR component (**component-scope**) without splitting the run into multiple invocations.
 
 ```json
 {
@@ -395,6 +395,11 @@ By default, a single decompose run uses one format and one strategy across every
       "metadataTypes": ["permissionset", "mutingpermissionset"],
       "strategy": "grouped-by-tag",
       "decomposeNestedPermissions": true
+    },
+    {
+      "components": ["permissionset:HR_Admin", "permissionset:Big_PermSet"],
+      "strategy": "grouped-by-tag",
+      "decomposeNestedPermissions": true
     }
   ]
 }
@@ -402,24 +407,37 @@ By default, a single decompose run uses one format and one strategy across every
 
 ### What can be overridden
 
-| Field                        | Notes                                                                                                                                             |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `metadataTypes`              | Required. Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override. |
-| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                             |
-| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                     |
-| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`.                                                                    |
-| `prePurge`                   | Per-type prePurge (decompose).                                                                                                                    |
-| `postPurge`                  | Per-type postPurge (decompose: remove originals after decomposing).                                                                               |
+| Field                        | Notes                                                                                                                                                                                                          |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metadataTypes`              | Optional (required if `components` is omitted). Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override.                        |
+| `components`                 | Optional (required if `metadataTypes` is omitted). Array of `<metadataSuffix>:<fullName>` keys (e.g. `permissionset:HR_Admin`, `report:MyFolder/MyReport`). Each component may appear in at most one override. |
+| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                                                                                          |
+| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                  |
+| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`.                                                                                                                                 |
+| `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                             |
+| `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                           |
 
 Run-scope options (`metadataSuffixes`, `manifest`, `ignorePackageDirectories`) are **not** valid inside an override; the plugin will throw if they are present.
 
+#### Component key conventions
+
+The `<fullName>` part of a component key is the SDR fullName for the component, matching the basename of the decomposed directory:
+
+- **Plain types** (e.g. `permissionset`, `flow`, `profile`, `workflow`): use the file stem, e.g. `permissionset:HR_Admin` for `permissionsets/HR_Admin.permissionset-meta.xml`.
+- **Strict-directory types** (e.g. `bot`): use the bot directory name, e.g. `bot:My_Bot` for `bots/My_Bot/My_Bot.bot-meta.xml`.
+- **Folder-typed metadata** (e.g. `report`, `dashboard`, `email`, `document`): the unit of decomposition is the folder; use the folder name, e.g. `report:MyFolder` to scope every report inside `reports/MyFolder/`.
+- **`labels`**: there is exactly one labels file per labels directory, so component-scope keys are not meaningful — use the type-scope `metadataTypes: ["labels"]` instead.
+
+Component overrides are not a filter. If `--metadata` / `metadataSuffixes` includes `permissionset`, every permission set is still decomposed; the override only changes how the named ones are decomposed. Use `--manifest` / the hook's `manifest` field if you want to scope the run itself to a subset of components.
+
 ### Precedence
 
-For each metadata type, the effective value is resolved as:
+For each component, each option is resolved independently in this order (highest first):
 
-1. The per-type override value, if set.
-2. Otherwise, the run-wide value (CLI flag, hook config top-level field, or built-in default).
-3. Hard plugin rules (e.g. labels → `unique-id`) still override both.
+1. The component-scope override value (matching `<suffix>:<fullName>` in `components`), if set.
+2. The type-scope override value (matching `<suffix>` in `metadataTypes`), if set.
+3. The run-wide value (CLI flag, hook config top-level field, or built-in default).
+4. Hard plugin rules (e.g. `labels` and `loyaltyProgramSetup` forced to `unique-id`) override all of the above.
 
 ### Opting in from the CLI
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -11,6 +11,11 @@
       "metadataTypes": ["permissionset", "mutingpermissionset"],
       "strategy": "grouped-by-tag",
       "decomposeNestedPermissions": true
+    },
+    {
+      "components": ["permissionset:HR_Admin"],
+      "strategy": "unique-id",
+      "decomposedFormat": "json"
     }
   ]
 }

--- a/messages/decomposer.decompose.md
+++ b/messages/decomposer.decompose.md
@@ -50,7 +50,7 @@ Additionally decompose object and field permissions on a permission set when str
 
 # flags.config.summary
 
-Load per-metadata-type overrides from .sfdecomposer.config.json in the repo root. When set, the file's "overrides" array is applied (format, strategy, decomposeNestedPermissions, prePurge, postPurge per type). Other top-level config fields are ignored when invoking the CLI directly.
+Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root. When set, the file's "overrides" array is applied (format, strategy, decomposeNestedPermissions, prePurge, postPurge per type or per individual component). Other top-level config fields are ignored when invoking the CLI directly.
 
 # error.missingMetadataOrManifest
 

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -67,32 +67,17 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
         return;
       }
 
-      const resolved = resolveDecomposeOptionsForType(
+      // Type-scope resolved options serve as the base for component-scope resolution further
+      // down the call stack. Hard strategy rules (labels / loyaltyProgramSetup) are applied per
+      // file inside the disassembler so they remain in force even when a component-scope override
+      // tries to flip the strategy.
+      const typeResolved = resolveDecomposeOptionsForType(
         metadataType,
         { format, strategy, decomposeNestedPerms, prepurge, postpurge },
         overrides,
       );
 
-      let effectiveStrategy = resolved.strategy;
-
-      if (metadataType === 'labels' && effectiveStrategy === 'grouped-by-tag') {
-        effectiveStrategy = 'unique-id';
-      }
-
-      if (metadataType === 'loyaltyProgramSetup' && effectiveStrategy === 'grouped-by-tag') {
-        effectiveStrategy = 'unique-id';
-      }
-
-      await decomposeFileHandler(
-        metaAttributes,
-        resolved.prepurge,
-        resolved.postpurge,
-        resolved.format,
-        ignorePath,
-        effectiveStrategy,
-        resolved.decomposeNestedPerms,
-        manifestXmlPaths,
-      );
+      await decomposeFileHandler(metaAttributes, typeResolved, ignorePath, overrides, manifestXmlPaths);
 
       processed.push(metadataType);
       log(`All metadata files have been decomposed for the metadata type: ${metadataType}`);

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -30,15 +30,9 @@ export async function resolveDefaultConfigPath(): Promise<string> {
   return configPath;
 }
 
-const ALLOWED_OVERRIDE_KEYS = new Set<string>([
-  'metadataTypes',
-  'decomposedFormat',
-  'strategy',
-  'decomposeNestedPermissions',
-  'prePurge',
-  'postPurge',
-]);
-
+// Run-scope keys that must never appear inside an override entry. Any other key is treated
+// as either a recognized override field (validated below) or as a forward-compatible unknown
+// key (silently ignored).
 const FORBIDDEN_OVERRIDE_KEYS = new Set<string>(['manifest', 'metadataSuffixes', 'ignorePackageDirectories']);
 
 export type ResolvedDecomposeTypeOptions = {
@@ -86,55 +80,122 @@ export async function loadOverridesFromConfig(configPath: string): Promise<Decom
  */
 export function validateOverrides(overrides: DecomposerOverride[]): void {
   const seenTypes = new Set<string>();
+  const seenComponents = new Set<string>();
 
   for (let i = 0; i < overrides.length; i++) {
-    const override = overrides[i];
-    if (!override || typeof override !== 'object') {
-      throw new Error(`Override at index ${i} must be an object.`);
-    }
+    validateOverride(overrides[i], i, seenTypes, seenComponents);
+  }
+}
 
-    if (!Array.isArray(override.metadataTypes) || override.metadataTypes.length === 0) {
-      throw new Error(`Override at index ${i} must include a non-empty "metadataTypes" array.`);
-    }
+function validateOverride(
+  override: DecomposerOverride,
+  i: number,
+  seenTypes: Set<string>,
+  seenComponents: Set<string>,
+): void {
+  if (!override || typeof override !== 'object') {
+    throw new Error(`Override at index ${i} must be an object.`);
+  }
 
-    for (const key of Object.keys(override)) {
-      if (FORBIDDEN_OVERRIDE_KEYS.has(key)) {
-        throw new Error(
-          `Override at index ${i} contains "${key}", which is a run-scope option and cannot be set per metadata type.`,
-        );
-      }
-      if (!ALLOWED_OVERRIDE_KEYS.has(key)) {
-        // Unknown keys are ignored to keep the config forward-compatible.
-        continue;
-      }
-    }
+  if (override.metadataTypes !== undefined && !Array.isArray(override.metadataTypes)) {
+    throw new Error(`Override at index ${i} has a non-array "metadataTypes".`);
+  }
 
-    if (override.decomposedFormat !== undefined && !DECOMPOSED_FILE_TYPES.includes(override.decomposedFormat)) {
+  if (override.components !== undefined && !Array.isArray(override.components)) {
+    throw new Error(`Override at index ${i} has a non-array "components".`);
+  }
+
+  const hasMetadataTypes = Array.isArray(override.metadataTypes) && override.metadataTypes.length > 0;
+  const hasComponents = Array.isArray(override.components) && override.components.length > 0;
+
+  if (!hasMetadataTypes && !hasComponents) {
+    throw new Error(`Override at index ${i} must include a non-empty "metadataTypes" or "components" array.`);
+  }
+
+  validateForbiddenKeys(override, i);
+  validateOverrideValues(override, i);
+
+  if (hasMetadataTypes) {
+    validateMetadataTypeEntries(override.metadataTypes as string[], i, seenTypes);
+  }
+
+  if (hasComponents) {
+    validateComponentEntries(override.components as string[], i, seenComponents);
+  }
+}
+
+function validateForbiddenKeys(override: DecomposerOverride, i: number): void {
+  for (const key of Object.keys(override)) {
+    if (FORBIDDEN_OVERRIDE_KEYS.has(key)) {
       throw new Error(
-        `Override at index ${i} has invalid "decomposedFormat": "${override.decomposedFormat}". ` +
-          `Allowed values: ${DECOMPOSED_FILE_TYPES.join(', ')}.`,
+        `Override at index ${i} contains "${key}", which is a run-scope option and cannot be set per metadata type.`,
       );
-    }
-
-    if (override.strategy !== undefined && !DECOMPOSED_STRATEGIES.includes(override.strategy)) {
-      throw new Error(
-        `Override at index ${i} has invalid "strategy": "${override.strategy}". ` +
-          `Allowed values: ${DECOMPOSED_STRATEGIES.join(', ')}.`,
-      );
-    }
-
-    for (const metadataType of override.metadataTypes) {
-      if (typeof metadataType !== 'string' || metadataType.trim() === '') {
-        throw new Error(`Override at index ${i} contains an empty or non-string metadata type.`);
-      }
-      if (seenTypes.has(metadataType)) {
-        throw new Error(
-          `Metadata type "${metadataType}" appears in more than one override. Each type may appear at most once.`,
-        );
-      }
-      seenTypes.add(metadataType);
     }
   }
+}
+
+function validateOverrideValues(override: DecomposerOverride, i: number): void {
+  if (override.decomposedFormat !== undefined && !DECOMPOSED_FILE_TYPES.includes(override.decomposedFormat)) {
+    throw new Error(
+      `Override at index ${i} has invalid "decomposedFormat": "${override.decomposedFormat}". ` +
+        `Allowed values: ${DECOMPOSED_FILE_TYPES.join(', ')}.`,
+    );
+  }
+
+  if (override.strategy !== undefined && !DECOMPOSED_STRATEGIES.includes(override.strategy)) {
+    throw new Error(
+      `Override at index ${i} has invalid "strategy": "${override.strategy}". ` +
+        `Allowed values: ${DECOMPOSED_STRATEGIES.join(', ')}.`,
+    );
+  }
+}
+
+function validateMetadataTypeEntries(metadataTypes: string[], i: number, seenTypes: Set<string>): void {
+  for (const metadataType of metadataTypes) {
+    if (typeof metadataType !== 'string' || metadataType.trim() === '') {
+      throw new Error(`Override at index ${i} contains an empty or non-string metadata type.`);
+    }
+    if (seenTypes.has(metadataType)) {
+      throw new Error(
+        `Metadata type "${metadataType}" appears in more than one override. Each type may appear at most once.`,
+      );
+    }
+    seenTypes.add(metadataType);
+  }
+}
+
+function validateComponentEntries(components: string[], i: number, seenComponents: Set<string>): void {
+  for (const component of components) {
+    if (typeof component !== 'string' || component.trim() === '') {
+      throw new Error(`Override at index ${i} contains an empty or non-string component.`);
+    }
+    if (!parseComponentKey(component)) {
+      throw new Error(
+        `Override at index ${i} has invalid component key "${component}". ` +
+          'Expected format: "<metadataSuffix>:<fullName>" (e.g. "permissionset:HR_Admin").',
+      );
+    }
+    if (seenComponents.has(component)) {
+      throw new Error(
+        `Component "${component}" appears in more than one override. Each component may appear at most once.`,
+      );
+    }
+    seenComponents.add(component);
+  }
+}
+
+/**
+ * Parse a component override key of the form `<metadataSuffix>:<fullName>`. Returns `undefined`
+ * when the key is malformed. Only the first colon is treated as the delimiter so fullNames that
+ * contain `/` (folder-typed metadata such as `report:MyFolder/MyReport`) are preserved verbatim.
+ */
+export function parseComponentKey(key: string): { metadataType: string; fullName: string } | undefined {
+  const colonIdx = key.indexOf(':');
+  if (colonIdx <= 0 || colonIdx === key.length - 1) return undefined;
+  const metadataType = key.slice(0, colonIdx).trim();
+  const fullName = key.slice(colonIdx + 1).trim();
+  if (!metadataType || !fullName) return undefined;
+  return { metadataType, fullName };
 }
 
 /**
@@ -145,7 +206,31 @@ export function getOverrideForType(
   overrides?: DecomposerOverride[],
 ): DecomposerOverride | undefined {
   if (!overrides || overrides.length === 0) return undefined;
-  return overrides.find((override) => override.metadataTypes.includes(metadataType));
+  return overrides.find((override) => override.metadataTypes?.includes(metadataType));
+}
+
+/**
+ * Find the override (if any) that targets a specific component, identified by its metadata
+ * suffix and SDR fullName.
+ */
+export function getOverrideForComponent(
+  metadataType: string,
+  fullName: string,
+  overrides?: DecomposerOverride[],
+): DecomposerOverride | undefined {
+  if (!overrides || overrides.length === 0) return undefined;
+  const key = `${metadataType}:${fullName}`;
+  return overrides.find((override) => override.components?.includes(key));
+}
+
+/**
+ * Returns true when at least one override targets a component of the given metadata type.
+ * Used by the decompose handler to decide whether per-component enumeration is required.
+ */
+export function hasComponentOverridesForType(metadataType: string, overrides?: DecomposerOverride[]): boolean {
+  if (!overrides || overrides.length === 0) return false;
+  const prefix = `${metadataType}:`;
+  return overrides.some((override) => override.components?.some((component) => component.startsWith(prefix)));
 }
 
 /**
@@ -169,3 +254,29 @@ export function resolveDecomposeOptionsForType(
   };
 }
 
+/**
+ * Resolve the effective decompose options for a single component. Precedence (highest first):
+ * component-scoped override fields (via `components`), then type-scoped resolved values
+ * (already applied by `resolveDecomposeOptionsForType`), then run-wide base values (passed
+ * through as the typeResolved fallback).
+ *
+ * Hard plugin rules (e.g. labels and loyaltyProgramSetup forced to `unique-id`) are applied
+ * separately by callers, not here, so this function stays pure.
+ */
+export function resolveDecomposeOptionsForComponent(
+  metadataType: string,
+  fullName: string,
+  typeResolved: ResolvedDecomposeTypeOptions,
+  overrides?: DecomposerOverride[],
+): ResolvedDecomposeTypeOptions {
+  const componentOverride = getOverrideForComponent(metadataType, fullName, overrides);
+  if (!componentOverride) return typeResolved;
+
+  return {
+    format: componentOverride.decomposedFormat ?? typeResolved.format,
+    strategy: componentOverride.strategy ?? typeResolved.strategy,
+    decomposeNestedPerms: componentOverride.decomposeNestedPermissions ?? typeResolved.decomposeNestedPerms,
+    prepurge: componentOverride.prePurge ?? typeResolved.prepurge,
+    postpurge: componentOverride.postPurge ?? typeResolved.postpurge,
+  };
+}

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -8,7 +8,10 @@ export type DecomposerResult = {
 };
 
 export type DecomposerOverride = {
-  metadataTypes: string[];
+  /** Suffix-scoped targets (e.g. `permissionset`). Applies to every component of the type. */
+  metadataTypes?: string[];
+  /** Component-scoped targets in the form `<suffix>:<fullName>` (e.g. `permissionset:HR_Admin`). */
+  components?: string[];
   decomposedFormat?: string;
   strategy?: string;
   decomposeNestedPermissions?: boolean;

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -1,11 +1,17 @@
 'use strict';
 
-import { resolve, relative, join, dirname } from 'node:path';
+import { resolve, relative, join, dirname, basename } from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
 import { DisassembleXMLFileHandler } from 'config-disassembler';
 import pLimit from 'p-limit';
 
 import { CUSTOM_LABELS_FILE, CONCURRENCY_LIMITS } from '../../helpers/constants.js';
+import { DecomposerOverride } from '../../helpers/types.js';
+import {
+  ResolvedDecomposeTypeOptions,
+  hasComponentOverridesForType,
+  resolveDecomposeOptionsForComponent,
+} from '../../helpers/configOverrides.js';
 import { prePurgeLabels, moveAndRenameLabels } from './customLabels.js';
 import { renameWorkflows } from './renameWorkflows.js';
 
@@ -17,12 +23,9 @@ export async function decomposeFileHandler(
     folderType: string;
     uniqueIdElements: string;
   },
-  prepurge: boolean,
-  postpurge: boolean,
-  format: string,
+  typeResolved: ResolvedDecomposeTypeOptions,
   ignorePath: string,
-  strategy: string,
-  decomposeNestedPerms: boolean,
+  overrides?: DecomposerOverride[],
   manifestXmlPaths?: Set<string>,
 ): Promise<void> {
   const { metadataPaths, metaSuffix, strictDirectoryName, folderType, uniqueIdElements } = metaAttributes;
@@ -31,15 +34,12 @@ export async function decomposeFileHandler(
     await decomposeFromManifest(
       manifestXmlPaths,
       uniqueIdElements,
-      prepurge,
-      postpurge,
-      format,
+      typeResolved,
       ignorePath,
-      strategy,
       metaSuffix,
       strictDirectoryName,
       folderType,
-      decomposeNestedPerms,
+      overrides,
     );
     return;
   }
@@ -50,48 +50,26 @@ export async function decomposeFileHandler(
   const tasks = metadataPaths.map((metadataPath) =>
     limit(async () => {
       if (strictDirectoryName || folderType) {
-        await subDirectoryHandler(
-          metadataPath,
-          uniqueIdElements,
-          prepurge,
-          postpurge,
-          format,
-          ignorePath,
-          strategy,
-          metaSuffix,
-          decomposeNestedPerms,
-        );
+        await subDirectoryHandler(metadataPath, uniqueIdElements, typeResolved, ignorePath, metaSuffix, overrides);
       } else if (metaSuffix === 'labels') {
-        // do not use the prePurge flag in the config-disassembler package for labels due to file moving
-        if (prepurge) await prePurgeLabels(metadataPath);
+        // Labels live in a single shared file; component-scope overrides are not applicable.
+        // Skip the prePurge flag in the disassembler for labels due to file moving.
+        if (typeResolved.prepurge) await prePurgeLabels(metadataPath);
         const absoluteLabelFilePath = resolve(metadataPath, CUSTOM_LABELS_FILE);
         const relativeLabelFilePath = relative(process.cwd(), absoluteLabelFilePath);
 
         disassembleHandler(
           relativeLabelFilePath,
           uniqueIdElements,
-          false,
-          postpurge,
-          format,
+          { ...typeResolved, prepurge: false },
           ignorePath,
-          strategy,
           metaSuffix,
-          decomposeNestedPerms,
         );
-        // move labels from the directory they are created in
         await moveAndRenameLabels(metadataPath);
+      } else if (hasComponentOverridesForType(metaSuffix, overrides)) {
+        await perFileHandler(metadataPath, uniqueIdElements, typeResolved, ignorePath, metaSuffix, overrides);
       } else {
-        disassembleHandler(
-          metadataPath,
-          uniqueIdElements,
-          prepurge,
-          postpurge,
-          format,
-          ignorePath,
-          strategy,
-          metaSuffix,
-          decomposeNestedPerms,
-        );
+        disassembleHandler(metadataPath, uniqueIdElements, typeResolved, ignorePath, metaSuffix);
       }
       if (metaSuffix === 'workflow') {
         await renameWorkflows(metadataPath);
@@ -105,15 +83,12 @@ export async function decomposeFileHandler(
 async function decomposeFromManifest(
   manifestXmlPaths: Set<string>,
   uniqueIdElements: string,
-  prepurge: boolean,
-  postpurge: boolean,
-  format: string,
+  typeResolved: ResolvedDecomposeTypeOptions,
   ignorePath: string,
-  strategy: string,
   metaSuffix: string,
   strictDirectoryName: boolean,
   folderType: string,
-  decomposeNestedPerms: boolean,
+  overrides?: DecomposerOverride[],
 ): Promise<void> {
   const limit = pLimit(CONCURRENCY_LIMITS.PACKAGE_DIRS);
   const xmlPaths = Array.from(manifestXmlPaths);
@@ -123,19 +98,15 @@ async function decomposeFromManifest(
     const labelDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
     const tasks = Array.from(labelDirs).map((labelDir) =>
       limit(async () => {
-        if (prepurge) await prePurgeLabels(labelDir);
+        if (typeResolved.prepurge) await prePurgeLabels(labelDir);
         const absoluteLabelFilePath = resolve(labelDir, CUSTOM_LABELS_FILE);
         const relativeLabelFilePath = relative(process.cwd(), absoluteLabelFilePath);
         disassembleHandler(
           relativeLabelFilePath,
           uniqueIdElements,
-          false,
-          postpurge,
-          format,
+          { ...typeResolved, prepurge: false },
           ignorePath,
-          strategy,
           metaSuffix,
-          decomposeNestedPerms,
         );
         await moveAndRenameLabels(labelDir);
       }),
@@ -145,42 +116,28 @@ async function decomposeFromManifest(
   }
 
   if (strictDirectoryName || folderType) {
-    // Each parent xml lives inside its own strict subdirectory (e.g. bots/MyBot/MyBot.bot-meta.xml).
-    // Dedupe by parent directory and disassemble the whole subdirectory.
+    // Each parent xml lives inside its own strict subdirectory (e.g. bots/MyBot/MyBot.bot-meta.xml),
+    // or, for folder-typed metadata, inside its containing folder (e.g. reports/MyFolder/MyReport.report-meta.xml).
+    // Dedupe by parent directory and disassemble the whole subdirectory; the parent directory's basename
+    // is the canonical fullName for component-scope override matching.
     const parentDirs = new Set(xmlPaths.map((xml) => dirname(xml)));
     const tasks = Array.from(parentDirs).map((parentDir) =>
-      limit(() =>
-        disassembleHandler(
-          parentDir,
-          uniqueIdElements,
-          prepurge,
-          postpurge,
-          format,
-          ignorePath,
-          strategy,
-          metaSuffix,
-          decomposeNestedPerms,
-        ),
-      ),
+      limit(() => {
+        const fullName = basename(parentDir);
+        const resolved = resolveDecomposeOptionsForComponent(metaSuffix, fullName, typeResolved, overrides);
+        return disassembleHandler(parentDir, uniqueIdElements, resolved, ignorePath, metaSuffix);
+      }),
     );
     await Promise.all(tasks);
     return;
   }
 
   const tasks = xmlPaths.map((xmlPath) =>
-    limit(() =>
-      disassembleHandler(
-        xmlPath,
-        uniqueIdElements,
-        prepurge,
-        postpurge,
-        format,
-        ignorePath,
-        strategy,
-        metaSuffix,
-        decomposeNestedPerms,
-      ),
-    ),
+    limit(() => {
+      const fullName = stripMetaSuffix(basename(xmlPath), metaSuffix);
+      const resolved = resolveDecomposeOptionsForComponent(metaSuffix, fullName, typeResolved, overrides);
+      return disassembleHandler(xmlPath, uniqueIdElements, resolved, ignorePath, metaSuffix);
+    }),
   );
   await Promise.all(tasks);
 
@@ -196,22 +153,19 @@ async function decomposeFromManifest(
 function disassembleHandler(
   filePath: string,
   uniqueIdElements: string,
-  prePurge: boolean,
-  postPurge: boolean,
-  format: string,
+  options: ResolvedDecomposeTypeOptions,
   ignorePath: string,
-  strategy: string,
   metaSuffix: string,
-  decomposeNestedPerms: boolean,
 ): void {
   const handler: DisassembleXMLFileHandler = new DisassembleXMLFileHandler();
   let multiLevel;
   let splitTags;
+  const effectiveStrategy = applyHardStrategyRules(metaSuffix, options.strategy);
   const decomposePermSets: boolean =
-    decomposeNestedPerms &&
+    options.decomposeNestedPerms &&
     (metaSuffix === 'permissionset' || metaSuffix === 'mutingpermissionset') &&
-    strategy === 'grouped-by-tag';
-  const decomposeLoyalyProgram: boolean = metaSuffix === 'loyaltyProgramSetup' && strategy === 'unique-id';
+    effectiveStrategy === 'grouped-by-tag';
+  const decomposeLoyalyProgram: boolean = metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id';
   if (decomposeLoyalyProgram) {
     multiLevel = 'programProcesses:programProcesses:parameterName,ruleName';
   }
@@ -223,26 +177,41 @@ function disassembleHandler(
   handler.disassemble({
     filePath,
     uniqueIdElements,
-    prePurge,
-    postPurge,
+    prePurge: options.prepurge,
+    postPurge: options.postpurge,
     ignorePath,
-    format,
-    strategy,
+    format: options.format,
+    strategy: effectiveStrategy,
     multiLevel,
     splitTags,
   });
 }
 
+/**
+ * Hard plugin rules that always win over user-provided strategies. `labels` and
+ * `loyaltyProgramSetup` are forced to `unique-id` regardless of run-, type-, or component-scope
+ * configuration because their on-disk layout depends on it.
+ */
+function applyHardStrategyRules(metaSuffix: string, strategy: string): string {
+  if (strategy !== 'grouped-by-tag') return strategy;
+  if (metaSuffix === 'labels' || metaSuffix === 'loyaltyProgramSetup') return 'unique-id';
+  return strategy;
+}
+
+function stripMetaSuffix(fileName: string, metaSuffix: string): string {
+  const metaEnding = `.${metaSuffix}-meta.xml`;
+  /* istanbul ignore next -- @preserve: parseManifest always builds xml paths from `${member}.${suffix}-meta.xml`,
+     so non-matching basenames cannot reach this helper through the public API. */
+  return fileName.endsWith(metaEnding) ? fileName.slice(0, -metaEnding.length) : fileName;
+}
+
 async function subDirectoryHandler(
   metadataPath: string,
   uniqueIdElements: string,
-  prepurge: boolean,
-  postpurge: boolean,
-  format: string,
+  typeResolved: ResolvedDecomposeTypeOptions,
   ignorePath: string,
-  strategy: string,
   metaSuffix: string,
-  decomposeNestedPerms: boolean,
+  overrides?: DecomposerOverride[],
 ): Promise<void> {
   const subFiles = await readdir(metadataPath);
 
@@ -262,20 +231,42 @@ async function subDirectoryHandler(
   const processTasks = statResults
     .filter(({ isDir }) => isDir)
     .map(({ subFilePath }) =>
-      processLimit(() =>
-        disassembleHandler(
-          subFilePath,
-          uniqueIdElements,
-          prepurge,
-          postpurge,
-          format,
-          ignorePath,
-          strategy,
-          metaSuffix,
-          decomposeNestedPerms,
-        ),
-      ),
+      processLimit(() => {
+        const fullName = basename(subFilePath);
+        const resolved = resolveDecomposeOptionsForComponent(metaSuffix, fullName, typeResolved, overrides);
+        return disassembleHandler(subFilePath, uniqueIdElements, resolved, ignorePath, metaSuffix);
+      }),
     );
 
   await Promise.all(processTasks);
+}
+
+/**
+ * Per-file disassembly used when component-scope overrides are present for a non-strict, non-labels
+ * metadata type. Walks the type's package directory, resolves options per file, and disassembles
+ * each parent metadata XML individually so different components can use different strategies/formats.
+ */
+async function perFileHandler(
+  metadataPath: string,
+  uniqueIdElements: string,
+  typeResolved: ResolvedDecomposeTypeOptions,
+  ignorePath: string,
+  metaSuffix: string,
+  overrides?: DecomposerOverride[],
+): Promise<void> {
+  const metaEnding = `.${metaSuffix}-meta.xml`;
+  const entries = await readdir(metadataPath, { withFileTypes: true });
+  const xmlEntries = entries.filter((entry) => entry.isFile() && entry.name.endsWith(metaEnding));
+
+  const limit = pLimit(CONCURRENCY_LIMITS.SUBDIRECTORIES);
+  const tasks = xmlEntries.map((entry) =>
+    limit(() => {
+      const filePath = join(metadataPath, entry.name);
+      const fullName = entry.name.slice(0, -metaEnding.length);
+      const resolved = resolveDecomposeOptionsForComponent(metaSuffix, fullName, typeResolved, overrides);
+      return disassembleHandler(filePath, uniqueIdElements, resolved, ignorePath, metaSuffix);
+    }),
+  );
+
+  await Promise.all(tasks);
 }

--- a/test/commands/decomposer/overrides.test.ts
+++ b/test/commands/decomposer/overrides.test.ts
@@ -1,17 +1,17 @@
 'use strict';
 
-import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readdir, writeFile, readFile, copyFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { cp } from 'node:fs/promises';
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 
 import { decomposeMetadataTypes } from '../../../src/core/decomposeMetadataTypes.js';
 import { recomposeMetadataTypes } from '../../../src/core/recomposeMetadataTypes.js';
 import { compareDirectories } from '../../utils/compareDirectories.js';
 import { SFDX_CONFIG_FILE } from '../../utils/constants.js';
 
-describe('decomposer per-type overrides', () => {
+describe('decomposer overrides (per-type)', () => {
   let tempProjectDir: string;
   let forceAppDir: string;
   let workflowsDir: string;
@@ -117,6 +117,156 @@ describe('decomposer per-type overrides', () => {
     });
 
     await compareDirectories(originalDirectory, forceAppDir);
+  });
+});
+
+// Per-component overrides allow two components of the same metadata type to be decomposed with
+// different strategies/formats in a single run. Reassembly is deterministic from the on-disk
+// sidecar so the round-trip works regardless of how each component was split.
+describe('decomposer per-component overrides', () => {
+  let tempProjectDir: string;
+  let forceAppDir: string;
+  let permissionsetsDir: string;
+  const fixtureDir: string = resolve('fixtures/package-dir-1');
+  const originalCwd = process.cwd();
+
+  const sfdxConfig = {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  beforeEach(async () => {
+    tempProjectDir = await mkdtemp(join(tmpdir(), 'component-overrides-test-'));
+    forceAppDir = join(tempProjectDir, 'force-app');
+    permissionsetsDir = join(forceAppDir, 'permissionsets');
+
+    await cp(fixtureDir, forceAppDir, { recursive: true, force: true });
+    // The base fixture only contains one "real" permission set (HR_Admin); duplicate it so
+    // we have two distinct components to differentiate via component-scope overrides.
+    const hrAdminPath = join(permissionsetsDir, 'HR_Admin.permissionset-meta.xml');
+    const bigPermSetPath = join(permissionsetsDir, 'Big_PermSet.permissionset-meta.xml');
+    await copyFile(hrAdminPath, bigPermSetPath);
+
+    await writeFile(join(tempProjectDir, SFDX_CONFIG_FILE), JSON.stringify(sfdxConfig, null, 2));
+    process.chdir(tempProjectDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempProjectDir, { recursive: true, force: true });
+  });
+
+  it('decomposes two components of the same type with different strategies and round-trips on recompose', async () => {
+    const logMock = vi.fn();
+
+    await decomposeMetadataTypes({
+      metadataTypes: ['permissionset'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        {
+          components: ['permissionset:Big_PermSet'],
+          strategy: 'grouped-by-tag',
+          decomposeNestedPermissions: true,
+        },
+      ],
+      log: logMock,
+    });
+
+    const hrAdminEntries = await readdir(join(permissionsetsDir, 'HR_Admin'), { withFileTypes: true });
+    const hrAdminFileNames = hrAdminEntries.filter((e) => e.isFile()).map((e) => e.name);
+
+    // HR_Admin used the default unique-id strategy. unique-id never produces top-level
+    // tag-named aggregate files (those are the grouped-by-tag fingerprint).
+    expect(hrAdminFileNames).not.toContain('applicationVisibilities.xml');
+    expect(hrAdminFileNames).not.toContain('classAccesses.xml');
+    expect(hrAdminFileNames).not.toContain('pageAccesses.xml');
+
+    // Inside fieldPermissions/, unique-id produces ONE file per individual field
+    // (named after the `field` value, e.g. `Job_Request__c.SalaryPay__c`), not a single
+    // grouped-by-object file.
+    const hrFieldPerms = await readdir(join(permissionsetsDir, 'HR_Admin', 'fieldPermissions'));
+    expect(hrFieldPerms).toContain('Job_Request__c.SalaryPay__c.fieldPermissions-meta.xml');
+    expect(hrFieldPerms).toContain('Job_Request__c.Salary__c.fieldPermissions-meta.xml');
+
+    // Big_PermSet was overridden to grouped-by-tag, so it produces tag-named aggregate files
+    // at the top level (one file per nested tag).
+    const bigPermSetDir = join(permissionsetsDir, 'Big_PermSet');
+    const bigEntries = await readdir(bigPermSetDir, { withFileTypes: true });
+    const bigFileNames = bigEntries.filter((e) => e.isFile()).map((e) => e.name);
+    expect(bigFileNames).toContain('applicationVisibilities.xml');
+    expect(bigFileNames).toContain('classAccesses.xml');
+    expect(bigFileNames).toContain('pageAccesses.xml');
+
+    // With decomposeNestedPermissions=true, fieldPermissions are grouped by object (one
+    // file per object aggregating all field entries) rather than one file per individual field.
+    const bigFieldPerms = await readdir(join(bigPermSetDir, 'fieldPermissions'));
+    expect(bigFieldPerms).toContain('Job_Request__c.fieldPermissions-meta.xml');
+    expect(bigFieldPerms).not.toContain('Job_Request__c.SalaryPay__c.fieldPermissions-meta.xml');
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['permissionset'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    // Both files should round-trip back to byte-identical XML (same source).
+    const hrAdminXml = await readFile(join(permissionsetsDir, 'HR_Admin.permissionset-meta.xml'), 'utf-8');
+    const bigPermSetXml = await readFile(join(permissionsetsDir, 'Big_PermSet.permissionset-meta.xml'), 'utf-8');
+    expect(hrAdminXml).toBe(bigPermSetXml);
+  });
+
+  it('applies per-component format overrides on top of a per-type format override', async () => {
+    const logMock = vi.fn();
+
+    await decomposeMetadataTypes({
+      metadataTypes: ['permissionset'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        // Type-scope: every permission set decomposes to YAML by default.
+        { metadataTypes: ['permissionset'], decomposedFormat: 'yaml' },
+        // Component-scope: HR_Admin is special and decomposes to JSON instead.
+        { components: ['permissionset:HR_Admin'], decomposedFormat: 'json' },
+      ],
+      log: logMock,
+    });
+
+    // Filter out the `.config-disassembler.json` metadata sidecar and the `.key_order.json`
+    // helper file (both are always JSON regardless of decomposed format and would confuse
+    // the per-format assertions below).
+    const isSidecar = (f: string): boolean => f.endsWith('.config-disassembler.json') || f.endsWith('.key_order.json');
+    const hrAdminFiles = (await collectFiles(join(permissionsetsDir, 'HR_Admin'))).filter((f) => !isSidecar(f));
+    const bigPermSetFiles = (await collectFiles(join(permissionsetsDir, 'Big_PermSet'))).filter((f) => !isSidecar(f));
+
+    // HR_Admin honors the component-scope override (JSON), not the type-scope override (YAML).
+    expect(hrAdminFiles.some((f) => f.endsWith('.json'))).toBe(true);
+    expect(hrAdminFiles.some((f) => f.endsWith('.yaml'))).toBe(false);
+    // Big_PermSet falls back to the type-scope override (YAML).
+    expect(bigPermSetFiles.some((f) => f.endsWith('.yaml'))).toBe(true);
+    expect(bigPermSetFiles.some((f) => f.endsWith('.json'))).toBe(false);
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['permissionset'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    const hrAdminXml = await readFile(join(permissionsetsDir, 'HR_Admin.permissionset-meta.xml'), 'utf-8');
+    const bigPermSetXml = await readFile(join(permissionsetsDir, 'Big_PermSet.permissionset-meta.xml'), 'utf-8');
+    expect(hrAdminXml).toBe(bigPermSetXml);
   });
 });
 

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -9,7 +9,11 @@ import {
   loadOverridesFromConfig,
   validateOverrides,
   getOverrideForType,
+  getOverrideForComponent,
+  hasComponentOverridesForType,
+  parseComponentKey,
   resolveDecomposeOptionsForType,
+  resolveDecomposeOptionsForComponent,
   resolveDefaultConfigPath,
 } from '../../src/helpers/configOverrides.js';
 import { HOOK_CONFIG_JSON, SFDX_PROJECT_FILE_NAME } from '../../src/helpers/constants.js';
@@ -29,14 +33,78 @@ describe('configOverrides helper', () => {
       expect(() => validateOverrides(overrides)).not.toThrow();
     });
 
-    it('rejects an override with an empty metadataTypes array', () => {
+    it('rejects an override with empty metadataTypes and no components', () => {
       expect(() => validateOverrides([{ metadataTypes: [] } as unknown as DecomposerOverride])).toThrow(
-        /non-empty "metadataTypes"/,
+        /non-empty "metadataTypes" or "components"/,
       );
     });
 
-    it('rejects an override missing metadataTypes', () => {
-      expect(() => validateOverrides([{} as unknown as DecomposerOverride])).toThrow(/non-empty "metadataTypes"/);
+    it('rejects an override missing both metadataTypes and components', () => {
+      expect(() => validateOverrides([{} as unknown as DecomposerOverride])).toThrow(
+        /non-empty "metadataTypes" or "components"/,
+      );
+    });
+
+    it('rejects a non-array metadataTypes', () => {
+      expect(() => validateOverrides([{ metadataTypes: 'flow' } as unknown as DecomposerOverride])).toThrow(
+        /non-array "metadataTypes"/,
+      );
+    });
+
+    it('rejects a non-array components', () => {
+      expect(() =>
+        validateOverrides([{ components: 'permissionset:HR_Admin' } as unknown as DecomposerOverride]),
+      ).toThrow(/non-array "components"/);
+    });
+
+    it('accepts a components-only override', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          components: ['permissionset:HR_Admin', 'permissionset:Big_PermSet'],
+          strategy: 'grouped-by-tag',
+          decomposeNestedPermissions: true,
+        },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('accepts a mixed override that targets both a type and components', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['permissionset'],
+          components: ['mutingpermissionset:Locked_Down'],
+          decomposedFormat: 'yaml',
+        },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('rejects duplicate component keys across overrides', () => {
+      const overrides: DecomposerOverride[] = [
+        { components: ['permissionset:HR_Admin'], decomposedFormat: 'yaml' },
+        { components: ['permissionset:HR_Admin'], strategy: 'grouped-by-tag' },
+      ];
+      expect(() => validateOverrides(overrides)).toThrow(/Component "permissionset:HR_Admin" appears in more than one/);
+    });
+
+    it('rejects a malformed component key without colon', () => {
+      const overrides: DecomposerOverride[] = [{ components: ['permissionset_HR_Admin'] }];
+      expect(() => validateOverrides(overrides)).toThrow(/invalid component key/);
+    });
+
+    it('rejects a component key with an empty fullName', () => {
+      const overrides: DecomposerOverride[] = [{ components: ['permissionset:'] }];
+      expect(() => validateOverrides(overrides)).toThrow(/invalid component key/);
+    });
+
+    it('rejects a component key with an empty suffix', () => {
+      const overrides: DecomposerOverride[] = [{ components: [':HR_Admin'] }];
+      expect(() => validateOverrides(overrides)).toThrow(/invalid component key/);
+    });
+
+    it('rejects a non-string component', () => {
+      const overrides = [{ components: [42] }] as unknown as DecomposerOverride[];
+      expect(() => validateOverrides(overrides)).toThrow(/empty or non-string component/);
     });
 
     it('rejects duplicate metadata types across overrides', () => {
@@ -85,10 +153,49 @@ describe('configOverrides helper', () => {
     });
   });
 
+  describe('parseComponentKey', () => {
+    it('parses a simple key', () => {
+      expect(parseComponentKey('permissionset:HR_Admin')).toEqual({
+        metadataType: 'permissionset',
+        fullName: 'HR_Admin',
+      });
+    });
+
+    it('preserves a folder-style fullName intact', () => {
+      expect(parseComponentKey('report:MyFolder/MyReport')).toEqual({
+        metadataType: 'report',
+        fullName: 'MyFolder/MyReport',
+      });
+    });
+
+    it('returns undefined for a key without a colon', () => {
+      expect(parseComponentKey('flow_MyFlow')).toBeUndefined();
+    });
+
+    it('returns undefined for a key starting with a colon', () => {
+      expect(parseComponentKey(':MyFlow')).toBeUndefined();
+    });
+
+    it('returns undefined for a key ending with a colon', () => {
+      expect(parseComponentKey('flow:')).toBeUndefined();
+    });
+
+    it('returns undefined when the suffix is only whitespace', () => {
+      // ` :HR_Admin` parses past the colon-position checks (colon is at index 1, not 0) but
+      // fails the post-trim emptiness guard.
+      expect(parseComponentKey(' :HR_Admin')).toBeUndefined();
+    });
+
+    it('returns undefined when the fullName is only whitespace', () => {
+      expect(parseComponentKey('permissionset:   ')).toBeUndefined();
+    });
+  });
+
   describe('getOverrideForType', () => {
     const overrides: DecomposerOverride[] = [
       { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
       { metadataTypes: ['permissionset', 'mutingpermissionset'], strategy: 'grouped-by-tag' },
+      { components: ['permissionset:HR_Admin'], strategy: 'grouped-by-tag' },
     ];
 
     it('returns undefined when overrides is undefined', () => {
@@ -106,6 +213,66 @@ describe('configOverrides helper', () => {
 
     it('returns undefined for an unmatched suffix', () => {
       expect(getOverrideForType('workflow', overrides)).toBeUndefined();
+    });
+
+    it('does not match a components-only override by suffix', () => {
+      // The third override only has `components`, so a type-suffix lookup must skip it even
+      // when the suffix appears inside a component key.
+      const componentsOnly: DecomposerOverride[] = [{ components: ['flow:My_Flow'], decomposedFormat: 'yaml' }];
+      expect(getOverrideForType('flow', componentsOnly)).toBeUndefined();
+    });
+  });
+
+  describe('getOverrideForComponent', () => {
+    const overrides: DecomposerOverride[] = [
+      { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+      {
+        components: ['permissionset:HR_Admin', 'permissionset:Big_PermSet'],
+        strategy: 'grouped-by-tag',
+        decomposeNestedPermissions: true,
+      },
+    ];
+
+    it('returns undefined when overrides is undefined or empty', () => {
+      expect(getOverrideForComponent('permissionset', 'HR_Admin', undefined)).toBeUndefined();
+      expect(getOverrideForComponent('permissionset', 'HR_Admin', [])).toBeUndefined();
+    });
+
+    it('returns the matching override for a known component', () => {
+      expect(getOverrideForComponent('permissionset', 'HR_Admin', overrides)).toBe(overrides[1]);
+      expect(getOverrideForComponent('permissionset', 'Big_PermSet', overrides)).toBe(overrides[1]);
+    });
+
+    it('returns undefined for an unmatched component', () => {
+      expect(getOverrideForComponent('permissionset', 'Unknown', overrides)).toBeUndefined();
+      expect(getOverrideForComponent('flow', 'My_Flow', overrides)).toBeUndefined();
+    });
+  });
+
+  describe('hasComponentOverridesForType', () => {
+    const overrides: DecomposerOverride[] = [
+      { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+      { components: ['permissionset:HR_Admin'], strategy: 'grouped-by-tag' },
+    ];
+
+    it('returns false when overrides is undefined or empty', () => {
+      expect(hasComponentOverridesForType('permissionset', undefined)).toBe(false);
+      expect(hasComponentOverridesForType('permissionset', [])).toBe(false);
+    });
+
+    it('returns true when at least one component targets the type', () => {
+      expect(hasComponentOverridesForType('permissionset', overrides)).toBe(true);
+    });
+
+    it('returns false when no component targets the type', () => {
+      expect(hasComponentOverridesForType('flow', overrides)).toBe(false);
+      expect(hasComponentOverridesForType('mutingpermissionset', overrides)).toBe(false);
+    });
+
+    it('does not match on a partial suffix prefix', () => {
+      // `permission` is a prefix of `permissionset` but must not match.
+      const sneaky: DecomposerOverride[] = [{ components: ['permissionset:HR_Admin'] }];
+      expect(hasComponentOverridesForType('permission', sneaky)).toBe(false);
     });
   });
 
@@ -128,9 +295,7 @@ describe('configOverrides helper', () => {
     });
 
     it('applies override values that are set, falling back to base for unset fields', () => {
-      const overrides: DecomposerOverride[] = [
-        { metadataTypes: ['flow'], decomposedFormat: 'yaml', prePurge: true },
-      ];
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['flow'], decomposedFormat: 'yaml', prePurge: true }];
       expect(resolveDecomposeOptionsForType('flow', base, overrides)).toEqual({
         format: 'yaml',
         strategy: 'unique-id',
@@ -155,6 +320,59 @@ describe('configOverrides helper', () => {
         prepurge: false,
         postpurge: false,
       });
+    });
+  });
+
+  describe('resolveDecomposeOptionsForComponent', () => {
+    const base = {
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      prepurge: false,
+      postpurge: false,
+    };
+
+    it('returns the type-resolved values when no component override matches', () => {
+      const typeResolved = { ...base, format: 'yaml' };
+      const overrides: DecomposerOverride[] = [{ components: ['permissionset:Other'], strategy: 'grouped-by-tag' }];
+      expect(resolveDecomposeOptionsForComponent('permissionset', 'HR_Admin', typeResolved, overrides)).toEqual(
+        typeResolved,
+      );
+    });
+
+    it('applies component override fields and falls back to typeResolved for unset fields', () => {
+      const typeResolved = { ...base, format: 'yaml', prepurge: true };
+      const overrides: DecomposerOverride[] = [
+        {
+          components: ['permissionset:HR_Admin'],
+          strategy: 'grouped-by-tag',
+          decomposeNestedPermissions: true,
+        },
+      ];
+      expect(resolveDecomposeOptionsForComponent('permissionset', 'HR_Admin', typeResolved, overrides)).toEqual({
+        format: 'yaml',
+        strategy: 'grouped-by-tag',
+        decomposeNestedPerms: true,
+        prepurge: true,
+        postpurge: false,
+      });
+    });
+
+    it('lets a component override fully overwrite a type-scoped field', () => {
+      const typeResolved = { ...base, format: 'yaml' };
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['permissionset'], decomposedFormat: 'yaml' },
+        { components: ['permissionset:HR_Admin'], decomposedFormat: 'json' },
+      ];
+      expect(resolveDecomposeOptionsForComponent('permissionset', 'HR_Admin', typeResolved, overrides)).toEqual({
+        ...typeResolved,
+        format: 'json',
+      });
+    });
+
+    it('returns typeResolved when overrides is undefined', () => {
+      const typeResolved = { ...base, format: 'json' };
+      expect(resolveDecomposeOptionsForComponent('flow', 'My_Flow', typeResolved)).toEqual(typeResolved);
     });
   });
 
@@ -214,10 +432,7 @@ describe('configOverrides helper', () => {
       await writeFile(
         configPath,
         JSON.stringify({
-          overrides: [
-            { metadataTypes: ['flow'] },
-            { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
-          ],
+          overrides: [{ metadataTypes: ['flow'] }, { metadataTypes: ['flow'], decomposedFormat: 'yaml' }],
         }),
       );
       await expect(loadOverridesFromConfig(configPath)).rejects.toThrow(/appears in more than one override/);


### PR DESCRIPTION
Extend the `overrides` array in `.sfdecomposer.config.json` with a `components` field keyed by `<suffix>:<fullName>` (e.g. `permissionset:HR_Admin`) so individual SDR components can be decomposed with different formats/strategies than the rest of their metadata type in a single run.

Resolution precedence (highest first):
  1. component-scope override (`components`)
  2. type-scope override (`metadataTypes`)
  3. run-scope (CLI flags / hook config / defaults)
  4. hard plugin rules (labels, loyaltyProgramSetup -> unique-id)

Reassembly is unchanged: it stays deterministic from the on-disk sidecar, so any mix of per-component formats/strategies round-trips.