### PR TITLE
feat(decompose): expose splitTags as an override field

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
 - [Troubleshooting](#troubleshooting)
 - [Hooks](#hooks)
 - [Per-Type & Per-Component Overrides](#per-type--per-component-overrides)
+  - [splitTags grammar](#splittags-grammar)
 - [Ignore Files](#ignore-files)
   - [.forceignore](#forceignore)
   - [.sfdecomposerignore](#sfdecomposerignore)
@@ -413,7 +414,8 @@ By default, a single decompose run uses one format and one strategy across every
 | `components`                 | Optional (required if `metadataTypes` is omitted). Array of `<metadataSuffix>:<fullName>` keys (e.g. `permissionset:HR_Admin`, `report:MyFolder/MyReport`). Each component may appear in at most one override. |
 | `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                                                                                          |
 | `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                  |
-| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`.                                                                                                                                 |
+| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`. Sets a known-good `splitTags` default; ignored if `splitTags` is also set in the same scope.                                    |
+| `splitTags`                  | Custom `splitTags` spec for `grouped-by-tag` strategy. See [splitTags grammar](#splittags-grammar). Ignored when the resolved strategy is not `grouped-by-tag`.                                                |
 | `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                             |
 | `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                           |
 
@@ -438,6 +440,51 @@ For each component, each option is resolved independently in this order (highest
 2. The type-scope override value (matching `<suffix>` in `metadataTypes`), if set.
 3. The run-wide value (CLI flag, hook config top-level field, or built-in default).
 4. Hard plugin rules (e.g. `labels` and `loyaltyProgramSetup` forced to `unique-id`) override all of the above.
+
+### splitTags grammar
+
+`splitTags` lets you control how `grouped-by-tag` writes nested arrays for any metadata type. The plugin already applies a known-good default for permission sets when `decomposeNestedPermissions: true` is set; setting `splitTags` directly takes precedence and works for any metadata type.
+
+**Spec:** Comma-separated rules. Each rule has 3 or 4 colon-separated parts:
+
+- `<tag>:<mode>:<field>` — read array items from the top-level `<tag>`.
+- `<tag>:<path>:<mode>:<field>` — read array items from the nested `<path>` (defaults to `<tag>`).
+
+`<mode>` is one of:
+
+- **`split`** — write one file per array item, named after the value of `<field>` on each item.
+- **`group`** — group array items by the value of `<field>`, writing one file per group.
+
+Each `<tag>` may appear at most once in a spec. The plugin validates the grammar at config-load time. Deeper checks (e.g. unknown tag names for the metadata type) are surfaced by the underlying disassembler crate at runtime.
+
+#### splitTags cookbook
+
+```json
+"overrides": [
+  {
+    "metadataTypes": ["permissionset", "mutingpermissionset"],
+    "strategy": "grouped-by-tag",
+    "splitTags": "objectPermissions:split:object,fieldPermissions:group:field"
+  },
+  {
+    "metadataTypes": ["profile"],
+    "strategy": "grouped-by-tag",
+    "splitTags": "objectPermissions:split:object,fieldPermissions:group:field,layoutAssignments:group:layout"
+  },
+  {
+    "metadataTypes": ["flow"],
+    "strategy": "grouped-by-tag",
+    "splitTags": "actionCalls:split:name,decisions:split:name,assignments:split:name"
+  },
+  {
+    "metadataTypes": ["workflow"],
+    "strategy": "grouped-by-tag",
+    "splitTags": "rules:split:fullName,alerts:split:fullName,fieldUpdates:split:fullName,tasks:split:fullName"
+  }
+]
+```
+
+> **Caveat:** When using `mode: split`, the chosen `<field>` must produce a unique value for every array item — otherwise two items would map to the same filename. If two items share a field value, prefer `mode: group` instead, which is designed for that case.
 
 ### Opting in from the CLI
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -13,6 +13,11 @@
       "decomposeNestedPermissions": true
     },
     {
+      "metadataTypes": ["profile"],
+      "strategy": "grouped-by-tag",
+      "splitTags": "objectPermissions:split:object,fieldPermissions:group:field,layoutAssignments:group:layout"
+    },
+    {
       "components": ["permissionset:HR_Admin"],
       "strategy": "unique-id",
       "decomposedFormat": "json"

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -41,7 +41,11 @@ export type ResolvedDecomposeTypeOptions = {
   decomposeNestedPerms: boolean;
   prepurge: boolean;
   postpurge: boolean;
+  /** Resolved custom `splitTags` spec, when explicitly set in an override. */
+  splitTags?: string;
 };
+
+const SPLIT_TAGS_MODES = new Set<string>(['split', 'group']);
 
 /**
  * Load and validate the `overrides` array from a `.sfdecomposer.config.json` file.
@@ -148,6 +152,64 @@ function validateOverrideValues(override: DecomposerOverride, i: number): void {
         `Allowed values: ${DECOMPOSED_STRATEGIES.join(', ')}.`,
     );
   }
+
+  if (override.splitTags !== undefined) {
+    validateSplitTagsSpec(override.splitTags, i);
+  }
+}
+
+/**
+ * Validate the comma-separated `splitTags` spec at config-load time. Each rule must be of the
+ * form `<tag>:<mode>:<field>` or `<tag>:<path>:<mode>:<field>`, with `mode` ∈ {split, group}.
+ * Tags must be unique within the spec. Deeper validation (e.g. unknown XML tag names) is left
+ * to the underlying disassembler crate at runtime.
+ */
+export function validateSplitTagsSpec(spec: string, i: number): void {
+  if (typeof spec !== 'string' || spec.trim() === '') {
+    throw new Error(`Override at index ${i} has an empty "splitTags" string.`);
+  }
+
+  const rules = spec.split(',').map((rule) => rule.trim());
+  const seenTags = new Set<string>();
+
+  for (const rule of rules) {
+    if (rule === '') {
+      throw new Error(`Override at index ${i} "splitTags" contains an empty rule.`);
+    }
+    const parts = rule.split(':').map((part) => part.trim());
+
+    let tag: string;
+    let mode: string;
+    let field: string;
+    if (parts.length === 3) {
+      [tag, mode, field] = parts;
+    } else if (parts.length === 4) {
+      // path defaults to tag in the 3-part form; we don't need to retain it for validation,
+      // we just check the parts are non-empty and the mode/field are well-formed.
+      [tag, , mode, field] = parts;
+    } else {
+      throw new Error(
+        `Override at index ${i} "splitTags" rule "${rule}" must have 3 or 4 colon-separated parts ` +
+          '("tag:mode:field" or "tag:path:mode:field").',
+      );
+    }
+
+    if (!tag || !mode || !field || (parts.length === 4 && !parts[1])) {
+      throw new Error(`Override at index ${i} "splitTags" rule "${rule}" has empty parts.`);
+    }
+    if (!SPLIT_TAGS_MODES.has(mode)) {
+      throw new Error(
+        `Override at index ${i} "splitTags" rule "${rule}" has invalid mode "${mode}". ` +
+          `Allowed values: ${Array.from(SPLIT_TAGS_MODES).join(', ')}.`,
+      );
+    }
+    if (seenTags.has(tag)) {
+      throw new Error(
+        `Override at index ${i} "splitTags" contains duplicate tag "${tag}". Each tag may appear at most once.`,
+      );
+    }
+    seenTags.add(tag);
+  }
 }
 
 function validateMetadataTypeEntries(metadataTypes: string[], i: number, seenTypes: Set<string>): void {
@@ -251,6 +313,7 @@ export function resolveDecomposeOptionsForType(
     decomposeNestedPerms: override.decomposeNestedPermissions ?? base.decomposeNestedPerms,
     prepurge: override.prePurge ?? base.prepurge,
     postpurge: override.postPurge ?? base.postpurge,
+    splitTags: override.splitTags ?? base.splitTags,
   };
 }
 
@@ -278,5 +341,6 @@ export function resolveDecomposeOptionsForComponent(
     decomposeNestedPerms: componentOverride.decomposeNestedPermissions ?? typeResolved.decomposeNestedPerms,
     prepurge: componentOverride.prePurge ?? typeResolved.prepurge,
     postpurge: componentOverride.postPurge ?? typeResolved.postpurge,
+    splitTags: componentOverride.splitTags ?? typeResolved.splitTags,
   };
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -15,6 +15,14 @@ export type DecomposerOverride = {
   decomposedFormat?: string;
   strategy?: string;
   decomposeNestedPermissions?: boolean;
+  /**
+   * Custom `splitTags` spec for `grouped-by-tag` strategy. Comma-separated rules of the form
+   * `<tag>:<mode>:<field>` or `<tag>:<path>:<mode>:<field>`, where `mode` is `split` (one file
+   * per array item, filename from `field`) or `group` (array items grouped by `field`, one file
+   * per group). When set, this wins over the hardcoded `decomposeNestedPermissions` default
+   * for permission sets. Only applied when the resolved strategy is `grouped-by-tag`.
+   */
+  splitTags?: string;
   prePurge?: boolean;
   postPurge?: boolean;
 };

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -159,19 +159,27 @@ function disassembleHandler(
 ): void {
   const handler: DisassembleXMLFileHandler = new DisassembleXMLFileHandler();
   let multiLevel;
-  let splitTags;
   const effectiveStrategy = applyHardStrategyRules(metaSuffix, options.strategy);
-  const decomposePermSets: boolean =
-    options.decomposeNestedPerms &&
-    (metaSuffix === 'permissionset' || metaSuffix === 'mutingpermissionset') &&
-    effectiveStrategy === 'grouped-by-tag';
   const decomposeLoyalyProgram: boolean = metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id';
   if (decomposeLoyalyProgram) {
     multiLevel = 'programProcesses:programProcesses:parameterName,ruleName';
   }
 
-  if (decomposePermSets) {
-    splitTags = 'objectPermissions:split:object,fieldPermissions:group:field';
+  // Resolve splitTags with this precedence:
+  //   1. an explicit `splitTags` set in the override (any metadata type, gated to grouped-by-tag);
+  //   2. the hardcoded permission-set default when `decomposeNestedPermissions: true` is set on
+  //      a permissionset / mutingpermissionset under grouped-by-tag.
+  // splitTags is a no-op for non-grouped-by-tag strategies, so we never pass it otherwise.
+  let splitTags: string | undefined;
+  if (effectiveStrategy === 'grouped-by-tag') {
+    if (options.splitTags) {
+      splitTags = options.splitTags;
+    } else if (
+      options.decomposeNestedPerms &&
+      (metaSuffix === 'permissionset' || metaSuffix === 'mutingpermissionset')
+    ) {
+      splitTags = 'objectPermissions:split:object,fieldPermissions:group:field';
+    }
   }
 
   handler.disassemble({

--- a/test/commands/decomposer/overrides.test.ts
+++ b/test/commands/decomposer/overrides.test.ts
@@ -223,6 +223,58 @@ describe('decomposer per-component overrides', () => {
     expect(hrAdminXml).toBe(bigPermSetXml);
   });
 
+  it('honors a custom splitTags spec over the hardcoded permission-set default', async () => {
+    const logMock = vi.fn();
+
+    // Custom spec: split fieldPermissions one-file-per-field instead of grouping by object,
+    // and leave objectPermissions as a single tag-named aggregate file (no rule for it).
+    await decomposeMetadataTypes({
+      metadataTypes: ['permissionset'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        {
+          metadataTypes: ['permissionset'],
+          strategy: 'grouped-by-tag',
+          // decomposeNestedPermissions intentionally omitted to prove the custom splitTags
+          // alone is enough to drive the nested-tag layout.
+          splitTags: 'fieldPermissions:split:field',
+        },
+      ],
+      log: logMock,
+    });
+
+    const hrAdminDir = join(permissionsetsDir, 'HR_Admin');
+    const fieldPermsFiles = await readdir(join(hrAdminDir, 'fieldPermissions'));
+    // split mode keys files by the `field` value (one file per field), not by object.
+    expect(fieldPermsFiles).toContain('Job_Request__c.SalaryPay__c.fieldPermissions-meta.xml');
+    expect(fieldPermsFiles).toContain('Job_Request__c.Salary__c.fieldPermissions-meta.xml');
+    // The hardcoded default would have produced this group-by-object filename; verify it does
+    // NOT exist, proving the custom spec replaced the default rather than merging with it.
+    expect(fieldPermsFiles).not.toContain('Job_Request__c.fieldPermissions-meta.xml');
+
+    // No splitTags rule for objectPermissions → it stays as a single aggregate top-level file
+    // (standard grouped-by-tag behavior).
+    const hrAdminEntries = await readdir(hrAdminDir, { withFileTypes: true });
+    const hrAdminFiles = hrAdminEntries.filter((e) => e.isFile()).map((e) => e.name);
+    expect(hrAdminFiles).toContain('objectPermissions.xml');
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['permissionset'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    const recomposedXml = await readFile(join(permissionsetsDir, 'HR_Admin.permissionset-meta.xml'), 'utf-8');
+    const originalXml = await readFile(join(fixtureDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml'), 'utf-8');
+    expect(recomposedXml).toBe(originalXml);
+  });
+
   it('applies per-component format overrides on top of a per-type format override', async () => {
     const logMock = vi.fn();
 

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   loadOverridesFromConfig,
   validateOverrides,
+  validateSplitTagsSpec,
   getOverrideForType,
   getOverrideForComponent,
   hasComponentOverridesForType,
@@ -150,6 +151,86 @@ describe('configOverrides helper', () => {
         { metadataTypes: ['flow'], decomposedFormat: 'yaml', futureFlag: true },
       ] as unknown as DecomposerOverride[];
       expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('accepts a well-formed splitTags spec', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['permissionset'],
+          strategy: 'grouped-by-tag',
+          splitTags: 'objectPermissions:split:object,fieldPermissions:group:field',
+        },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('rejects a malformed splitTags spec', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['flow'], strategy: 'grouped-by-tag', splitTags: 'actionCalls:split' },
+      ];
+      expect(() => validateOverrides(overrides)).toThrow(/3 or 4 colon-separated parts/);
+    });
+  });
+
+  describe('validateSplitTagsSpec', () => {
+    it('accepts a 3-part rule', () => {
+      expect(() => validateSplitTagsSpec('objectPermissions:split:object', 0)).not.toThrow();
+    });
+
+    it('accepts a 4-part rule (with explicit path)', () => {
+      expect(() => validateSplitTagsSpec('items:nested.items:group:label', 0)).not.toThrow();
+    });
+
+    it('accepts multiple comma-separated rules', () => {
+      expect(() =>
+        validateSplitTagsSpec('objectPermissions:split:object,fieldPermissions:group:field', 0),
+      ).not.toThrow();
+    });
+
+    it('rejects an empty spec', () => {
+      expect(() => validateSplitTagsSpec('', 0)).toThrow(/empty "splitTags" string/);
+    });
+
+    it('rejects a whitespace-only spec', () => {
+      expect(() => validateSplitTagsSpec('   ', 0)).toThrow(/empty "splitTags" string/);
+    });
+
+    it('rejects an empty rule between commas', () => {
+      expect(() => validateSplitTagsSpec('objectPermissions:split:object,,fieldPermissions:group:field', 0)).toThrow(
+        /contains an empty rule/,
+      );
+    });
+
+    it('rejects a rule with too few parts', () => {
+      expect(() => validateSplitTagsSpec('actionCalls:split', 0)).toThrow(/3 or 4 colon-separated parts/);
+    });
+
+    it('rejects a rule with too many parts', () => {
+      expect(() => validateSplitTagsSpec('a:b:c:d:e', 0)).toThrow(/3 or 4 colon-separated parts/);
+    });
+
+    it('rejects a rule with an empty tag', () => {
+      expect(() => validateSplitTagsSpec(':split:object', 0)).toThrow(/empty parts/);
+    });
+
+    it('rejects a 4-part rule with an empty path', () => {
+      expect(() => validateSplitTagsSpec('items::group:label', 0)).toThrow(/empty parts/);
+    });
+
+    it('rejects an unknown mode', () => {
+      expect(() => validateSplitTagsSpec('actionCalls:explode:name', 0)).toThrow(/invalid mode "explode"/);
+    });
+
+    it('rejects duplicate tags within a single spec', () => {
+      expect(() => validateSplitTagsSpec('actionCalls:split:name,actionCalls:group:label', 0)).toThrow(
+        /duplicate tag "actionCalls"/,
+      );
+    });
+
+    it('tolerates rules with surrounding whitespace', () => {
+      expect(() =>
+        validateSplitTagsSpec('  objectPermissions : split : object , fieldPermissions : group : field ', 0),
+      ).not.toThrow();
     });
   });
 
@@ -319,7 +400,19 @@ describe('configOverrides helper', () => {
         decomposeNestedPerms: true,
         prepurge: false,
         postpurge: false,
+        splitTags: undefined,
       });
+    });
+
+    it('threads a type-scope splitTags through resolution', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['flow'],
+          strategy: 'grouped-by-tag',
+          splitTags: 'actionCalls:split:name',
+        },
+      ];
+      expect(resolveDecomposeOptionsForType('flow', base, overrides).splitTags).toBe('actionCalls:split:name');
     });
   });
 
@@ -373,6 +466,22 @@ describe('configOverrides helper', () => {
     it('returns typeResolved when overrides is undefined', () => {
       const typeResolved = { ...base, format: 'json' };
       expect(resolveDecomposeOptionsForComponent('flow', 'My_Flow', typeResolved)).toEqual(typeResolved);
+    });
+
+    it('lets a component override replace a type-scoped splitTags', () => {
+      const typeResolved = { ...base, strategy: 'grouped-by-tag', splitTags: 'actionCalls:split:name' };
+      const overrides: DecomposerOverride[] = [{ components: ['flow:Special'], splitTags: 'decisions:group:label' }];
+      expect(resolveDecomposeOptionsForComponent('flow', 'Special', typeResolved, overrides).splitTags).toBe(
+        'decisions:group:label',
+      );
+    });
+
+    it('inherits a type-scoped splitTags when the component override does not set one', () => {
+      const typeResolved = { ...base, strategy: 'grouped-by-tag', splitTags: 'actionCalls:split:name' };
+      const overrides: DecomposerOverride[] = [{ components: ['flow:Other'], decomposedFormat: 'yaml' }];
+      expect(resolveDecomposeOptionsForComponent('flow', 'Other', typeResolved, overrides).splitTags).toBe(
+        'actionCalls:split:name',
+      );
     });
   });
 


### PR DESCRIPTION
Let advanced admins customize how `grouped-by-tag` writes nested arrays for any metadata type, not just the hardcoded perm-set default. `splitTags` works at both type-scope (`metadataTypes`) and component-scope (`components`) and follows the same precedence as the rest of the override fields. Grammar (`tag:mode:field` or `tag:path:mode:field`, comma-separated, mode ∈ {split, group}) is validated at config-load time so users get errors before the run.

The hardcoded perm-set default tied to `decomposeNestedPermissions` is preserved; an explicit `splitTags` simply wins over it.