### PR TITLE
feat: add multiLevel override and round-trip verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
 - [Commands](#commands)
   - [sf decomposer decompose](#sf-decomposer-decompose)
   - [sf decomposer recompose](#sf-decomposer-recompose)
-  - [Manifest-scoped runs](#manifest-scoped-runs)
+  - [sf decomposer verify](#sf-decomposer-verify)
+- [Manifest-scoped runs](#manifest-scoped-runs)
 - [Decompose Strategies](#decompose-strategies)
   - [Custom Labels](#custom-labels-decomposition)
   - [Permission Sets (grouped-by-tag)](#additional-permission-set-decomposition)
@@ -28,6 +29,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
 - [Hooks](#hooks)
 - [Per-Type & Per-Component Overrides](#per-type--per-component-overrides)
   - [splitTags grammar](#splittags-grammar)
+  - [multiLevel grammar](#multilevel-grammar)
 - [Ignore Files](#ignore-files)
   - [.forceignore](#forceignore)
   - [.sfdecomposerignore](#sfdecomposerignore)
@@ -114,10 +116,11 @@ Salesforce’s built-in decomposition is limited. sf-decomposer gives admins and
 
 ## Commands
 
-| Command                   | Description                                                     |
-| ------------------------- | --------------------------------------------------------------- |
-| `sf decomposer decompose` | Decompose metadata in package directories into smaller files.   |
-| `sf decomposer recompose` | Recompose decomposed files back into deployment-ready metadata. |
+| Command                   | Description                                                                         |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `sf decomposer decompose` | Decompose metadata in package directories into smaller files.                       |
+| `sf decomposer recompose` | Recompose decomposed files back into deployment-ready metadata.                     |
+| `sf decomposer verify`    | Round-trip check: decompose + recompose in a temp directory and diff the originals. |
 
 ### sf decomposer decompose
 
@@ -194,9 +197,49 @@ sf decomposer recompose -x "manifest/package.xml"
 sf project deploy start -x "manifest/package.xml"
 ```
 
-### Manifest-scoped runs
+### sf decomposer verify
 
-The `-x` / `--manifest` flag accepts any standard Salesforce `package.xml` and limits the work to just the components it lists. This is especially useful for CI/CD pipelines that deploy a subset of metadata per change.
+Non-destructive round-trip check: copies your package directories into a temp directory under your OS's `tmpdir()`, runs decompose then recompose there, and diffs the rebuilt parents against the originals using **structural XML equality** (sibling and attribute order are ignored). Exits non-zero on any drift; your working tree is never modified.
+
+```
+USAGE
+  $ sf decomposer verify [-m <value>] [-x <value>] [-f <value>] [-i <value>] [-s <value>] [-p -c --json]
+
+FLAGS
+  -m, --metadata-type=<value>             Metadata suffix to verify (e.g. flow, labels). Repeatable. Optional when --manifest is provided.
+  -x, --manifest=<value>                  Path to a package.xml manifest. When provided, only the components listed in the manifest are verified.
+  -f, --format=<value>                    Output format used for the round-trip decompose: xml | yaml | json | json5 [default: xml]
+  -i, --ignore-package-directory=<value>  Package directory to skip. Repeatable.
+  -s, --strategy=<value>                  unique-id | grouped-by-tag [default: unique-id]
+  -p, --decompose-nested-permissions      With grouped-by-tag, further decompose permission set and muting permission set object/field permissions.
+  -c, --config                            Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root, the same as `decompose --config`. [default: false]
+
+GLOBAL FLAGS
+  --json  Output as JSON.
+```
+
+> At least one of `--metadata-type` or `--manifest` is required. When both are supplied, the run is scoped to the intersection of the two.
+
+**Examples**
+
+```bash
+# Verify two metadata types round-trip cleanly with defaults
+sf decomposer verify -m "permissionset" -m "profile"
+
+# Verify a different strategy + nested-perms split before committing the change
+sf decomposer verify -m "permissionset" -s "grouped-by-tag" -p
+
+# CI gate: verify just the components in a deploy manifest, using the repo-root config
+sf decomposer verify -x "manifest/package.xml" --config
+```
+
+Files where the **only** delta is sibling or attribute ordering are surfaced separately as informational notices ("Note: N file(s) round-tripped semantically but with sibling/attribute reordering") rather than as drift. This is safe — Salesforce treats metadata as order-agnostic and `config-disassembler` does not preserve original sibling order — but it tells you up front that committing the post-recompose output will produce a diff in git even though the metadata is functionally identical.
+
+---
+
+## Manifest-scoped runs
+
+The `-x` / `--manifest` flag is supported by every `sf decomposer` command (`decompose`, `recompose`, `verify`) and accepts any standard Salesforce `package.xml`, limiting the work to just the components it lists. This is especially useful for CI/CD pipelines that deploy a subset of metadata per change.
 
 How it works:
 
@@ -416,6 +459,7 @@ By default, a single decompose run uses one format and one strategy across every
 | `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                  |
 | `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`. Sets a known-good `splitTags` default; ignored if `splitTags` is also set in the same scope.                                    |
 | `splitTags`                  | Custom `splitTags` spec for `grouped-by-tag` strategy. See [splitTags grammar](#splittags-grammar). Ignored when the resolved strategy is not `grouped-by-tag`.                                                |
+| `multiLevel`                 | Custom `multiLevel` spec for nested-array decomposition. See [multiLevel grammar](#multilevel-grammar). When set, replaces the hardcoded `loyaltyProgramSetup` default for the targeted scope.                 |
 | `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                             |
 | `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                           |
 
@@ -485,6 +529,35 @@ Each `<tag>` may appear at most once in a spec. The plugin validates the grammar
 ```
 
 > **Caveat:** When using `mode: split`, the chosen `<field>` must produce a unique value for every array item — otherwise two items would map to the same filename. If two items share a field value, prefer `mode: group` instead, which is designed for that case.
+
+### multiLevel grammar
+
+`multiLevel` enables a second decomposition pass on inner-level files for metadata types whose XML has deeply nested repeatable blocks (e.g. `loyaltyProgramSetup`'s `programProcesses → parameters → ...`). The plugin already applies a known-good default for `loyaltyProgramSetup` when running the `unique-id` strategy; setting `multiLevel` directly takes precedence and works for any metadata type.
+
+**Spec:** A single rule with exactly 3 colon-separated parts (the third part is itself a comma-separated list):
+
+```
+<file_pattern>:<root_to_strip>:<unique_id_elements>
+```
+
+- **`<file_pattern>`** — basename pattern that selects which inner-level files get the second decomposition pass (e.g. `programProcesses`).
+- **`<root_to_strip>`** — XML root tag to strip from each matched file before splitting.
+- **`<unique_id_elements>`** — comma-separated list of element names used to derive a stable filename for each inner-level item (e.g. `parameterName,ruleName`). The first element that resolves to a non-empty value wins.
+
+The plugin validates the grammar at config-load time; deeper checks (whether the file pattern matches anything, whether the unique-id elements actually appear on the inner XML) are surfaced by the underlying disassembler crate at runtime.
+
+```json
+"overrides": [
+  {
+    "metadataTypes": ["loyaltyProgramSetup"],
+    "multiLevel": "programProcesses:programProcesses:parameterName,ruleName"
+  }
+]
+```
+
+> **Limit:** Only one rule per scope. The disassembler does not currently accept multiple comma-separated multiLevel specs, because the third part of the rule is itself a comma-separated list.
+
+> **Tip:** Use [`sf decomposer verify`](#sf-decomposer-verify) to non-destructively confirm a new override config still round-trips before committing it.
 
 ### Opting in from the CLI
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -18,6 +18,10 @@
       "splitTags": "objectPermissions:split:object,fieldPermissions:group:field,layoutAssignments:group:layout"
     },
     {
+      "metadataTypes": ["loyaltyProgramSetup"],
+      "multiLevel": "programProcesses:programProcesses:parameterName,ruleName"
+    },
+    {
       "components": ["permissionset:HR_Admin"],
       "strategy": "unique-id",
       "decomposedFormat": "json"

--- a/messages/decomposer.verify.md
+++ b/messages/decomposer.verify.md
@@ -1,0 +1,57 @@
+# summary
+
+Round-trip verify that decompose followed by recompose preserves your metadata byte-for-byte.
+
+# description
+
+Copies your package directories into a temp directory under your OS's `tmpdir()`, runs decompose
+then recompose there with the same flags and `.sfdecomposer.config.json` overrides you would use
+in production, then diffs every rebuilt parent XML against the original. Comparison is
+**structural** (sibling and attribute order are ignored, matching how Salesforce treats metadata).
+The command never modifies your working tree.
+
+Files where the only delta is ordering are surfaced as informational notices ("reordered") and do
+not fail the run. Genuine semantic differences are reported as drift and exit non-zero, which
+makes the command suitable as a CI gate before committing strategy, format, or override changes.
+
+# examples
+
+- `sf decomposer verify -m "permissionset" -f "xml"`
+- `sf decomposer verify -m "permissionset" -m "profile" -s "grouped-by-tag" -p`
+- `sf decomposer verify -x "manifest/package.xml" --config`
+
+# flags.metadata-type.summary
+
+The metadata suffix to verify, such as 'flow', 'labels', etc. Required unless --manifest is provided.
+
+# flags.manifest.summary
+
+Path to a package.xml manifest file. When provided, only the metadata listed in the manifest is verified. If --metadata-type is also provided, the intersection of the two is used.
+
+# flags.format.summary
+
+File format to decompose into for the round-trip check.
+
+# flags.ignore-package-directory.summary
+
+Ignore a package directory.
+
+# flags.strategy.summary
+
+Strategy to follow when decomposing files for the round-trip check.
+
+# flags.decompose-nested-permissions.summary
+
+Additionally decompose object and field permissions on a permission set when strategy is set to "grouped-by-tag".
+
+# flags.config.summary
+
+Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root, the same as `decomposer decompose --config`.
+
+# error.missingMetadataOrManifest
+
+Either --metadata-type (-m) or --manifest (-x) must be provided.
+
+# error.driftDetected
+
+Round-trip verify failed: %s file(s) drifted between the original tree and the round-tripped output. See the log above for the offending paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.0",
         "config-disassembler": "^1.0.0",
+        "fast-xml-parser": "^5.7.2",
         "p-limit": "^7.3.0"
       },
       "devDependencies": {
@@ -6850,7 +6851,6 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
         "fast-xml-builder": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.0",
     "config-disassembler": "^1.0.0",
+    "fast-xml-parser": "^5.7.2",
     "p-limit": "^7.3.0"
   },
   "devDependencies": {
@@ -143,8 +144,10 @@
       "files": [
         "src/commands/decomposer/decompose.ts",
         "src/commands/decomposer/recompose.ts",
+        "src/commands/decomposer/verify.ts",
         "messages/decomposer.decompose.md",
         "messages/decomposer.recompose.md",
+        "messages/decomposer.verify.md",
         "README.md"
       ],
       "dependencies": [

--- a/src/commands/decomposer/verify.ts
+++ b/src/commands/decomposer/verify.ts
@@ -1,0 +1,94 @@
+'use strict';
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+
+import { DECOMPOSED_FILE_TYPES, DECOMPOSED_STRATEGIES } from '../../helpers/constants.js';
+import { verifyMetadataTypes } from '../../core/verifyMetadataTypes.js';
+import { loadOverridesFromConfig, resolveDefaultConfigPath } from '../../helpers/configOverrides.js';
+import { VerifyResult } from '../../helpers/types.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('sf-decomposer', 'decomposer.verify');
+
+export default class DecomposerVerify extends SfCommand<VerifyResult> {
+  public static override readonly summary = messages.getMessage('summary');
+  public static override readonly description = messages.getMessage('description');
+  public static override readonly examples = messages.getMessages('examples');
+
+  public static override readonly flags = {
+    'metadata-type': Flags.string({
+      summary: messages.getMessage('flags.metadata-type.summary'),
+      char: 'm',
+      multiple: true,
+      required: false,
+    }),
+    manifest: Flags.file({
+      summary: messages.getMessage('flags.manifest.summary'),
+      char: 'x',
+      required: false,
+      exists: true,
+    }),
+    format: Flags.string({
+      summary: messages.getMessage('flags.format.summary'),
+      char: 'f',
+      required: true,
+      multiple: false,
+      default: 'xml',
+      options: DECOMPOSED_FILE_TYPES,
+    }),
+    'ignore-package-directory': Flags.directory({
+      summary: messages.getMessage('flags.ignore-package-directory.summary'),
+      char: 'i',
+      required: false,
+      multiple: true,
+    }),
+    strategy: Flags.string({
+      summary: messages.getMessage('flags.strategy.summary'),
+      char: 's',
+      required: true,
+      multiple: false,
+      default: 'unique-id',
+      options: DECOMPOSED_STRATEGIES,
+    }),
+    'decompose-nested-permissions': Flags.boolean({
+      summary: messages.getMessage('flags.decompose-nested-permissions.summary'),
+      char: 'p',
+      required: false,
+      default: false,
+    }),
+    config: Flags.boolean({
+      summary: messages.getMessage('flags.config.summary'),
+      char: 'c',
+      required: false,
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<VerifyResult> {
+    const { flags } = await this.parse(DecomposerVerify);
+
+    if (!flags['metadata-type'] && !flags['manifest']) {
+      throw messages.createError('error.missingMetadataOrManifest');
+    }
+
+    const overrides = flags['config'] ? await loadOverridesFromConfig(await resolveDefaultConfigPath()) : undefined;
+
+    const result = await verifyMetadataTypes({
+      metadataTypes: flags['metadata-type'],
+      format: flags['format'],
+      ignoreDirs: flags['ignore-package-directory'],
+      strategy: flags['strategy'],
+      decomposeNestedPerms: flags['decompose-nested-permissions'],
+      manifest: flags['manifest'],
+      overrides,
+      log: this.log.bind(this),
+    });
+
+    if (result.drift.length > 0) {
+      throw messages.createError('error.driftDetected', [String(result.drift.length)]);
+    }
+
+    return result;
+  }
+}

--- a/src/core/verifyMetadataTypes.ts
+++ b/src/core/verifyMetadataTypes.ts
@@ -1,0 +1,164 @@
+'use strict';
+
+import { mkdtemp, rm, readFile, writeFile, cp, stat, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import { getRepoRoot } from '../service/core/getRepoRoot.js';
+import { diffDirectories } from '../service/verify/diffDirectories.js';
+import { SFDX_PROJECT_FILE_NAME } from '../helpers/constants.js';
+import { SfdxProject, VerifyDrift, VerifyOptions, VerifyResult } from '../helpers/types.js';
+import { decomposeMetadataTypes } from './decomposeMetadataTypes.js';
+import { recomposeMetadataTypes } from './recomposeMetadataTypes.js';
+
+/**
+ * Run a non-destructive round-trip check: copy the user's package directories into a scratch
+ * directory under the OS temp folder, decompose + recompose them there, and diff the rebuilt
+ * parents against the originals.
+ *
+ * The temp directory is always removed before this function returns, and the user's working tree
+ * is never modified. The returned `drift` array is empty when every parent XML survived the round
+ * trip byte-identically; otherwise each entry names the offending file (relative to its package
+ * directory) and a short reason.
+ */
+export async function verifyMetadataTypes(options: VerifyOptions): Promise<VerifyResult> {
+  const { metadataTypes, format, ignoreDirs, strategy, decomposeNestedPerms, manifest, overrides, log } = options;
+
+  const { repoRoot, dxConfigFilePath } = (await getRepoRoot()) as {
+    repoRoot: string;
+    dxConfigFilePath: string;
+  };
+
+  const sfdxProjectRaw = await readFile(dxConfigFilePath, 'utf-8');
+  const sfdxProject = JSON.parse(sfdxProjectRaw) as SfdxProject;
+  const packageDirRelPaths = sfdxProject.packageDirectories.map((p) => p.path);
+
+  const tempProjectDir = await mkdtemp(join(tmpdir(), 'sf-decomposer-verify-'));
+  const originalCwd = process.cwd();
+
+  try {
+    await Promise.all(
+      packageDirRelPaths.map(async (rel) => {
+        const src = resolve(repoRoot, rel);
+        const dst = resolve(tempProjectDir, rel);
+        /* istanbul ignore next -- @preserve: declared package dirs typically exist; defensive only */
+        if (!(await pathExists(src))) {
+          /* istanbul ignore next -- @preserve: declared package dirs typically exist; defensive only */
+          return;
+        }
+        await cp(src, dst, { recursive: true });
+      }),
+    );
+
+    await writeFile(join(tempProjectDir, SFDX_PROJECT_FILE_NAME), sfdxProjectRaw);
+
+    // Manifests are validated by oclif's `Flags.file({ exists: true })`, so when one is supplied
+    // it always points to a real file under the user's repo. Mirror it into the temp project at
+    // the same relative path so parseManifest (which is repoRoot-relative once we chdir) finds it.
+    let tempManifest: string | undefined;
+    if (manifest) {
+      const absManifest = resolve(originalCwd, manifest);
+      const relManifest = relative(repoRoot, absManifest);
+      const tempManifestAbs = resolve(tempProjectDir, relManifest);
+      await mkdir(dirname(tempManifestAbs), { recursive: true });
+      await cp(absManifest, tempManifestAbs);
+      tempManifest = tempManifestAbs;
+    }
+
+    process.chdir(tempProjectDir);
+
+    // Strip any user-supplied prePurge/postPurge from the overrides for verify only. Verify needs
+    // the parent XML to survive the decompose phase so that manifest-driven recompose can
+    // re-resolve it (parseManifest only returns parent XML paths that exist on disk). Letting the
+    // user's overrides drive post-purge here would silently break manifest filtering.
+    const verifyOverrides = overrides?.map((override) => {
+      const { prePurge, postPurge, ...rest } = override;
+      // Reference the stripped fields so the linter understands they are intentionally discarded.
+      void prePurge;
+      void postPurge;
+      return rest;
+    });
+
+    const decomposed = await decomposeMetadataTypes({
+      metadataTypes,
+      // Wipe any pre-existing decomposed children so we always start from a clean fixture, but
+      // keep the parent XML intact for the recompose phase (see comment above).
+      prepurge: true,
+      postpurge: false,
+      format,
+      ignoreDirs,
+      strategy,
+      decomposeNestedPerms,
+      manifest: tempManifest,
+      overrides: verifyOverrides,
+      log,
+    });
+
+    if (decomposed.metadata.length > 0) {
+      await recomposeMetadataTypes({
+        metadataTypes: decomposed.metadata,
+        // Postpurge here removes the decomposed children we generated above, leaving the rebuilt
+        // parent XML as the only artifact to diff against the original.
+        postpurge: true,
+        ignoreDirs,
+        manifest: tempManifest,
+        log,
+      });
+    }
+
+    process.chdir(originalCwd);
+
+    const drift: VerifyDrift[] = [];
+    const reordered: string[] = [];
+    const diffTasks = packageDirRelPaths.map(async (rel) => {
+      const original = resolve(repoRoot, rel);
+      const reconstructed = resolve(tempProjectDir, rel);
+      /* istanbul ignore if -- @preserve: we just `cp`'d into this directory, so it always exists */
+      if (!(await pathExists(reconstructed))) {
+        return { drift: [] as VerifyDrift[], reordered: [] as string[] };
+      }
+      return diffDirectories(original, reconstructed);
+    });
+    for (const result of await Promise.all(diffTasks)) {
+      drift.push(...result.drift);
+      reordered.push(...result.reordered);
+    }
+
+    if (drift.length === 0) {
+      log(`Round-trip verified for ${decomposed.metadata.length} metadata type(s); no drift detected.`);
+    } else {
+      log(`Round-trip drift detected in ${drift.length} file(s):`);
+      for (const entry of drift) {
+        log(`  - ${entry.path}: ${entry.reason}`);
+      }
+    }
+
+    if (reordered.length > 0) {
+      // Informational only — semantic content matches, just sibling/attribute order changed.
+      // Salesforce treats metadata as order-agnostic, so this is safe to commit.
+      log(`Note: ${reordered.length} file(s) round-tripped semantically but with sibling/attribute reordering:`);
+      for (const path of reordered) {
+        log(`  - ${path}`);
+      }
+    }
+
+    return { metadata: decomposed.metadata, drift, reordered };
+  } finally {
+    /* istanbul ignore next -- @preserve: defensive guard; we already chdir back on the happy path */
+    if (process.cwd() !== originalCwd) {
+      process.chdir(originalCwd);
+    }
+    await rm(tempProjectDir, { recursive: true, force: true });
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    /* istanbul ignore next -- @preserve: package directories declared in sfdx-project.json always
+       exist on disk in the supported flow; this catch is defensive for partially-broken projects. */
+    return false;
+  }
+}

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -43,6 +43,8 @@ export type ResolvedDecomposeTypeOptions = {
   postpurge: boolean;
   /** Resolved custom `splitTags` spec, when explicitly set in an override. */
   splitTags?: string;
+  /** Resolved custom `multiLevel` spec, when explicitly set in an override. */
+  multiLevel?: string;
 };
 
 const SPLIT_TAGS_MODES = new Set<string>(['split', 'group']);
@@ -156,6 +158,10 @@ function validateOverrideValues(override: DecomposerOverride, i: number): void {
   if (override.splitTags !== undefined) {
     validateSplitTagsSpec(override.splitTags, i);
   }
+
+  if (override.multiLevel !== undefined) {
+    validateMultiLevelSpec(override.multiLevel, i);
+  }
 }
 
 /**
@@ -209,6 +215,44 @@ export function validateSplitTagsSpec(spec: string, i: number): void {
       );
     }
     seenTags.add(tag);
+  }
+}
+
+/**
+ * Validate the `multiLevel` spec at config-load time. The underlying disassembler currently
+ * accepts a single colon-separated rule of the form
+ * `<file_pattern>:<root_to_strip>:<unique_id_elements>` where `<unique_id_elements>` is itself
+ * a comma-separated list. Deeper checks (whether the file pattern matches anything, whether
+ * the unique-id elements actually exist on the inner XML) are left to the runtime crate.
+ */
+export function validateMultiLevelSpec(spec: string, i: number): void {
+  if (typeof spec !== 'string' || spec.trim() === '') {
+    throw new Error(`Override at index ${i} has an empty "multiLevel" string.`);
+  }
+
+  const parts = spec.split(':').map((part) => part.trim());
+  if (parts.length !== 3) {
+    throw new Error(
+      `Override at index ${i} "multiLevel" must have exactly 3 colon-separated parts ` +
+        '("<file_pattern>:<root_to_strip>:<unique_id_elements>").',
+    );
+  }
+
+  const [filePattern, rootToStrip, uniqueIdElements] = parts;
+  if (!filePattern || !rootToStrip || !uniqueIdElements) {
+    throw new Error(`Override at index ${i} "multiLevel" has empty parts.`);
+  }
+
+  const ids = uniqueIdElements.split(',').map((id) => id.trim());
+  const seenIds = new Set<string>();
+  for (const id of ids) {
+    if (id === '') {
+      throw new Error(`Override at index ${i} "multiLevel" unique-id list contains an empty entry.`);
+    }
+    if (seenIds.has(id)) {
+      throw new Error(`Override at index ${i} "multiLevel" unique-id list has duplicate entry "${id}".`);
+    }
+    seenIds.add(id);
   }
 }
 
@@ -314,6 +358,7 @@ export function resolveDecomposeOptionsForType(
     prepurge: override.prePurge ?? base.prepurge,
     postpurge: override.postPurge ?? base.postpurge,
     splitTags: override.splitTags ?? base.splitTags,
+    multiLevel: override.multiLevel ?? base.multiLevel,
   };
 }
 
@@ -342,5 +387,6 @@ export function resolveDecomposeOptionsForComponent(
     prepurge: componentOverride.prePurge ?? typeResolved.prepurge,
     postpurge: componentOverride.postPurge ?? typeResolved.postpurge,
     splitTags: componentOverride.splitTags ?? typeResolved.splitTags,
+    multiLevel: componentOverride.multiLevel ?? typeResolved.multiLevel,
   };
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -23,6 +23,13 @@ export type DecomposerOverride = {
    * for permission sets. Only applied when the resolved strategy is `grouped-by-tag`.
    */
   splitTags?: string;
+  /**
+   * Custom `multiLevel` spec for nested-array decomposition. Format:
+   * `<file_pattern>:<root_to_strip>:<unique_id_elements>` (the third part is itself a
+   * comma-separated list). When set, this wins over the hardcoded `loyaltyProgramSetup`
+   * default. Applies regardless of strategy because multiLevel works on a per-file pattern.
+   */
+  multiLevel?: string;
   prePurge?: boolean;
   postPurge?: boolean;
 };
@@ -84,4 +91,34 @@ export type RecomposeOptions = {
   ignoreDirs?: string[];
   manifest?: string;
   log: (msg: string) => void;
+};
+
+export type VerifyOptions = {
+  metadataTypes?: string[];
+  format: string;
+  ignoreDirs?: string[];
+  strategy: string;
+  decomposeNestedPerms: boolean;
+  manifest?: string;
+  overrides?: DecomposerOverride[];
+  log: (msg: string) => void;
+};
+
+export type VerifyDrift = {
+  /** Path of the offending file relative to its package directory. */
+  path: string;
+  /** Short human-readable reason: `'content drift'` or `'missing in round-trip output'`. */
+  reason: string;
+};
+
+export type VerifyResult = {
+  /** Metadata types that participated in the round trip. */
+  metadata: string[];
+  /** One entry per file that did not survive the round trip semantically. Empty on success. */
+  drift: VerifyDrift[];
+  /**
+   * Files where the only delta was sibling/attribute ordering — content is semantically identical
+   * but not byte-identical. Reported for awareness; does not fail `verify`.
+   */
+  reordered: string[];
 };

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -158,10 +158,15 @@ function disassembleHandler(
   metaSuffix: string,
 ): void {
   const handler: DisassembleXMLFileHandler = new DisassembleXMLFileHandler();
-  let multiLevel;
   const effectiveStrategy = applyHardStrategyRules(metaSuffix, options.strategy);
-  const decomposeLoyalyProgram: boolean = metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id';
-  if (decomposeLoyalyProgram) {
+
+  // Resolve multiLevel with this precedence:
+  //   1. an explicit `multiLevel` set in the override (any metadata type);
+  //   2. the hardcoded loyaltyProgramSetup default when running unique-id strategy.
+  let multiLevel: string | undefined;
+  if (options.multiLevel) {
+    multiLevel = options.multiLevel;
+  } else if (metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id') {
     multiLevel = 'programProcesses:programProcesses:parameterName,ruleName';
   }
 

--- a/src/service/verify/diffDirectories.ts
+++ b/src/service/verify/diffDirectories.ts
@@ -1,0 +1,151 @@
+'use strict';
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+import { XMLParser } from 'fast-xml-parser';
+
+import { VerifyDrift } from '../../helpers/types.js';
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+  ignoreDeclaration: true,
+  ignorePiTags: true,
+});
+
+export type DirDiffResult = {
+  /** Files whose contents are semantically different (real drift). */
+  drift: VerifyDrift[];
+  /**
+   * Files where the only delta is sibling/attribute ordering. Surfaced for awareness — these are
+   * NOT failures, since Salesforce metadata is generally order-agnostic and `config-disassembler`
+   * does not preserve original sibling order.
+   */
+  reordered: string[];
+};
+
+/**
+ * Recursively diff two directory trees. Files in the reference tree are compared against the
+ * mock tree; files that exist only in the mock tree are intentionally ignored, so the helper is
+ * safe to use against round-trip output that contains transient sidecars (e.g.
+ * `.config-disassembler.json`) which the original tree never had.
+ *
+ * For `.xml` files, comparison is **structural and order-insensitive**: sibling elements with the
+ * same tag name can appear in any order without registering as drift. Files that are byte-different
+ * but semantically equal are returned in `reordered` so the caller can surface the difference.
+ */
+export async function diffDirectories(referenceDir: string, mockDir: string, prefix = ''): Promise<DirDiffResult> {
+  const out: DirDiffResult = { drift: [], reordered: [] };
+
+  let entries;
+  try {
+    entries = await readdir(referenceDir, { withFileTypes: true });
+  } catch {
+    /* istanbul ignore next -- @preserve: caller already filters to existing directories */
+    return out;
+  }
+
+  for (const entry of entries) {
+    const refPath = join(referenceDir, entry.name);
+    const mockPath = join(mockDir, entry.name);
+    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+    if (entry.isDirectory()) {
+      // eslint-disable-next-line no-await-in-loop
+      const nested = await diffDirectories(refPath, mockPath, relPath);
+      out.drift.push(...nested.drift);
+      out.reordered.push(...nested.reordered);
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const mockExists = await fileExists(mockPath);
+    if (!mockExists) {
+      out.drift.push({ path: relPath, reason: 'missing in round-trip output' });
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const [ref, mock] = await Promise.all([readFile(refPath, 'utf-8'), readFile(mockPath, 'utf-8')]);
+    if (ref === mock) continue;
+
+    if (isXmlFile(entry.name)) {
+      // Byte-different but maybe semantically identical — e.g. siblings reordered on round trip.
+      if (xmlEquivalent(ref, mock)) {
+        out.reordered.push(relPath);
+      } else {
+        out.drift.push({ path: relPath, reason: 'content drift' });
+      }
+    } else {
+      out.drift.push({ path: relPath, reason: 'content drift' });
+    }
+  }
+
+  return out;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isXmlFile(fileName: string): boolean {
+  return extname(fileName).toLowerCase() === '.xml';
+}
+
+/**
+ * Compare two XML strings for structural equality, ignoring sibling order and attribute order.
+ * Falls back to `false` if either side fails to parse, so genuinely malformed output still
+ * surfaces as drift through the caller.
+ */
+export function xmlEquivalent(a: string, b: string): boolean {
+  if (a === b) return true;
+  let parsedA: unknown;
+  let parsedB: unknown;
+  try {
+    parsedA = xmlParser.parse(a);
+    parsedB = xmlParser.parse(b);
+  } catch {
+    /* istanbul ignore next -- @preserve: fast-xml-parser is permissive; this is defensive only */
+    return false;
+  }
+  return canonicalJson(parsedA) === canonicalJson(parsedB);
+}
+
+/**
+ * Convert any JSON value into a stable string representation: object keys are sorted, and arrays
+ * are sorted by the canonical-JSON of each element. Two values produce the same canonical string
+ * iff they are deeply equal up to sibling order.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    const normalized = value.map(canonicalize);
+    normalized.sort((left, right) => {
+      const ls = JSON.stringify(left);
+      const rs = JSON.stringify(right);
+      if (ls < rs) return -1;
+      if (ls > rs) return 1;
+      return 0;
+    });
+    return normalized;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    out[key] = canonicalize(record[key]);
+  }
+  return out;
+}

--- a/test/commands/decomposer/overrides.test.ts
+++ b/test/commands/decomposer/overrides.test.ts
@@ -83,6 +83,47 @@ describe('decomposer overrides (per-type)', () => {
     await compareDirectories(originalDirectory, forceAppDir);
   });
 
+  it('threads a custom multiLevel override through the disassembler and round-trips on recompose', async () => {
+    const logMock = vi.fn();
+
+    // Explicitly set the same spec the plugin hardcodes for loyalty. The point of this test is
+    // to prove the override path is wired all the way through; if the override silently dropped,
+    // round-trip would still pass (the hardcoded default would kick in), so we additionally
+    // verify the resolved options surface it (covered by unit tests) and that decompose produced
+    // the inner-level files we expect.
+    await decomposeMetadataTypes({
+      metadataTypes: ['loyaltyProgramSetup'],
+      prepurge: true,
+      postpurge: false,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        {
+          metadataTypes: ['loyaltyProgramSetup'],
+          multiLevel: 'programProcesses:programProcesses:parameterName,ruleName',
+        },
+      ],
+      log: logMock,
+    });
+
+    const loyaltyDir = join(forceAppDir, 'loyaltyProgramSetups', 'Cloud_Kicks_Inner_Circle');
+    const loyaltyEntries = await readdir(loyaltyDir, { withFileTypes: true });
+    // multiLevel decomposition produces a per-process subdir with parameter/rule files inside.
+    const subdirs = loyaltyEntries.filter((e) => e.isDirectory()).map((e) => e.name);
+    expect(subdirs).toContain('programProcesses');
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['loyaltyProgramSetup'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    await compareDirectories(originalDirectory, forceAppDir);
+  });
+
   it('applies per-type strategy overrides during decompose', async () => {
     const logMock = vi.fn();
 

--- a/test/commands/decomposer/verify.test.ts
+++ b/test/commands/decomposer/verify.test.ts
@@ -1,0 +1,319 @@
+'use strict';
+
+import { mkdtemp, rm, writeFile, readFile, copyFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { cp } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import * as diffModule from '../../../src/service/verify/diffDirectories.js';
+import { verifyMetadataTypes } from '../../../src/core/verifyMetadataTypes.js';
+import { SFDX_CONFIG_FILE } from '../../utils/constants.js';
+
+describe('decomposer verify', () => {
+  let tempProjectDir: string;
+  let forceAppDir: string;
+  const fixtureDir: string = resolve('fixtures/package-dir-1');
+  const originalCwd = process.cwd();
+
+  const sfdxConfig = {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  beforeEach(async () => {
+    tempProjectDir = await mkdtemp(join(tmpdir(), 'verify-test-'));
+    forceAppDir = join(tempProjectDir, 'force-app');
+    await cp(fixtureDir, forceAppDir, { recursive: true, force: true });
+    await writeFile(join(tempProjectDir, SFDX_CONFIG_FILE), JSON.stringify(sfdxConfig, null, 2));
+    process.chdir(tempProjectDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempProjectDir, { recursive: true, force: true });
+  });
+
+  it('returns no drift for a clean fixture round-trip and leaves the working tree untouched', async () => {
+    const logMock = vi.fn();
+    const before = await readFile(join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml'), 'utf-8');
+
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset', 'workflow'],
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual([]);
+    expect(result.metadata).toEqual(expect.arrayContaining(['permissionset', 'workflow']));
+    expect(logMock).toHaveBeenCalledWith(expect.stringContaining('no drift detected'));
+
+    const after = await readFile(join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml'), 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  it('tolerates sibling reordering in the original XML (semantic equality, not byte equality)', async () => {
+    // Round-trip is order-insensitive by design (Salesforce metadata is sibling-order agnostic
+    // and config-disassembler does not preserve original sibling order). Build an "original"
+    // that is the fixture with two top-level children swapped, and confirm verify still passes.
+    const target = join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+    const original = await readFile(target, 'utf-8');
+    // Swap the first two `<applicationVisibilities>` blocks if present; otherwise fall back to
+    // a generic <description>↔<label> swap, which both real fixtures contain.
+    const reordered = swapFirstTwoBlocks(original, 'fieldPermissions');
+    expect(reordered).not.toBe(original);
+    await writeFile(target, reordered);
+
+    const logMock = vi.fn();
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([]);
+  });
+
+  it('logs both drift entries and reordered notices when the diff reports each', async () => {
+    // Constructing genuine round-trip drift / reorder on this fixture is unreliable —
+    // config-disassembler is deterministic and this fixture round-trips clean — so we stub
+    // diffDirectories to exercise both reporting branches together.
+    const spy = vi.spyOn(diffModule, 'diffDirectories').mockResolvedValue({
+      drift: [
+        { path: 'permissionsets/HR_Admin.permissionset-meta.xml', reason: 'content drift' },
+        { path: 'workflows/Case.workflow-meta.xml', reason: 'missing in round-trip output' },
+      ],
+      reordered: ['profiles/SuperUser.profile-meta.xml'],
+    });
+
+    const logMock = vi.fn();
+    try {
+      const result = await verifyMetadataTypes({
+        metadataTypes: ['permissionset'],
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        log: logMock,
+      });
+
+      expect(result.drift).toHaveLength(2);
+      expect(result.reordered).toEqual(['profiles/SuperUser.profile-meta.xml']);
+
+      expect(logMock).toHaveBeenCalledWith(expect.stringContaining('Round-trip drift detected in 2 file(s)'));
+      expect(logMock).toHaveBeenCalledWith(
+        expect.stringContaining('permissionsets/HR_Admin.permissionset-meta.xml: content drift'),
+      );
+      expect(logMock).toHaveBeenCalledWith(
+        expect.stringContaining('workflows/Case.workflow-meta.xml: missing in round-trip output'),
+      );
+
+      expect(logMock).toHaveBeenCalledWith(
+        expect.stringContaining('1 file(s) round-tripped semantically but with sibling/attribute reordering'),
+      );
+      expect(logMock).toHaveBeenCalledWith(expect.stringContaining('profiles/SuperUser.profile-meta.xml'));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('logs reorder notices on a clean round-trip (no drift) when only ordering changed', async () => {
+    // Stub a reorder-only result to confirm `verify` does NOT fail on reorder and does log it.
+    const spy = vi.spyOn(diffModule, 'diffDirectories').mockResolvedValue({
+      drift: [],
+      reordered: ['workflows/Case.workflow-meta.xml'],
+    });
+
+    const logMock = vi.fn();
+    try {
+      const result = await verifyMetadataTypes({
+        metadataTypes: ['workflow'],
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        log: logMock,
+      });
+
+      expect(result.drift).toEqual([]);
+      expect(result.reordered).toEqual(['workflows/Case.workflow-meta.xml']);
+      expect(logMock).toHaveBeenCalledWith(expect.stringContaining('no drift detected'));
+      expect(logMock).toHaveBeenCalledWith(
+        expect.stringContaining('1 file(s) round-tripped semantically but with sibling/attribute reordering'),
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('skips the recompose step when no metadata types survive the manifest filter', async () => {
+    // Build a manifest pointing at a member that does not exist on disk; parseManifest filters
+    // it out, decompose returns zero processed types, and the recompose call must be skipped
+    // (otherwise it would throw "Either --metadata-type or --manifest must be provided").
+    await writeFile(
+      join(tempProjectDir, 'package.xml'),
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<Package xmlns="http://soap.sforce.com/2006/04/metadata">',
+        '  <types>',
+        '    <members>Definitely_Missing_Workflow</members>',
+        '    <name>Workflow</name>',
+        '  </types>',
+        '  <version>58.0</version>',
+        '</Package>',
+        '',
+      ].join('\n'),
+    );
+
+    const logMock = vi.fn();
+    const result = await verifyMetadataTypes({
+      metadataTypes: undefined,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      manifest: 'package.xml',
+      log: logMock,
+    });
+
+    expect(result.metadata).toEqual([]);
+    expect(result.drift).toEqual([]);
+  });
+
+  it('honors the manifest filter end-to-end', async () => {
+    await writeFile(
+      join(tempProjectDir, 'package.xml'),
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<Package xmlns="http://soap.sforce.com/2006/04/metadata">',
+        '  <types>',
+        '    <members>Case</members>',
+        '    <name>Workflow</name>',
+        '  </types>',
+        '  <version>58.0</version>',
+        '</Package>',
+        '',
+      ].join('\n'),
+    );
+
+    const logMock = vi.fn();
+    const result = await verifyMetadataTypes({
+      metadataTypes: undefined,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      manifest: 'package.xml',
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([]);
+    expect(result.metadata).toEqual(['workflow']);
+  });
+});
+
+describe('decomposer verify (component overrides)', () => {
+  let tempProjectDir: string;
+  let forceAppDir: string;
+  const fixtureDir: string = resolve('fixtures/package-dir-1');
+  const originalCwd = process.cwd();
+
+  const sfdxConfig = {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  beforeEach(async () => {
+    tempProjectDir = await mkdtemp(join(tmpdir(), 'verify-overrides-test-'));
+    forceAppDir = join(tempProjectDir, 'force-app');
+    await cp(fixtureDir, forceAppDir, { recursive: true, force: true });
+    const hrAdminPath = join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+    const bigPermSetPath = join(forceAppDir, 'permissionsets', 'Big_PermSet.permissionset-meta.xml');
+    await copyFile(hrAdminPath, bigPermSetPath);
+    await writeFile(join(tempProjectDir, SFDX_CONFIG_FILE), JSON.stringify(sfdxConfig, null, 2));
+    process.chdir(tempProjectDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempProjectDir, { recursive: true, force: true });
+  });
+
+  it('verifies a mixed per-component config without drift', async () => {
+    const logMock = vi.fn();
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        { metadataTypes: ['permissionset'], decomposedFormat: 'yaml' },
+        { components: ['permissionset:HR_Admin'], strategy: 'grouped-by-tag', decomposeNestedPermissions: true },
+      ],
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([]);
+    expect(result.metadata).toEqual(['permissionset']);
+  });
+
+  it('ignores user-supplied prePurge / postPurge in overrides during verify', async () => {
+    // A user might have postPurge:true in their config to model the real workflow. Verify must
+    // ignore those so the parent XML stays put for the manifest-driven recompose phase below.
+    const logMock = vi.fn();
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [{ metadataTypes: ['permissionset'], prePurge: true, postPurge: true }],
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([]);
+  });
+});
+
+/**
+ * Best-effort sibling swap: locate the first two top-level `<tag>...</tag>` blocks and swap
+ * them. Falls back to returning the input unchanged when fewer than two blocks exist (the test
+ * guards against this with an explicit `not.toBe` assertion).
+ */
+function swapFirstTwoBlocks(xml: string, tag: string): string {
+  const open = `<${tag}>`;
+  const close = `</${tag}>`;
+
+  const firstStart = xml.indexOf(open);
+  if (firstStart === -1) return xml;
+  const firstEnd = xml.indexOf(close, firstStart);
+  /* istanbul ignore next -- @preserve: malformed XML is not produced by the fixture */
+  if (firstEnd === -1) return xml;
+  const firstFull = firstEnd + close.length;
+
+  const secondStart = xml.indexOf(open, firstFull);
+  if (secondStart === -1) return xml;
+  const secondEnd = xml.indexOf(close, secondStart);
+  /* istanbul ignore next -- @preserve: malformed XML is not produced by the fixture */
+  if (secondEnd === -1) return xml;
+  const secondFull = secondEnd + close.length;
+
+  const head = xml.slice(0, firstStart);
+  const blockA = xml.slice(firstStart, firstFull);
+  const middle = xml.slice(firstFull, secondStart);
+  const blockB = xml.slice(secondStart, secondFull);
+  const tail = xml.slice(secondFull);
+  return `${head}${blockB}${middle}${blockA}${tail}`;
+}

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -9,6 +9,7 @@ import {
   loadOverridesFromConfig,
   validateOverrides,
   validateSplitTagsSpec,
+  validateMultiLevelSpec,
   getOverrideForType,
   getOverrideForComponent,
   hasComponentOverridesForType,
@@ -170,6 +171,23 @@ describe('configOverrides helper', () => {
       ];
       expect(() => validateOverrides(overrides)).toThrow(/3 or 4 colon-separated parts/);
     });
+
+    it('accepts a well-formed multiLevel spec', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['loyaltyProgramSetup'],
+          multiLevel: 'programProcesses:programProcesses:parameterName,ruleName',
+        },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('rejects a malformed multiLevel spec', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['loyaltyProgramSetup'], multiLevel: 'programProcesses:programProcesses' },
+      ];
+      expect(() => validateOverrides(overrides)).toThrow(/exactly 3 colon-separated parts/);
+    });
   });
 
   describe('validateSplitTagsSpec', () => {
@@ -231,6 +249,48 @@ describe('configOverrides helper', () => {
       expect(() =>
         validateSplitTagsSpec('  objectPermissions : split : object , fieldPermissions : group : field ', 0),
       ).not.toThrow();
+    });
+  });
+
+  describe('validateMultiLevelSpec', () => {
+    it('accepts the canonical loyalty spec', () => {
+      expect(() => validateMultiLevelSpec('programProcesses:programProcesses:parameterName,ruleName', 0)).not.toThrow();
+    });
+
+    it('accepts a single-id rule', () => {
+      expect(() => validateMultiLevelSpec('items:items:name', 0)).not.toThrow();
+    });
+
+    it('rejects an empty spec', () => {
+      expect(() => validateMultiLevelSpec('', 0)).toThrow(/empty "multiLevel" string/);
+    });
+
+    it('rejects a whitespace-only spec', () => {
+      expect(() => validateMultiLevelSpec('   ', 0)).toThrow(/empty "multiLevel" string/);
+    });
+
+    it('rejects a rule with too few parts', () => {
+      expect(() => validateMultiLevelSpec('items:items', 0)).toThrow(/exactly 3 colon-separated parts/);
+    });
+
+    it('rejects a rule with too many parts', () => {
+      expect(() => validateMultiLevelSpec('items:items:name:extra', 0)).toThrow(/exactly 3 colon-separated parts/);
+    });
+
+    it('rejects a rule with empty parts', () => {
+      expect(() => validateMultiLevelSpec(':items:name', 0)).toThrow(/empty parts/);
+    });
+
+    it('rejects a unique-id list with an empty entry', () => {
+      expect(() => validateMultiLevelSpec('items:items:name,', 0)).toThrow(/empty entry/);
+    });
+
+    it('rejects duplicate unique-id entries', () => {
+      expect(() => validateMultiLevelSpec('items:items:name,name', 0)).toThrow(/duplicate entry "name"/);
+    });
+
+    it('tolerates surrounding whitespace', () => {
+      expect(() => validateMultiLevelSpec(' items : items : name , label ', 0)).not.toThrow();
     });
   });
 
@@ -401,6 +461,7 @@ describe('configOverrides helper', () => {
         prepurge: false,
         postpurge: false,
         splitTags: undefined,
+        multiLevel: undefined,
       });
     });
 
@@ -413,6 +474,18 @@ describe('configOverrides helper', () => {
         },
       ];
       expect(resolveDecomposeOptionsForType('flow', base, overrides).splitTags).toBe('actionCalls:split:name');
+    });
+
+    it('threads a type-scope multiLevel through resolution', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['loyaltyProgramSetup'],
+          multiLevel: 'programProcesses:programProcesses:parameterName,ruleName',
+        },
+      ];
+      expect(resolveDecomposeOptionsForType('loyaltyProgramSetup', base, overrides).multiLevel).toBe(
+        'programProcesses:programProcesses:parameterName,ruleName',
+      );
     });
   });
 
@@ -482,6 +555,27 @@ describe('configOverrides helper', () => {
       expect(resolveDecomposeOptionsForComponent('flow', 'Other', typeResolved, overrides).splitTags).toBe(
         'actionCalls:split:name',
       );
+    });
+
+    it('lets a component override replace a type-scoped multiLevel', () => {
+      const typeResolved = { ...base, multiLevel: 'programProcesses:programProcesses:parameterName,ruleName' };
+      const overrides: DecomposerOverride[] = [
+        { components: ['loyaltyProgramSetup:Custom'], multiLevel: 'rules:rules:ruleName' },
+      ];
+      expect(
+        resolveDecomposeOptionsForComponent('loyaltyProgramSetup', 'Custom', typeResolved, overrides).multiLevel,
+      ).toBe('rules:rules:ruleName');
+    });
+
+    it('inherits a type-scoped multiLevel when the component override does not set one', () => {
+      const typeResolved = {
+        ...base,
+        multiLevel: 'programProcesses:programProcesses:parameterName,ruleName',
+      };
+      const overrides: DecomposerOverride[] = [{ components: ['loyaltyProgramSetup:Other'], decomposedFormat: 'yaml' }];
+      expect(
+        resolveDecomposeOptionsForComponent('loyaltyProgramSetup', 'Other', typeResolved, overrides).multiLevel,
+      ).toBe('programProcesses:programProcesses:parameterName,ruleName');
     });
   });
 

--- a/test/units/diffDirectories.test.ts
+++ b/test/units/diffDirectories.test.ts
@@ -1,0 +1,161 @@
+'use strict';
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { diffDirectories, xmlEquivalent, canonicalJson } from '../../src/service/verify/diffDirectories.js';
+
+describe('diffDirectories', () => {
+  let refDir: string;
+  let mockDir: string;
+
+  beforeEach(async () => {
+    refDir = await mkdtemp(join(tmpdir(), 'diff-ref-'));
+    mockDir = await mkdtemp(join(tmpdir(), 'diff-mock-'));
+  });
+
+  afterEach(async () => {
+    await rm(refDir, { recursive: true, force: true });
+    await rm(mockDir, { recursive: true, force: true });
+  });
+
+  it('returns empty drift and reordered for identical trees', async () => {
+    await writeFile(join(refDir, 'a.xml'), '<r><x>1</x></r>');
+    await writeFile(join(mockDir, 'a.xml'), '<r><x>1</x></r>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result).toEqual({ drift: [], reordered: [] });
+  });
+
+  it('reports sibling-reordered XML as `reordered` (informational), not drift', async () => {
+    await writeFile(join(refDir, 'a.xml'), '<r><x>1</x><x>2</x></r>');
+    await writeFile(join(mockDir, 'a.xml'), '<r><x>2</x><x>1</x></r>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual(['a.xml']);
+  });
+
+  it('does not double-report a byte-identical file as reordered', async () => {
+    // Identical files should never appear in either bucket.
+    await writeFile(join(refDir, 'a.xml'), '<r><x>1</x><x>2</x></r>');
+    await writeFile(join(mockDir, 'a.xml'), '<r><x>1</x><x>2</x></r>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual([]);
+  });
+
+  it('flags content drift for genuinely different XML', async () => {
+    await writeFile(join(refDir, 'a.xml'), '<r><x>1</x></r>');
+    await writeFile(join(mockDir, 'a.xml'), '<r><x>2</x></r>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([{ path: 'a.xml', reason: 'content drift' }]);
+    expect(result.reordered).toEqual([]);
+  });
+
+  it('flags missing files in the round-trip output', async () => {
+    await writeFile(join(refDir, 'a.xml'), '<r/>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([{ path: 'a.xml', reason: 'missing in round-trip output' }]);
+    expect(result.reordered).toEqual([]);
+  });
+
+  it('ignores files that exist only in the mock tree', async () => {
+    await writeFile(join(refDir, 'a.xml'), '<r/>');
+    await writeFile(join(mockDir, 'a.xml'), '<r/>');
+    await writeFile(join(mockDir, 'extra.json'), '{}');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual([]);
+  });
+
+  it('byte-compares non-XML files (no semantic-equality fallback)', async () => {
+    await writeFile(join(refDir, 'a.json'), '{"k":1}');
+    await writeFile(join(mockDir, 'a.json'), '{"k": 1}');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([{ path: 'a.json', reason: 'content drift' }]);
+    expect(result.reordered).toEqual([]);
+  });
+
+  it('recurses into subdirectories and reports drift with relative paths', async () => {
+    await mkdir(join(refDir, 'nested'));
+    await mkdir(join(mockDir, 'nested'));
+    await writeFile(join(refDir, 'nested', 'a.xml'), '<r><v>1</v></r>');
+    await writeFile(join(mockDir, 'nested', 'a.xml'), '<r><v>2</v></r>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([{ path: 'nested/a.xml', reason: 'content drift' }]);
+  });
+
+  it('recurses into subdirectories and reports reorder with relative paths', async () => {
+    await mkdir(join(refDir, 'nested'));
+    await mkdir(join(mockDir, 'nested'));
+    await writeFile(join(refDir, 'nested', 'a.xml'), '<r><v>1</v><v>2</v></r>');
+    await writeFile(join(mockDir, 'nested', 'a.xml'), '<r><v>2</v><v>1</v></r>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual(['nested/a.xml']);
+  });
+
+  it('returns drift when a referenced subdirectory is missing on the mock side', async () => {
+    await mkdir(join(refDir, 'nested'));
+    await writeFile(join(refDir, 'nested', 'a.xml'), '<r/>');
+
+    const result = await diffDirectories(refDir, mockDir);
+    expect(result.drift).toEqual([{ path: 'nested/a.xml', reason: 'missing in round-trip output' }]);
+  });
+});
+
+describe('xmlEquivalent', () => {
+  it('treats identical strings as equal without parsing', () => {
+    expect(xmlEquivalent('<r/>', '<r/>')).toBe(true);
+  });
+
+  it('treats reordered siblings as equal', () => {
+    expect(xmlEquivalent('<r><a>1</a><a>2</a></r>', '<r><a>2</a><a>1</a></r>')).toBe(true);
+  });
+
+  it('treats reordered child tags as equal', () => {
+    expect(xmlEquivalent('<r><a>1</a><b>2</b></r>', '<r><b>2</b><a>1</a></r>')).toBe(true);
+  });
+
+  it('treats different leaf values as unequal', () => {
+    expect(xmlEquivalent('<r><a>1</a></r>', '<r><a>2</a></r>')).toBe(false);
+  });
+
+  it('treats different attribute values as unequal', () => {
+    expect(xmlEquivalent('<r a="1"/>', '<r a="2"/>')).toBe(false);
+  });
+
+  it('treats reordered attributes as equal', () => {
+    expect(xmlEquivalent('<r a="1" b="2"/>', '<r b="2" a="1"/>')).toBe(true);
+  });
+
+  it('treats single vs duplicated child tags as unequal', () => {
+    expect(xmlEquivalent('<r><a>1</a></r>', '<r><a>1</a><a>1</a></r>')).toBe(false);
+  });
+});
+
+describe('canonicalJson', () => {
+  it('sorts object keys alphabetically', () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe(canonicalJson({ a: 2, b: 1 }));
+  });
+
+  it('sorts arrays by canonical content', () => {
+    expect(canonicalJson([2, 1, 3])).toBe(canonicalJson([1, 2, 3]));
+  });
+
+  it('returns scalars as-is', () => {
+    expect(canonicalJson(null)).toBe('null');
+    expect(canonicalJson('foo')).toBe('"foo"');
+    expect(canonicalJson(42)).toBe('42');
+  });
+});


### PR DESCRIPTION
Expose `multiLevel` as a generic per-type/per-component override (`<file_pattern>:<root_to_strip>:<unique_id_elements>`), validated at config-load time and threaded through both resolvers. When set, it wins over the hardcoded loyaltyProgramSetup default; otherwise behavior is unchanged.

Add `sf decomposer verify`, a non-destructive round-trip check that copies the user's package directories into a temp sandbox, runs decompose
+ recompose with the same flags and overrides as production, and diffs the rebuilt parents against the originals. Comparison is structural via fast-xml-parser (sibling and attribute order ignored) so legitimate order-only deltas don't fail the run; they're surfaced separately as informational `reordered` notices for awareness. Genuine semantic differences are reported as drift and exit non-zero, making the command suitable as a CI gate before committing strategy, format, or override changes. The user's working tree is never modified.

User-supplied prePurge/postPurge are stripped from overrides during verify so the parent XML survives the decompose phase and manifest- driven recompose can re-resolve it.