### PR TITLE
feat: support multi-rule multiLevel overrides

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -1,0 +1,268 @@
+# Admin Handbook — Decomposing Tricky Salesforce Metadata
+
+This handbook collects ready-to-paste `.sfdecomposer.config.json` recipes for the metadata types where Salesforce's native source format either doesn't decompose at all or decomposes too coarsely to diff well in version control. Every recipe in this guide:
+
+- decomposes the original file into per-piece units that survive `git diff` cleanly,
+- recomposes back to a **byte-identical** XML deployable to any org,
+- is verified by `sf decomposer verify` before you commit it.
+
+If you want the underlying option grammar instead of recipes, see the [main README](./README.md#per-type--per-component-overrides).
+
+## Contents
+
+- [Choosing a strategy](#choosing-a-strategy)
+- [Bots (Agentforce and Einstein)](#bots-agentforce-and-einstein)
+- [Flexipages (Lightning App / Record / Home pages)](#flexipages-lightning-app--record--home-pages)
+- [Layouts (page layouts)](#layouts-page-layouts)
+- [Other deeply-nested types](#other-deeply-nested-types)
+- [The verification workflow](#the-verification-workflow)
+- [Common pitfalls](#common-pitfalls)
+
+## Choosing a strategy
+
+Three knobs cover almost every case:
+
+| Symptom of the source XML                                                                     | Reach for                                                                                          |
+| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| One repeating section at the top level (e.g. `<labels>` of a custom-labels file).             | `strategy: unique-id` (default).                                                                   |
+| Lots of small repeatable tags, you want one file per tag-name, not per-instance.              | `strategy: grouped-by-tag`.                                                                        |
+| `grouped-by-tag`, but a few specific tags (e.g. `objectPermissions`) need finer-grained diff. | Add `splitTags`.                                                                                   |
+| A deeply-nested repeatable block lives _inside_ another repeatable block (the bot pattern).   | Add `multiLevel`. If there are several such nested blocks, pass them as an array — see Bots below. |
+
+Hard rules the plugin always enforces (so you don't have to):
+
+- `labels` and `loyaltyProgramSetup` are always treated as `unique-id` regardless of any override.
+- `loyaltyProgramSetup` automatically gets `multiLevel: programProcesses:programProcesses:parameterName,ruleName` when run under `unique-id` — you can replace it but you don't have to set it.
+
+Everything else in this handbook is opt-in.
+
+## Bots (Agentforce and Einstein)
+
+**Why this is hard.** Agentforce and Einstein bots both ship as `.bot-meta.xml`, but their internals diverge:
+
+- The bot **header** (`Bot.bot-meta.xml`) is small — a few leaves, a few `botUserList` entries.
+- The bot **versions** (`vN.botVersion-meta.xml`) are the painful ones. A single `BotVersion` typically contains:
+  - `botDialogGroups` (logical groupings),
+  - `botDialogs` (the dialogs themselves), and inside each dialog,
+  - `botSteps` (often nested 2–3 levels deep — message, collect, transfer, condition, ...),
+  - `mlIntents`, `conversationVariables`, `botStepConditions`, ...
+
+A flat `unique-id` decomposition of a `BotVersion` produces one giant per-dialog file with hundreds of nested steps inside. That's only marginally easier to review than the original.
+
+**Recipe — multi-rule decomposition.**
+
+```json
+{
+  "metadataSuffixes": "bot",
+  "strategy": "unique-id",
+  "decomposedFormat": "xml",
+  "overrides": [
+    {
+      "metadataTypes": ["bot"],
+      "multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]
+    }
+  ]
+}
+```
+
+What this produces on disk for `Assessment_Bot/v1.botVersion-meta.xml`:
+
+```
+bots/
+└── Assessment_Bot/
+    ├── Assessment_Bot.bot-meta.xml          ← bot header (untouched)
+    ├── v1/
+    │   ├── botDialogGroups/
+    │   │   ├── Alert_Items.botDialogGroups-meta.xml
+    │   │   ├── Question_Items.botDialogGroups-meta.xml
+    │   │   └── ...
+    │   ├── botDialogs/
+    │   │   ├── Welcome.botDialogs-meta.xml      ← per-dialog file
+    │   │   └── Welcome/
+    │   │       └── botSteps/
+    │   │           ├── Collect.botSteps-meta.xml ← inner steps split out
+    │   │           ├── Message.botSteps-meta.xml
+    │   │           └── ...
+    │   └── v1.botVersion-meta.xml               ← leaf-only outer wrapper
+    └── ...
+```
+
+**Tweaking it for your bots.**
+
+- If your dialog `developerName`s are non-unique across versions (rare), swap the first rule's UID list to `developerName,id`.
+- If `botSteps` collide on `type` (very common — many `Message` steps in one dialog), add `stepIdentifier` as a tiebreaker: `botSteps:botSteps:stepIdentifier,type`.
+- **Per-bot precision**: scope a rule to one component if a single bot needs different decomposition than the rest:
+
+  ```json
+  {
+    "components": ["bot:Assessment_Bot"],
+    "multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:stepIdentifier,type"]
+  }
+  ```
+
+> **Agentforce vs Einstein.** Both share the `bot` suffix, so a single override entry covers both bot families. The structural difference (Agentforce uses richer `botFlowInvocation` and `genAi*` blocks where Einstein uses `botNavigation` and `mlIntents`) is invisible to this recipe — `multiLevel` rules only target the repeating sections that exist on each side.
+
+## Flexipages (Lightning App / Record / Home pages)
+
+**Why this is hard.** A non-trivial flexipage looks like:
+
+```xml
+<FlexiPage>
+  <flexiPageRegions>
+    <itemInstances>
+      <componentInstance>
+        <componentInstanceProperties>...</componentInstanceProperties>
+        <componentName>...</componentName>
+      </componentInstance>
+    </itemInstances>
+    <itemInstances>...</itemInstances>
+    ...
+  </flexiPageRegions>
+  <flexiPageRegions>...</flexiPageRegions>
+</FlexiPage>
+```
+
+Two repeating layers (`flexiPageRegions → itemInstances`) and component identity is buried inside `componentInstance` — the surrounding wrappers don't have a stable name, so a naive `unique-id` pass produces hash-named files that churn whenever a component is reordered.
+
+**Recipe — flexiPageRegions out, then itemInstances per region.**
+
+```json
+{
+  "overrides": [
+    {
+      "metadataTypes": ["flexipage"],
+      "strategy": "unique-id",
+      "multiLevel": ["flexiPageRegions:flexiPageRegions:name", "itemInstances:itemInstances:componentName,facetId"]
+    }
+  ]
+}
+```
+
+What you'll see on disk:
+
+```
+flexipages/
+└── Account_Record_Page/
+    ├── flexiPageRegions/
+    │   ├── header.flexiPageRegions-meta.xml
+    │   ├── main.flexiPageRegions-meta.xml
+    │   └── main/
+    │       └── itemInstances/
+    │           ├── force_highlightsPanel.itemInstances-meta.xml
+    │           ├── runtime_sales_activities__activitiesComponent.itemInstances-meta.xml
+    │           └── ...
+    └── Account_Record_Page.flexipage-meta.xml
+```
+
+**When to adjust.**
+
+- Flexipages where regions are addressed by `regionId` instead of `name` — swap the first rule to `flexiPageRegions:flexiPageRegions:regionId,name`.
+- If the same `componentName` appears multiple times in one region (common for blank `force:emptySpace`), include `facetId` (already in the recipe) and, if needed, a stable property: `itemInstances:itemInstances:componentName,facetId,componentInstanceProperties.value`.
+
+## Layouts (page layouts)
+
+**Why this is hard.** Layouts have three nested repeatables:
+
+```xml
+<Layout>
+  <layoutSections>
+    <layoutColumns>
+      <layoutItems>
+        <field>...</field>
+      </layoutItems>
+    </layoutColumns>
+  </layoutSections>
+</Layout>
+```
+
+For a fat object (Account, Opportunity), this often runs to thousands of lines. Reviewing a "moved one field from column 1 to column 2" change in the raw XML is painful.
+
+**Recipe — section out, item per field.**
+
+```json
+{
+  "overrides": [
+    {
+      "metadataTypes": ["layout"],
+      "strategy": "unique-id",
+      "multiLevel": ["layoutSections:layoutSections:label", "layoutItems:layoutItems:field,customLink,emptySpace"]
+    }
+  ]
+}
+```
+
+What you'll see on disk:
+
+```
+layouts/
+└── Account-Account_Layout/
+    ├── layoutSections/
+    │   ├── Account_Information.layoutSections-meta.xml
+    │   ├── Address_Information.layoutSections-meta.xml
+    │   └── Account_Information/
+    │       └── layoutItems/
+    │           ├── Name.layoutItems-meta.xml
+    │           ├── Type.layoutItems-meta.xml
+    │           └── ...
+    └── Account-Account_Layout.layout-meta.xml
+```
+
+**Caveats.**
+
+- Empty-space layout items (`<emptySpace>true</emptySpace>` with no `field`) all collapse to the same key. The recipe above falls through to `customLink` and then `emptySpace`, but if you have many empty-space spacers per section you'll get hash-named tiebreakers. That's fine for diffs (they only churn when the layout changes), just be aware.
+- Sections with duplicate labels are unusual but legal (e.g. two "Custom Links" sections). If you hit collisions, add a stable secondary like `style`: `layoutSections:layoutSections:label,style`.
+
+## Other deeply-nested types
+
+These follow the same pattern; pick the rules that match your repo's data. None of these are decomposed natively by Salesforce.
+
+| Metadata type                              | Suggested override                                                                                 |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `flow`                                     | `multiLevel: ["actionCalls:actionCalls:name", "decisions:decisions:name", "rules:rules:name"]`     |
+| `globalValueSet`                           | `multiLevel: ["customValue:customValue:fullName"]` — handy when value sets have hundreds of picks. |
+| `marketingappextension`                    | `multiLevel: ["activityDefinitions:activityDefinitions:apiName"]`                                  |
+| `cmsDeliveryChannel` (and other CMS types) | `strategy: grouped-by-tag` plus `splitTags` for any wide repeatable tag.                           |
+| `dashboard`                                | `multiLevel: ["components:components:title"]` — one file per dashboard widget.                     |
+
+If a metadata type has a single deeply-nested repeatable block, a one-rule `multiLevel` is enough. Reach for the array form only when you have **two or more** distinct nested sections you want addressable on disk.
+
+## The verification workflow
+
+Always verify a new override before committing it:
+
+```bash
+# 1. Stash any uncommitted source first.
+git stash --include-untracked
+
+# 2. Decompose with the new override.
+sf decomposer decompose -t bot --config
+
+# 3. Recompose back from the decomposed tree.
+sf decomposer recompose -t bot
+
+# 4. Check the round-trip didn't drift.
+sf decomposer verify -t bot --config
+```
+
+`sf decomposer verify` is non-destructive: it decomposes into a temp dir, recomposes from the temp dir, and compares the result to your committed source. If anything drifts (content, missing file, sibling reorder) it tells you exactly which paths broke. Treat any drift as a blocker — fix the override (or fall back to the previous one) before committing.
+
+## Common pitfalls
+
+**1. "I added two `multiLevel` rules but only one survived."**
+You probably ran two `decompose` invocations back-to-back, one rule each. Don't. The disassembler rewrites `.multi_level.json` on every run, so each call replaces the prior one. Pass every rule for a given component in **one** override entry, in array form.
+
+**2. "My `multiLevel` rule is correct but recompose produces a smaller file."**
+Almost always a unique-id collision. Two array items resolved to the same filename and one overwrote the other on disk. Add a tiebreaker to `unique_id_elements` (e.g. `developerName,id`) and re-decompose with `prePurge: true`.
+
+**3. "Component-scope override fields look ignored."**
+Component-scope wins over type-scope, but only for fields **the component override explicitly sets**. Fields it leaves out fall through to the type-scope value, then to the run-wide default. If you set `decomposedFormat: "yaml"` on a type and `strategy: "grouped-by-tag"` on the component, the component still gets `decomposedFormat: "yaml"` from the type override.
+
+**4. "Reassembly removed my decomposed directory even though I didn't pass `postPurge`."**
+That's by design for `multiLevel` types only. Multi-level recompose has to clean up inner-level directories so the next level can merge their reassembled XML. If you want the decomposed tree preserved for inspection, copy it before running `recompose`.
+
+**5. "Decompose succeeded but my decomposed files all have hash names."**
+Your `unique_id_elements` (or the rule's third part) didn't resolve to a non-empty value on those items. Check the source XML for the elements you listed — names are case-sensitive and live at the immediate child level of each repeating item. The plugin only walks one level deep when picking a UID.
+
+---
+
+When in doubt: write the override, run `verify`, read the diff. Every recipe in this handbook was derived that way.

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ Within one scope, the `(file_pattern, root_to_strip)` pair must be unique across
 
 > **Tip:** Use [`sf decomposer verify`](#sf-decomposer-verify) to non-destructively confirm a new override config still round-trips before committing it.
 
-> **Tip:** See the [admin handbook](./HANDBOOK.md) for end-to-end recipes for Bots, Flexipages, Layouts, and other deeply-nested metadata.
+> **Tip:** See the [admin handbook](https://github.com/mcarvin8/sf-decomposer/blob/main/HANDBOOK.md) for end-to-end recipes for Bots, Flexipages, Layouts, and other deeply-nested metadata.
 
 ### Opting in from the CLI
 

--- a/README.md
+++ b/README.md
@@ -451,17 +451,17 @@ By default, a single decompose run uses one format and one strategy across every
 
 ### What can be overridden
 
-| Field                        | Notes                                                                                                                                                                                                          |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `metadataTypes`              | Optional (required if `components` is omitted). Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override.                        |
-| `components`                 | Optional (required if `metadataTypes` is omitted). Array of `<metadataSuffix>:<fullName>` keys (e.g. `permissionset:HR_Admin`, `report:MyFolder/MyReport`). Each component may appear in at most one override. |
-| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                                                                                          |
-| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                  |
-| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`. Sets a known-good `splitTags` default; ignored if `splitTags` is also set in the same scope.                                    |
-| `splitTags`                  | Custom `splitTags` spec for `grouped-by-tag` strategy. See [splitTags grammar](#splittags-grammar). Ignored when the resolved strategy is not `grouped-by-tag`.                                                |
-| `multiLevel`                 | Custom `multiLevel` spec for nested-array decomposition. See [multiLevel grammar](#multilevel-grammar). When set, replaces the hardcoded `loyaltyProgramSetup` default for the targeted scope.                 |
-| `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                             |
-| `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                           |
+| Field                        | Notes                                                                                                                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `metadataTypes`              | Optional (required if `components` is omitted). Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override.                                                                      |
+| `components`                 | Optional (required if `metadataTypes` is omitted). Array of `<metadataSuffix>:<fullName>` keys (e.g. `permissionset:HR_Admin`, `report:MyFolder/MyReport`). Each component may appear in at most one override.                                               |
+| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                                                                                                                                        |
+| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                                                                |
+| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`. Sets a known-good `splitTags` default; ignored if `splitTags` is also set in the same scope.                                                                                  |
+| `splitTags`                  | Custom `splitTags` spec for `grouped-by-tag` strategy. See [splitTags grammar](#splittags-grammar). Ignored when the resolved strategy is not `grouped-by-tag`.                                                                                              |
+| `multiLevel`                 | One or more `multiLevel` specs for nested-array decomposition. Pass a string, a `string[]`, or a `;`-separated string. See [multiLevel grammar](#multilevel-grammar). When set, replaces the hardcoded `loyaltyProgramSetup` default for the targeted scope. |
+| `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                                                                           |
+| `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                                                                         |
 
 Run-scope options (`metadataSuffixes`, `manifest`, `ignorePackageDirectories`) are **not** valid inside an override; the plugin will throw if they are present.
 
@@ -532,9 +532,9 @@ Each `<tag>` may appear at most once in a spec. The plugin validates the grammar
 
 ### multiLevel grammar
 
-`multiLevel` enables a second decomposition pass on inner-level files for metadata types whose XML has deeply nested repeatable blocks (e.g. `loyaltyProgramSetup`'s `programProcesses → parameters → ...`). The plugin already applies a known-good default for `loyaltyProgramSetup` when running the `unique-id` strategy; setting `multiLevel` directly takes precedence and works for any metadata type.
+`multiLevel` enables a second decomposition pass on inner-level files for metadata types whose XML has deeply nested repeatable blocks (e.g. `loyaltyProgramSetup`'s `programProcesses → parameters → ...`, or a Bot's `botVersion → botDialogs → botSteps`). The plugin already applies a known-good default for `loyaltyProgramSetup` when running the `unique-id` strategy; setting `multiLevel` directly takes precedence and works for any metadata type.
 
-**Spec:** A single rule with exactly 3 colon-separated parts (the third part is itself a comma-separated list):
+**Spec:** Each rule has exactly 3 colon-separated parts (the third part is itself a comma-separated list):
 
 ```
 <file_pattern>:<root_to_strip>:<unique_id_elements>
@@ -544,20 +544,35 @@ Each `<tag>` may appear at most once in a spec. The plugin validates the grammar
 - **`<root_to_strip>`** — XML root tag to strip from each matched file before splitting.
 - **`<unique_id_elements>`** — comma-separated list of element names used to derive a stable filename for each inner-level item (e.g. `parameterName,ruleName`). The first element that resolves to a non-empty value wins.
 
-The plugin validates the grammar at config-load time; deeper checks (whether the file pattern matches anything, whether the unique-id elements actually appear on the inner XML) are surfaced by the underlying disassembler crate at runtime.
+A scope may target several nested sections by passing **multiple rules**. Three input shapes are supported:
+
+- a single rule string (legacy, unchanged behaviour);
+- a JSON `string[]` of rules (preferred — clearest intent, easiest to diff);
+- a single `;`-separated string of rules (compact form, also accepted).
+
+Within one scope, the `(file_pattern, root_to_strip)` pair must be unique across rules. The plugin validates the grammar at config-load time; deeper checks (whether a file pattern matches anything, whether the unique-id elements actually appear on the inner XML) are surfaced by the underlying disassembler crate at runtime.
 
 ```json
 "overrides": [
   {
     "metadataTypes": ["loyaltyProgramSetup"],
     "multiLevel": "programProcesses:programProcesses:parameterName,ruleName"
+  },
+  {
+    "components": ["bot:Assessment_Bot"],
+    "multiLevel": [
+      "botDialogs:botDialogs:developerName",
+      "botSteps:botSteps:type"
+    ]
   }
 ]
 ```
 
-> **Limit:** Only one rule per scope. The disassembler does not currently accept multiple comma-separated multiLevel specs, because the third part of the rule is itself a comma-separated list.
+> **Why one call:** Pass every rule for a given component in a single override. Sequential single-rule decompositions rewrite the on-disk `.multi_level.json` and only the last rule survives — so multi-rule scenarios must travel together.
 
 > **Tip:** Use [`sf decomposer verify`](#sf-decomposer-verify) to non-destructively confirm a new override config still round-trips before committing it.
+
+> **Tip:** See the [admin handbook](./HANDBOOK.md) for end-to-end recipes for Bots, Flexipages, Layouts, and other deeply-nested metadata.
 
 ### Opting in from the CLI
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -22,6 +22,10 @@
       "multiLevel": "programProcesses:programProcesses:parameterName,ruleName"
     },
     {
+      "components": ["bot:Assessment_Bot"],
+      "multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]
+    },
+    {
       "components": ["permissionset:HR_Admin"],
       "strategy": "unique-id",
       "decomposedFormat": "json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "^8.26.3",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.0",
-        "config-disassembler": "^1.0.0",
+        "config-disassembler": "^1.1.0",
         "fast-xml-parser": "^5.7.2",
         "p-limit": "^7.3.0"
       },
@@ -5448,9 +5448,9 @@
       "dev": true
     },
     "node_modules/config-disassembler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.0.0.tgz",
-      "integrity": "sha512-pXPL/kRkouksnspSFBc7A3udVRIxnRPBd7US4RrWeRgy8tnPJ6YoOElrCsJKfO7WSinqbHeh9rq8KVjrZrBneg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.1.0.tgz",
+      "integrity": "sha512-GoShA861lL/I+FVPyCYlnrhsRk9S5F7raNXUv7cMotZAzlDwyrXgXBOyQcytBzTKk7ZbScaNRrGxCKbYnrvrsA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "^8.26.3",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.0",
-    "config-disassembler": "^1.0.0",
+    "config-disassembler": "^1.1.0",
     "fast-xml-parser": "^5.7.2",
     "p-limit": "^7.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "/messages",
     "/oclif.manifest.json",
     "/oclif.lock",
-    "/CHANGELOG.md"
+    "/CHANGELOG.md",
+    "/HANDBOOK.md"
   ],
   "keywords": [
     "force",

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -43,8 +43,12 @@ export type ResolvedDecomposeTypeOptions = {
   postpurge: boolean;
   /** Resolved custom `splitTags` spec, when explicitly set in an override. */
   splitTags?: string;
-  /** Resolved custom `multiLevel` spec, when explicitly set in an override. */
-  multiLevel?: string;
+  /**
+   * Resolved custom `multiLevel` spec(s), when explicitly set in an override. Preserves the
+   * input shape (string vs string[]) so the disassembler crate can decide how to parse it;
+   * a single `;`-separated string is treated by the crate as multiple rules.
+   */
+  multiLevel?: string | string[];
 };
 
 const SPLIT_TAGS_MODES = new Set<string>(['split', 'group']);
@@ -219,41 +223,82 @@ export function validateSplitTagsSpec(spec: string, i: number): void {
 }
 
 /**
- * Validate the `multiLevel` spec at config-load time. The underlying disassembler currently
- * accepts a single colon-separated rule of the form
- * `<file_pattern>:<root_to_strip>:<unique_id_elements>` where `<unique_id_elements>` is itself
- * a comma-separated list. Deeper checks (whether the file pattern matches anything, whether
- * the unique-id elements actually exist on the inner XML) are left to the runtime crate.
+ * Validate the `multiLevel` spec at config-load time. Each rule must be of the form
+ * `<file_pattern>:<root_to_strip>:<unique_id_elements>`, where `<unique_id_elements>` is
+ * itself a comma-separated list. Three input shapes are supported: a single rule string
+ * (legacy); a string[] of rules (preferred when targeting multiple nested sections); or a
+ * single `;`-separated string of rules (compact form, also accepted by the crate).
+ *
+ * Rules are validated individually and the (file_pattern, root_to_strip) pair must be
+ * unique across rules in the same scope. Deeper checks (whether a file pattern matches
+ * anything, whether the unique-id elements actually exist on the inner XML) are left to
+ * the runtime crate.
  */
-export function validateMultiLevelSpec(spec: string, i: number): void {
+export function validateMultiLevelSpec(spec: string | string[], i: number): void {
+  const rules = normalizeMultiLevelRules(spec, i);
+  const seenPairs = new Set<string>();
+  for (const rule of rules) {
+    const { filePattern, rootToStrip } = validateSingleMultiLevelRule(rule, i);
+    const pairKey = `${filePattern}:${rootToStrip}`;
+    if (seenPairs.has(pairKey)) {
+      throw new Error(
+        `Override at index ${i} "multiLevel" has duplicate (file_pattern, root_to_strip) pair "${pairKey}". ` +
+          'Each pair may appear at most once per scope.',
+      );
+    }
+    seenPairs.add(pairKey);
+  }
+}
+
+function normalizeMultiLevelRules(spec: string | string[], i: number): string[] {
+  if (Array.isArray(spec)) {
+    if (spec.length === 0) {
+      throw new Error(`Override at index ${i} has an empty "multiLevel" array.`);
+    }
+    for (const entry of spec) {
+      if (typeof entry !== 'string' || entry.trim() === '') {
+        throw new Error(`Override at index ${i} "multiLevel" array contains an empty or non-string entry.`);
+      }
+    }
+    return spec.map((rule) => rule.trim());
+  }
   if (typeof spec !== 'string' || spec.trim() === '') {
     throw new Error(`Override at index ${i} has an empty "multiLevel" string.`);
   }
+  // A single `;`-separated string is treated as multiple rules to mirror the crate's parser.
+  return spec
+    .split(';')
+    .map((rule) => rule.trim())
+    .filter((rule) => rule.length > 0);
+}
 
-  const parts = spec.split(':').map((part) => part.trim());
+function validateSingleMultiLevelRule(rule: string, i: number): { filePattern: string; rootToStrip: string } {
+  const parts = rule.split(':').map((part) => part.trim());
   if (parts.length !== 3) {
     throw new Error(
-      `Override at index ${i} "multiLevel" must have exactly 3 colon-separated parts ` +
+      `Override at index ${i} "multiLevel" rule "${rule}" must have exactly 3 colon-separated parts ` +
         '("<file_pattern>:<root_to_strip>:<unique_id_elements>").',
     );
   }
 
   const [filePattern, rootToStrip, uniqueIdElements] = parts;
   if (!filePattern || !rootToStrip || !uniqueIdElements) {
-    throw new Error(`Override at index ${i} "multiLevel" has empty parts.`);
+    throw new Error(`Override at index ${i} "multiLevel" rule "${rule}" has empty parts.`);
   }
 
   const ids = uniqueIdElements.split(',').map((id) => id.trim());
   const seenIds = new Set<string>();
   for (const id of ids) {
     if (id === '') {
-      throw new Error(`Override at index ${i} "multiLevel" unique-id list contains an empty entry.`);
+      throw new Error(`Override at index ${i} "multiLevel" rule "${rule}" unique-id list contains an empty entry.`);
     }
     if (seenIds.has(id)) {
-      throw new Error(`Override at index ${i} "multiLevel" unique-id list has duplicate entry "${id}".`);
+      throw new Error(`Override at index ${i} "multiLevel" rule "${rule}" unique-id list has duplicate entry "${id}".`);
     }
     seenIds.add(id);
   }
+
+  return { filePattern, rootToStrip };
 }
 
 function validateMetadataTypeEntries(metadataTypes: string[], i: number, seenTypes: Set<string>): void {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -24,12 +24,14 @@ export type DecomposerOverride = {
    */
   splitTags?: string;
   /**
-   * Custom `multiLevel` spec for nested-array decomposition. Format:
+   * Custom `multiLevel` spec(s) for nested-array decomposition. Each rule has the form
    * `<file_pattern>:<root_to_strip>:<unique_id_elements>` (the third part is itself a
-   * comma-separated list). When set, this wins over the hardcoded `loyaltyProgramSetup`
-   * default. Applies regardless of strategy because multiLevel works on a per-file pattern.
+   * comma-separated list). Pass a string for a single rule, a string[] for several rules
+   * (preferred), or a single `;`-separated string. When set, this wins over the hardcoded
+   * `loyaltyProgramSetup` default. Applies regardless of strategy because multiLevel
+   * works on a per-file pattern.
    */
-  multiLevel?: string;
+  multiLevel?: string | string[];
   prePurge?: boolean;
   postPurge?: boolean;
 };

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -163,10 +163,11 @@ function disassembleHandler(
   // Resolve multiLevel with this precedence:
   //   1. an explicit `multiLevel` set in the override (any metadata type);
   //   2. the hardcoded loyaltyProgramSetup default when running unique-id strategy.
-  let multiLevel: string | undefined;
-  if (options.multiLevel) {
-    multiLevel = options.multiLevel;
-  } else if (metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id') {
+  // The override may be a single rule (string) or several rules (string[]); both shapes are
+  // forwarded verbatim — the crate decides how to split them. Empty arrays are rejected
+  // upstream by validateMultiLevelSpec, so we don't need to guard against them here.
+  let multiLevel: string | string[] | undefined = options.multiLevel;
+  if (multiLevel === undefined && metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id') {
     multiLevel = 'programProcesses:programProcesses:parameterName,ruleName';
   }
 

--- a/test/commands/decomposer/overrides.test.ts
+++ b/test/commands/decomposer/overrides.test.ts
@@ -124,6 +124,46 @@ describe('decomposer overrides (per-type)', () => {
     await compareDirectories(originalDirectory, forceAppDir);
   });
 
+  it('threads an array-form multiLevel override through the disassembler and round-trips on recompose', async () => {
+    const logMock = vi.fn();
+
+    // Same shape as the previous test, but the override is supplied as a string[] rather than
+    // a single string. This pins the new multi-rule input path against a known-good fixture
+    // without depending on a multi-section bot fixture in this repo. End-to-end multi-rule
+    // round-trip is covered by the underlying config-disassembler@^1.1.0 integration tests.
+    await decomposeMetadataTypes({
+      metadataTypes: ['loyaltyProgramSetup'],
+      prepurge: true,
+      postpurge: false,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        {
+          metadataTypes: ['loyaltyProgramSetup'],
+          multiLevel: ['programProcesses:programProcesses:parameterName,ruleName'],
+        },
+      ],
+      log: logMock,
+    });
+
+    const loyaltyDir = join(forceAppDir, 'loyaltyProgramSetups', 'Cloud_Kicks_Inner_Circle');
+    const subdirs = (await readdir(loyaltyDir, { withFileTypes: true }))
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    expect(subdirs).toContain('programProcesses');
+
+    await recomposeMetadataTypes({
+      metadataTypes: ['loyaltyProgramSetup'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log: logMock,
+    });
+
+    await compareDirectories(originalDirectory, forceAppDir);
+  });
+
   it('applies per-type strategy overrides during decompose', async () => {
     const logMock = vi.fn();
 

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -188,6 +188,26 @@ describe('configOverrides helper', () => {
       ];
       expect(() => validateOverrides(overrides)).toThrow(/exactly 3 colon-separated parts/);
     });
+
+    it('accepts a multiLevel spec passed as an array of rules', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['bot'],
+          multiLevel: ['botDialogs:botDialogs:developerName', 'botSteps:botSteps:type'],
+        },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('accepts a multiLevel spec with multiple rules joined by ";"', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['bot'],
+          multiLevel: 'botDialogs:botDialogs:developerName;botSteps:botSteps:type',
+        },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
   });
 
   describe('validateSplitTagsSpec', () => {
@@ -291,6 +311,40 @@ describe('configOverrides helper', () => {
 
     it('tolerates surrounding whitespace', () => {
       expect(() => validateMultiLevelSpec(' items : items : name , label ', 0)).not.toThrow();
+    });
+
+    it('accepts a string[] of rules', () => {
+      expect(() =>
+        validateMultiLevelSpec(['botDialogs:botDialogs:developerName', 'botSteps:botSteps:type'], 0),
+      ).not.toThrow();
+    });
+
+    it('accepts a single ";"-separated string of rules', () => {
+      expect(() =>
+        validateMultiLevelSpec('botDialogs:botDialogs:developerName;botSteps:botSteps:type', 0),
+      ).not.toThrow();
+    });
+
+    it('rejects an empty array', () => {
+      expect(() => validateMultiLevelSpec([], 0)).toThrow(/empty "multiLevel" array/);
+    });
+
+    it('rejects an array entry that is empty', () => {
+      expect(() => validateMultiLevelSpec(['botDialogs:botDialogs:developerName', ''], 0)).toThrow(
+        /array contains an empty or non-string entry/,
+      );
+    });
+
+    it('rejects duplicate (file_pattern, root_to_strip) pairs across rules', () => {
+      expect(() =>
+        validateMultiLevelSpec(['botDialogs:botDialogs:developerName', 'botDialogs:botDialogs:label'], 0),
+      ).toThrow(/duplicate \(file_pattern, root_to_strip\) pair/);
+    });
+
+    it('rejects a malformed rule inside an otherwise valid array', () => {
+      expect(() => validateMultiLevelSpec(['botDialogs:botDialogs:developerName', 'broken:rule'], 0)).toThrow(
+        /exactly 3 colon-separated parts/,
+      );
     });
   });
 
@@ -486,6 +540,19 @@ describe('configOverrides helper', () => {
       expect(resolveDecomposeOptionsForType('loyaltyProgramSetup', base, overrides).multiLevel).toBe(
         'programProcesses:programProcesses:parameterName,ruleName',
       );
+    });
+
+    it('threads an array-form multiLevel through resolution without flattening', () => {
+      const overrides: DecomposerOverride[] = [
+        {
+          metadataTypes: ['bot'],
+          multiLevel: ['botDialogs:botDialogs:developerName', 'botSteps:botSteps:type'],
+        },
+      ];
+      expect(resolveDecomposeOptionsForType('bot', base, overrides).multiLevel).toEqual([
+        'botDialogs:botDialogs:developerName',
+        'botSteps:botSteps:type',
+      ]);
     });
   });
 


### PR DESCRIPTION
Widens DecomposerOverride.multiLevel to string | string[] so a single override can target several deeply-nested sections in one decompose call. Sequential single-rule decompositions rewrite the on-disk sidecar, so multi-section types (Bots, Flexipages, Layouts) need every rule to travel together.

Adds HANDBOOK.md with paste-ready recipes for those types plus the verification workflow admins should run before committing a config.

Bumps config-disassembler to ^1.1.0 for the new array-form input.