### PR TITLE
chore(test): add performance benchmark suite

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 *.cjs/
+scripts/

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,138 @@
+# Performance benchmark for the decompose/recompose pipeline against deterministic
+# synthetic large-org fixtures (see scripts/gen-perf-fixtures.ts).
+#
+# Triggers:
+#   - workflow_dispatch  : ad-hoc; pick a profile/formats/types from the UI.
+#   - schedule (weekly)  : Monday 05:00 UTC; catches slow drift from npm dep
+#                          updates, runner-image refreshes, V8/Rust upstream.
+#   - workflow_call      : invoked by release.yml after a successful publish so
+#                          every version on npm has a perf artifact attached.
+#
+# Intentionally NOT run on every push - perf needs the same OS/Node every time
+# to be comparable, and PR feedback should stay fast. Contributors who suspect
+# their PR regresses perf can `gh workflow run perf.yml --ref <branch>`.
+name: Performance
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Fixture size profile'
+        type: choice
+        default: large
+        options:
+          - small
+          - medium
+          - large
+          - xlarge
+      formats:
+        description: 'Comma-separated formats to test (xml,json,json5,yaml)'
+        type: string
+        default: 'xml,json,json5,yaml'
+      types:
+        description: 'Comma-separated metadata types (blank = defaults from test/perf/decompose.perf.ts)'
+        type: string
+        default: ''
+  schedule:
+    # Mondays 05:00 UTC - quiet hours on the GitHub-hosted runner pool.
+    - cron: '0 5 * * 1'
+  workflow_call:
+    inputs:
+      profile:
+        type: string
+        required: false
+        default: large
+      formats:
+        type: string
+        required: false
+        default: 'xml,json,json5,yaml'
+      types:
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  perf:
+    name: Perf (${{ inputs.profile || 'large' }})
+    # Single OS, single Node version: cross-runner / cross-Node perf is too
+    # noisy to be useful. Correctness is already covered by test.yml's matrix.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run compile
+
+      - name: Print runner facts
+        run: |
+          echo "## Runner facts" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "image:    $ImageOS / $ImageVersion" >> "$GITHUB_STEP_SUMMARY"
+          echo "node:     $(node --version)" >> "$GITHUB_STEP_SUMMARY"
+          echo "cpu:      $(grep 'model name' /proc/cpuinfo | head -1 | cut -d: -f2 | xargs)" >> "$GITHUB_STEP_SUMMARY"
+          echo "cores:    $(nproc)" >> "$GITHUB_STEP_SUMMARY"
+          echo "mem:      $(free -h | awk '/^Mem:/ {print $2}')" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run performance suite
+        run: npm run test:perf
+        env:
+          PERF_PROFILE: ${{ inputs.profile || 'large' }}
+          PERF_FORMATS: ${{ inputs.formats || 'xml,json,json5,yaml' }}
+          PERF_TYPES: ${{ inputs.types }}
+          SF_DISABLE_TELEMETRY: true
+          # Node tuning for reproducibility:
+          #   - disable JIT randomization-sensitive optimizations off by default
+          #   - explicit max old space so a leak fails loudly rather than swapping
+          NODE_OPTIONS: '--max-old-space-size=4096'
+
+      - name: Summarize results
+        if: always()
+        run: |
+          if [ ! -d perf-results ]; then
+            echo "No perf-results/ directory; the test likely failed before reporting." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "## Perf results (profile=${PERF_PROFILE:-large})" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '| Format | Sample | Elapsed (ms) | RSS Δ (MB) |' >> "$GITHUB_STEP_SUMMARY"
+          echo '|---|---|---:|---:|' >> "$GITHUB_STEP_SUMMARY"
+          node -e '
+            const fs = require("fs"), path = require("path");
+            const dir = "perf-results";
+            const files = fs.readdirSync(dir).filter(f => f.endsWith(".json")).sort();
+            for (const f of files) {
+              const r = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+              for (const s of r.samples) {
+                const ms = s.elapsedMs.toFixed(1);
+                const rss = (s.rssDeltaBytes / 1024 / 1024).toFixed(2);
+                process.stdout.write(`| ${r.format} | ${s.label} | ${ms} | ${rss} |\n`);
+              }
+            }
+          ' >> "$GITHUB_STEP_SUMMARY"
+        env:
+          PERF_PROFILE: ${{ inputs.profile || 'large' }}
+
+      - name: Upload perf artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results-${{ inputs.profile || 'large' }}-${{ github.run_id }}
+          path: |
+            perf-results/
+          retention-days: 90
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,13 @@ jobs:
     if: ${{ needs.release.outputs.release_created == 'true' }}
     uses: ./.github/workflows/smoke-test.yml
     secrets: inherit
+  perf-baseline:
+    # Runs after a successful publish so every released version has a
+    # comparable timing artifact attached to its run. Does not gate the
+    # release - it's an observability run, not a quality gate.
+    needs: smoke-test
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/perf.yml
+    with:
+      profile: large
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ package.json.bak.
 .wireit
 node_modules
 
+# performance fixtures (generated, large, deterministic) and timing artifacts
+perf-fixtures
+perf-results
+
 # --
 # put files here you don't want cleaned with sf-clean
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "test": "wireit",
     "test:nuts": "oclif manifest && vitest run --config ./vitest.nut.config.ts",
     "test:only": "wireit",
+    "test:perf": "vitest run --config ./vitest.perf.config.ts",
+    "test:perf:gen": "node --import ts-node/esm scripts/gen-perf-fixtures.ts",
     "version": "oclif readme"
   },
   "publishConfig": {

--- a/scripts/gen-perf-fixtures.ts
+++ b/scripts/gen-perf-fixtures.ts
@@ -1,0 +1,876 @@
+/*
+ * Deterministic generator for large synthetic Salesforce metadata fixtures.
+ *
+ * Produces XML files that mimic the *shape* and *scale* of metadata typically
+ * found in large, long-lived orgs (5MB+ permission sets, 1MB+ applications,
+ * 800KB+ bot versions, 400KB+ flows, etc.) without copying any real-world
+ * customer data.
+ *
+ * Output is fully deterministic given the same profile + seed: every identifier
+ * is generated from a counter so the bytes on disk are byte-identical between
+ * runs. This lets us measure decompose/recompose performance and assert
+ * round-trip stability without leaking any proprietary metadata into the repo.
+ *
+ * Usage:
+ *   node --import ts-node/esm scripts/gen-perf-fixtures.ts [--profile large] [--out perf-fixtures]
+ */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type Profile = 'small' | 'medium' | 'large' | 'xlarge';
+
+export interface SizeSpec {
+  permissionSet: {
+    fieldPerms: number;
+    objectPerms: number;
+    appVis: number;
+    classAccesses: number;
+    pageAccesses: number;
+    tabSettings: number;
+    recordTypeVis: number;
+  };
+  profile: {
+    fieldPerms: number;
+    objectPerms: number;
+    appVis: number;
+    classAccesses: number;
+    pageAccesses: number;
+    tabSettings: number;
+    recordTypeVis: number;
+    layoutAssignments: number;
+  };
+  flow: { decisions: number; assignments: number; recordLookups: number; actionCalls: number; variables: number };
+  workflow: { alerts: number; fieldUpdates: number; rules: number };
+  labels: { count: number };
+  application: { actionOverrides: number; profileActionOverrides: number; tabs: number };
+  globalValueSet: { customValues: number };
+  bot: { dialogs: number; mlIntents: number };
+}
+
+const PROFILES: Record<Profile, SizeSpec> = {
+  small: {
+    permissionSet: {
+      fieldPerms: 200,
+      objectPerms: 50,
+      appVis: 20,
+      classAccesses: 50,
+      pageAccesses: 30,
+      tabSettings: 30,
+      recordTypeVis: 20,
+    },
+    profile: {
+      fieldPerms: 400,
+      objectPerms: 80,
+      appVis: 30,
+      classAccesses: 80,
+      pageAccesses: 40,
+      tabSettings: 40,
+      recordTypeVis: 30,
+      layoutAssignments: 40,
+    },
+    flow: { decisions: 30, assignments: 30, recordLookups: 20, actionCalls: 20, variables: 30 },
+    workflow: { alerts: 30, fieldUpdates: 30, rules: 30 },
+    labels: { count: 200 },
+    application: { actionOverrides: 100, profileActionOverrides: 50, tabs: 20 },
+    globalValueSet: { customValues: 100 },
+    bot: { dialogs: 30, mlIntents: 20 },
+  },
+  medium: {
+    permissionSet: {
+      fieldPerms: 2_000,
+      objectPerms: 200,
+      appVis: 50,
+      classAccesses: 200,
+      pageAccesses: 100,
+      tabSettings: 100,
+      recordTypeVis: 80,
+    },
+    profile: {
+      fieldPerms: 4_000,
+      objectPerms: 300,
+      appVis: 80,
+      classAccesses: 300,
+      pageAccesses: 150,
+      tabSettings: 150,
+      recordTypeVis: 120,
+      layoutAssignments: 200,
+    },
+    flow: { decisions: 100, assignments: 120, recordLookups: 80, actionCalls: 80, variables: 100 },
+    workflow: { alerts: 150, fieldUpdates: 150, rules: 150 },
+    labels: { count: 1_000 },
+    application: { actionOverrides: 500, profileActionOverrides: 250, tabs: 50 },
+    globalValueSet: { customValues: 500 },
+    bot: { dialogs: 150, mlIntents: 80 },
+  },
+  large: {
+    // Calibrated against shapes seen in large 10+ year-old orgs:
+    //   permission set ~3MB, profile ~5MB, flow ~400KB, workflow ~500KB,
+    //   labels ~1MB, application ~1.8MB, bot version ~800KB, GVS ~200KB.
+    permissionSet: {
+      fieldPerms: 12_000,
+      objectPerms: 500,
+      appVis: 100,
+      classAccesses: 800,
+      pageAccesses: 300,
+      tabSettings: 300,
+      recordTypeVis: 250,
+    },
+    profile: {
+      fieldPerms: 22_000,
+      objectPerms: 800,
+      appVis: 150,
+      classAccesses: 1_500,
+      pageAccesses: 500,
+      tabSettings: 500,
+      recordTypeVis: 400,
+      layoutAssignments: 800,
+    },
+    flow: { decisions: 250, assignments: 300, recordLookups: 200, actionCalls: 200, variables: 250 },
+    workflow: { alerts: 400, fieldUpdates: 400, rules: 400 },
+    labels: { count: 4_000 },
+    application: { actionOverrides: 2_500, profileActionOverrides: 1_500, tabs: 100 },
+    globalValueSet: { customValues: 1_500 },
+    bot: { dialogs: 600, mlIntents: 250 },
+  },
+  xlarge: {
+    permissionSet: {
+      fieldPerms: 25_000,
+      objectPerms: 1_000,
+      appVis: 200,
+      classAccesses: 1_500,
+      pageAccesses: 600,
+      tabSettings: 600,
+      recordTypeVis: 500,
+    },
+    profile: {
+      fieldPerms: 45_000,
+      objectPerms: 1_500,
+      appVis: 250,
+      classAccesses: 3_000,
+      pageAccesses: 1_000,
+      tabSettings: 1_000,
+      recordTypeVis: 800,
+      layoutAssignments: 1_500,
+    },
+    flow: { decisions: 500, assignments: 600, recordLookups: 400, actionCalls: 400, variables: 500 },
+    workflow: { alerts: 800, fieldUpdates: 800, rules: 800 },
+    labels: { count: 8_000 },
+    application: { actionOverrides: 5_000, profileActionOverrides: 3_000, tabs: 200 },
+    globalValueSet: { customValues: 3_000 },
+    bot: { dialogs: 1_200, mlIntents: 500 },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// XML helpers
+// ---------------------------------------------------------------------------
+
+const XML_HEADER = '<?xml version="1.0" encoding="UTF-8"?>\n';
+const NS = ' xmlns="http://soap.sforce.com/2006/04/metadata"';
+
+function escape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function pad(n: number, width: number): string {
+  return n.toString().padStart(width, '0');
+}
+
+/** Deterministic UUID-ish identifier from a counter. */
+function detId(idx: number): string {
+  const hex = idx.toString(16).padStart(12, '0');
+  return `00000000-0000-4000-8000-${hex}`;
+}
+
+/** Stable cycle through a small finite set so the data has variety. */
+function pick<T>(arr: readonly T[], idx: number): T {
+  return arr[idx % arr.length] as T;
+}
+
+// ---------------------------------------------------------------------------
+// Generators
+// ---------------------------------------------------------------------------
+
+function genPermissionSet(spec: SizeSpec['permissionSet']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<PermissionSet${NS}>`);
+
+  for (let i = 1; i <= spec.appVis; i++) {
+    lines.push('    <applicationVisibilities>');
+    lines.push(`        <application>Sample_App_${pad(i, 4)}</application>`);
+    lines.push(`        <visible>${i % 2 === 0 ? 'true' : 'false'}</visible>`);
+    lines.push('    </applicationVisibilities>');
+  }
+
+  for (let i = 1; i <= spec.classAccesses; i++) {
+    lines.push('    <classAccesses>');
+    lines.push(`        <apexClass>Sample_Class_${pad(i, 5)}</apexClass>`);
+    lines.push('        <enabled>true</enabled>');
+    lines.push('    </classAccesses>');
+  }
+
+  for (let i = 1; i <= spec.fieldPerms; i++) {
+    const objIdx = (i % 200) + 1;
+    lines.push('    <fieldPermissions>');
+    lines.push('        <editable>true</editable>');
+    lines.push(`        <field>Sample_Object_${pad(objIdx, 3)}__c.Sample_Field_${pad(i, 6)}__c</field>`);
+    lines.push('        <readable>true</readable>');
+    lines.push('    </fieldPermissions>');
+  }
+
+  lines.push(`    <description>Synthetic permission set for performance testing.</description>`);
+  lines.push(`    <hasActivationRequired>false</hasActivationRequired>`);
+  lines.push(`    <label>Mega Permission Set</label>`);
+  lines.push(`    <license>Salesforce</license>`);
+
+  for (let i = 1; i <= spec.objectPerms; i++) {
+    lines.push('    <objectPermissions>');
+    lines.push('        <allowCreate>true</allowCreate>');
+    lines.push('        <allowDelete>true</allowDelete>');
+    lines.push('        <allowEdit>true</allowEdit>');
+    lines.push('        <allowRead>true</allowRead>');
+    lines.push('        <modifyAllRecords>false</modifyAllRecords>');
+    lines.push(`        <object>Sample_Object_${pad(i, 3)}__c</object>`);
+    lines.push('        <viewAllRecords>false</viewAllRecords>');
+    lines.push('    </objectPermissions>');
+  }
+
+  for (let i = 1; i <= spec.pageAccesses; i++) {
+    lines.push('    <pageAccesses>');
+    lines.push(`        <apexPage>Sample_Page_${pad(i, 5)}</apexPage>`);
+    lines.push('        <enabled>true</enabled>');
+    lines.push('    </pageAccesses>');
+  }
+
+  for (let i = 1; i <= spec.recordTypeVis; i++) {
+    const objIdx = (i % 50) + 1;
+    lines.push('    <recordTypeVisibilities>');
+    lines.push(`        <recordType>Sample_Object_${pad(objIdx, 3)}__c.Sample_Record_Type_${pad(i, 4)}</recordType>`);
+    lines.push('        <visible>true</visible>');
+    lines.push('    </recordTypeVisibilities>');
+  }
+
+  for (let i = 1; i <= spec.tabSettings; i++) {
+    lines.push('    <tabSettings>');
+    lines.push(`        <tab>Sample_Tab_${pad(i, 4)}</tab>`);
+    lines.push('        <visibility>Available</visibility>');
+    lines.push('    </tabSettings>');
+  }
+
+  lines.push('    <userPermissions>');
+  lines.push('        <enabled>true</enabled>');
+  lines.push('        <name>ApiEnabled</name>');
+  lines.push('    </userPermissions>');
+  lines.push('    <userPermissions>');
+  lines.push('        <enabled>true</enabled>');
+  lines.push('        <name>ViewAllData</name>');
+  lines.push('    </userPermissions>');
+
+  lines.push('</PermissionSet>');
+  return lines.join('\n') + '\n';
+}
+
+function genProfile(spec: SizeSpec['profile']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<Profile${NS}>`);
+
+  for (let i = 1; i <= spec.appVis; i++) {
+    lines.push('    <applicationVisibilities>');
+    lines.push(`        <application>Sample_App_${pad(i, 4)}</application>`);
+    lines.push(`        <default>${i === 1 ? 'true' : 'false'}</default>`);
+    lines.push(`        <visible>true</visible>`);
+    lines.push('    </applicationVisibilities>');
+  }
+
+  for (let i = 1; i <= spec.classAccesses; i++) {
+    lines.push('    <classAccesses>');
+    lines.push(`        <apexClass>Sample_Class_${pad(i, 5)}</apexClass>`);
+    lines.push('        <enabled>true</enabled>');
+    lines.push('    </classAccesses>');
+  }
+
+  for (let i = 1; i <= spec.fieldPerms; i++) {
+    const objIdx = (i % 200) + 1;
+    lines.push('    <fieldPermissions>');
+    lines.push('        <editable>true</editable>');
+    lines.push(`        <field>Sample_Object_${pad(objIdx, 3)}__c.Sample_Field_${pad(i, 6)}__c</field>`);
+    lines.push('        <readable>true</readable>');
+    lines.push('    </fieldPermissions>');
+  }
+
+  for (let i = 1; i <= spec.layoutAssignments; i++) {
+    const objIdx = (i % 50) + 1;
+    lines.push('    <layoutAssignments>');
+    lines.push(`        <layout>Sample_Object_${pad(objIdx, 3)}__c-Layout_${pad(i, 4)}</layout>`);
+    if (i % 5 === 0) {
+      lines.push(`        <recordType>Sample_Object_${pad(objIdx, 3)}__c.Sample_Record_Type_${pad(i, 4)}</recordType>`);
+    }
+    lines.push('    </layoutAssignments>');
+  }
+
+  for (let i = 1; i <= spec.objectPerms; i++) {
+    lines.push('    <objectPermissions>');
+    lines.push('        <allowCreate>true</allowCreate>');
+    lines.push('        <allowDelete>true</allowDelete>');
+    lines.push('        <allowEdit>true</allowEdit>');
+    lines.push('        <allowRead>true</allowRead>');
+    lines.push('        <modifyAllRecords>false</modifyAllRecords>');
+    lines.push(`        <object>Sample_Object_${pad(i, 3)}__c</object>`);
+    lines.push('        <viewAllRecords>false</viewAllRecords>');
+    lines.push('    </objectPermissions>');
+  }
+
+  for (let i = 1; i <= spec.pageAccesses; i++) {
+    lines.push('    <pageAccesses>');
+    lines.push(`        <apexPage>Sample_Page_${pad(i, 5)}</apexPage>`);
+    lines.push('        <enabled>true</enabled>');
+    lines.push('    </pageAccesses>');
+  }
+
+  for (let i = 1; i <= spec.recordTypeVis; i++) {
+    const objIdx = (i % 50) + 1;
+    lines.push('    <recordTypeVisibilities>');
+    lines.push(`        <default>${i === 1 ? 'true' : 'false'}</default>`);
+    lines.push(`        <recordType>Sample_Object_${pad(objIdx, 3)}__c.Sample_Record_Type_${pad(i, 4)}</recordType>`);
+    lines.push('        <visible>true</visible>');
+    lines.push('    </recordTypeVisibilities>');
+  }
+
+  for (let i = 1; i <= spec.tabSettings; i++) {
+    const visibilities = ['DefaultOn', 'DefaultOff', 'Hidden'] as const;
+    lines.push('    <tabVisibilities>');
+    lines.push(`        <tab>Sample_Tab_${pad(i, 4)}</tab>`);
+    lines.push(`        <visibility>${pick(visibilities, i)}</visibility>`);
+    lines.push('    </tabVisibilities>');
+  }
+
+  lines.push('    <custom>false</custom>');
+  lines.push('    <userLicense>Salesforce</userLicense>');
+  lines.push('    <userPermissions>');
+  lines.push('        <enabled>true</enabled>');
+  lines.push('        <name>ApiEnabled</name>');
+  lines.push('    </userPermissions>');
+
+  lines.push('</Profile>');
+  return lines.join('\n') + '\n';
+}
+
+function genFlow(spec: SizeSpec['flow']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<Flow${NS}>`);
+  lines.push('    <apiVersion>62.0</apiVersion>');
+  lines.push(`    <description>Synthetic flow for performance testing.</description>`);
+  lines.push('    <environments>Default</environments>');
+  lines.push('    <interviewLabel>Mega Flow {!$Flow.CurrentDateTime}</interviewLabel>');
+  lines.push('    <label>Mega Flow</label>');
+  lines.push('    <processMetadataValues>');
+  lines.push('        <name>BuilderType</name>');
+  lines.push('        <value><stringValue>LightningFlowBuilder</stringValue></value>');
+  lines.push('    </processMetadataValues>');
+  lines.push('    <processType>AutoLaunchedFlow</processType>');
+  lines.push('    <runInMode>SystemModeWithSharing</runInMode>');
+  lines.push('    <start>');
+  lines.push('        <locationX>50</locationX>');
+  lines.push('        <locationY>0</locationY>');
+  lines.push('        <connector><targetReference>Decision_0001</targetReference></connector>');
+  lines.push('    </start>');
+  lines.push('    <status>Active</status>');
+
+  for (let i = 1; i <= spec.decisions; i++) {
+    const next = i < spec.decisions ? `Decision_${pad(i + 1, 4)}` : `Assignment_${pad(1, 4)}`;
+    lines.push('    <decisions>');
+    lines.push(`        <name>Decision_${pad(i, 4)}</name>`);
+    lines.push(`        <label>Decision ${i}</label>`);
+    lines.push(`        <locationX>${100 + (i % 20) * 30}</locationX>`);
+    lines.push(`        <locationY>${100 + i * 5}</locationY>`);
+    lines.push('        <defaultConnector>');
+    lines.push(`            <targetReference>${next}</targetReference>`);
+    lines.push('        </defaultConnector>');
+    lines.push('        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>');
+    lines.push('        <rules>');
+    lines.push(`            <name>Rule_${pad(i, 4)}_A</name>`);
+    lines.push('            <conditionLogic>and</conditionLogic>');
+    lines.push('            <conditions>');
+    lines.push(`                <leftValueReference>Variable_${pad((i % spec.variables) + 1, 4)}</leftValueReference>`);
+    lines.push('                <operator>EqualTo</operator>');
+    lines.push('                <rightValue><stringValue>Match</stringValue></rightValue>');
+    lines.push('            </conditions>');
+    lines.push('            <connector>');
+    lines.push(`                <targetReference>${next}</targetReference>`);
+    lines.push('            </connector>');
+    lines.push(`            <label>Rule ${i} A</label>`);
+    lines.push('        </rules>');
+    lines.push('    </decisions>');
+  }
+
+  for (let i = 1; i <= spec.assignments; i++) {
+    const next = i < spec.assignments ? `Assignment_${pad(i + 1, 4)}` : `Lookup_${pad(1, 4)}`;
+    lines.push('    <assignments>');
+    lines.push(`        <name>Assignment_${pad(i, 4)}</name>`);
+    lines.push(`        <label>Assignment ${i}</label>`);
+    lines.push(`        <locationX>${50 + (i % 10) * 40}</locationX>`);
+    lines.push(`        <locationY>${500 + i * 5}</locationY>`);
+    lines.push('        <assignmentItems>');
+    lines.push(`            <assignToReference>Variable_${pad((i % spec.variables) + 1, 4)}</assignToReference>`);
+    lines.push('            <operator>Assign</operator>');
+    lines.push(`            <value><stringValue>Value_${pad(i, 5)}</stringValue></value>`);
+    lines.push('        </assignmentItems>');
+    lines.push('        <connector>');
+    lines.push(`            <targetReference>${next}</targetReference>`);
+    lines.push('        </connector>');
+    lines.push('    </assignments>');
+  }
+
+  for (let i = 1; i <= spec.recordLookups; i++) {
+    const next = i < spec.recordLookups ? `Lookup_${pad(i + 1, 4)}` : `Action_${pad(1, 4)}`;
+    lines.push('    <recordLookups>');
+    lines.push(`        <name>Lookup_${pad(i, 4)}</name>`);
+    lines.push(`        <label>Lookup ${i}</label>`);
+    lines.push(`        <locationX>${200 + (i % 8) * 50}</locationX>`);
+    lines.push(`        <locationY>${1000 + i * 5}</locationY>`);
+    lines.push('        <assignNullValuesIfNoRecordsFound>true</assignNullValuesIfNoRecordsFound>');
+    lines.push('        <connector>');
+    lines.push(`            <targetReference>${next}</targetReference>`);
+    lines.push('        </connector>');
+    lines.push('        <filterLogic>and</filterLogic>');
+    lines.push('        <filters>');
+    lines.push('            <field>Id</field>');
+    lines.push('            <operator>EqualTo</operator>');
+    lines.push(
+      `            <value><elementReference>Variable_${pad((i % spec.variables) + 1, 4)}</elementReference></value>`,
+    );
+    lines.push('        </filters>');
+    lines.push('        <getFirstRecordOnly>true</getFirstRecordOnly>');
+    lines.push('        <object>Sample_Object_001__c</object>');
+    lines.push('        <storeOutputAutomatically>true</storeOutputAutomatically>');
+    lines.push('    </recordLookups>');
+  }
+
+  for (let i = 1; i <= spec.actionCalls; i++) {
+    const next = i < spec.actionCalls ? `Action_${pad(i + 1, 4)}` : 'End';
+    lines.push('    <actionCalls>');
+    lines.push(`        <name>Action_${pad(i, 4)}</name>`);
+    lines.push(`        <label>Action ${i}</label>`);
+    lines.push(`        <locationX>${300 + (i % 6) * 60}</locationX>`);
+    lines.push(`        <locationY>${1500 + i * 5}</locationY>`);
+    lines.push(`        <actionName>Sample_Apex_Action_${pad(i, 4)}</actionName>`);
+    lines.push('        <actionType>apex</actionType>');
+    if (i < spec.actionCalls) {
+      lines.push('        <connector>');
+      lines.push(`            <targetReference>${next}</targetReference>`);
+      lines.push('        </connector>');
+    }
+    lines.push('        <flowTransactionModel>CurrentTransaction</flowTransactionModel>');
+    lines.push(`        <nameSegment>Sample_Apex_Action_${pad(i, 4)}</nameSegment>`);
+    lines.push('        <storeOutputAutomatically>true</storeOutputAutomatically>');
+    lines.push('        <versionSegment>1</versionSegment>');
+    lines.push('    </actionCalls>');
+  }
+
+  for (let i = 1; i <= spec.variables; i++) {
+    lines.push('    <variables>');
+    lines.push(`        <name>Variable_${pad(i, 4)}</name>`);
+    lines.push('        <dataType>String</dataType>');
+    lines.push('        <isCollection>false</isCollection>');
+    lines.push('        <isInput>false</isInput>');
+    lines.push('        <isOutput>false</isOutput>');
+    lines.push('    </variables>');
+  }
+
+  lines.push('</Flow>');
+  return lines.join('\n') + '\n';
+}
+
+function genWorkflow(spec: SizeSpec['workflow']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<Workflow${NS}>`);
+
+  for (let i = 1; i <= spec.alerts; i++) {
+    lines.push('    <alerts>');
+    lines.push(`        <fullName>Alert_${pad(i, 4)}</fullName>`);
+    lines.push(`        <description>Synthetic alert ${i}.</description>`);
+    lines.push('        <protected>false</protected>');
+    lines.push('        <recipients>');
+    lines.push('            <type>accountOwner</type>');
+    lines.push('        </recipients>');
+    lines.push('        <recipients>');
+    lines.push(`            <field>Sample_Field_${pad(i, 6)}__c</field>`);
+    lines.push('            <type>contactLookup</type>');
+    lines.push('        </recipients>');
+    lines.push(`        <senderType>CurrentUser</senderType>`);
+    lines.push(`        <template>unfiled$public/Sample_Template_${pad((i % 20) + 1, 3)}</template>`);
+    lines.push('    </alerts>');
+  }
+
+  for (let i = 1; i <= spec.fieldUpdates; i++) {
+    lines.push('    <fieldUpdates>');
+    lines.push(`        <fullName>Field_Update_${pad(i, 4)}</fullName>`);
+    lines.push(`        <description>Synthetic field update ${i}.</description>`);
+    lines.push(`        <field>Sample_Field_${pad(i, 6)}__c</field>`);
+    lines.push(`        <name>Field Update ${i}</name>`);
+    lines.push('        <notifyAssignee>false</notifyAssignee>');
+    lines.push(`        <operation>Literal</operation>`);
+    lines.push(`        <literalValue>Value_${pad(i, 5)}</literalValue>`);
+    lines.push('        <protected>false</protected>');
+    lines.push('    </fieldUpdates>');
+  }
+
+  for (let i = 1; i <= spec.rules; i++) {
+    lines.push('    <rules>');
+    lines.push(`        <fullName>Rule_${pad(i, 4)}</fullName>`);
+    lines.push('        <actions>');
+    lines.push(`            <name>Alert_${pad(((i - 1) % spec.alerts) + 1, 4)}</name>`);
+    lines.push('            <type>Alert</type>');
+    lines.push('        </actions>');
+    lines.push('        <active>true</active>');
+    lines.push('        <criteriaItems>');
+    lines.push(`            <field>Sample_Object_001__c.Sample_Field_${pad(i, 6)}__c</field>`);
+    lines.push('            <operation>notEqual</operation>');
+    lines.push(`            <value>Value_${pad(i, 5)}</value>`);
+    lines.push('        </criteriaItems>');
+    lines.push('        <triggerType>onCreateOrTriggeringUpdate</triggerType>');
+    lines.push('    </rules>');
+  }
+
+  lines.push('</Workflow>');
+  return lines.join('\n') + '\n';
+}
+
+function genCustomLabels(spec: SizeSpec['labels']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<CustomLabels${NS}>`);
+
+  for (let i = 1; i <= spec.count; i++) {
+    lines.push('    <labels>');
+    lines.push(`        <fullName>Sample_Label_${pad(i, 5)}</fullName>`);
+    lines.push('        <categories>Sample,Performance</categories>');
+    lines.push('        <language>en_US</language>');
+    lines.push('        <protected>false</protected>');
+    lines.push(`        <shortDescription>Sample Label ${i}</shortDescription>`);
+    lines.push(`        <value>${escape(`Synthetic label ${i} value used for performance testing only.`)}</value>`);
+    lines.push('    </labels>');
+  }
+
+  lines.push('</CustomLabels>');
+  return lines.join('\n') + '\n';
+}
+
+function genApplication(spec: SizeSpec['application']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<CustomApplication${NS}>`);
+
+  const formFactors = ['Large', 'Small', 'Medium'] as const;
+  const types = ['Flexipage', 'Standard'] as const;
+
+  for (let i = 1; i <= spec.actionOverrides; i++) {
+    lines.push('    <actionOverrides>');
+    lines.push('        <actionName>View</actionName>');
+    lines.push(`        <comment>Action override created for performance fixture ${i}.</comment>`);
+    lines.push(`        <content>Sample_Page_${pad(i, 5)}</content>`);
+    lines.push(`        <formFactor>${pick(formFactors, i)}</formFactor>`);
+    lines.push('        <skipRecordTypeSelect>false</skipRecordTypeSelect>');
+    lines.push(`        <type>${pick(types, i)}</type>`);
+    lines.push(`        <pageOrSobjectType>Sample_Object_${pad((i % 200) + 1, 3)}__c</pageOrSobjectType>`);
+    lines.push('    </actionOverrides>');
+  }
+
+  lines.push('    <brand>');
+  lines.push('        <headerColor>#0070D2</headerColor>');
+  lines.push('        <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>');
+  lines.push('    </brand>');
+  lines.push('    <formFactors>Large</formFactors>');
+  lines.push('    <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>');
+  lines.push('    <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>');
+  lines.push('    <label>Mega App</label>');
+  lines.push('    <navType>Standard</navType>');
+
+  for (let i = 1; i <= spec.profileActionOverrides; i++) {
+    lines.push('    <profileActionOverrides>');
+    lines.push('        <actionName>View</actionName>');
+    lines.push(`        <content>Sample_Profile_Page_${pad(i, 5)}</content>`);
+    lines.push(`        <formFactor>${pick(formFactors, i)}</formFactor>`);
+    lines.push(`        <pageOrSobjectType>Sample_Object_${pad((i % 200) + 1, 3)}__c</pageOrSobjectType>`);
+    lines.push(`        <profile>Sample_Profile_${pad((i % 30) + 1, 3)}</profile>`);
+    lines.push(
+      `        <recordType>Sample_Object_${pad((i % 50) + 1, 3)}__c.Sample_Record_Type_${pad(i, 4)}</recordType>`,
+    );
+    lines.push('        <type>Flexipage</type>');
+    lines.push('    </profileActionOverrides>');
+  }
+
+  for (let i = 1; i <= spec.tabs; i++) {
+    lines.push(`    <tabs>Sample_Tab_${pad(i, 4)}</tabs>`);
+  }
+  lines.push('    <uiType>Lightning</uiType>');
+
+  lines.push('</CustomApplication>');
+  return lines.join('\n') + '\n';
+}
+
+function genGlobalValueSet(spec: SizeSpec['globalValueSet']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<GlobalValueSet${NS}>`);
+  lines.push('    <description>Synthetic GVS for performance testing.</description>');
+  lines.push('    <masterLabel>Mega Values</masterLabel>');
+  lines.push('    <sorted>false</sorted>');
+  for (let i = 1; i <= spec.customValues; i++) {
+    lines.push('    <customValue>');
+    lines.push(`        <fullName>Sample_Value_${pad(i, 5)}</fullName>`);
+    lines.push('        <default>false</default>');
+    lines.push(`        <label>Sample Value ${i}</label>`);
+    lines.push(`        <isActive>${i % 7 !== 0}</isActive>`);
+    lines.push('    </customValue>');
+  }
+  lines.push('</GlobalValueSet>');
+  return lines.join('\n') + '\n';
+}
+
+function genBot(): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<Bot${NS}>`);
+  lines.push('    <agentDSLEnabled>false</agentDSLEnabled>');
+  lines.push('    <botMlDomain>');
+  lines.push('        <label>Mega Bot</label>');
+  lines.push('        <name>Mega_Bot</name>');
+  lines.push('    </botMlDomain>');
+  lines.push('    <botSource>None</botSource>');
+  for (let i = 1; i <= 8; i++) {
+    lines.push('    <contextVariables>');
+    lines.push('        <dataType>Text</dataType>');
+    lines.push(`        <developerName>Sample_Var_${pad(i, 3)}</developerName>`);
+    lines.push('        <includeInPrompt>false</includeInPrompt>');
+    lines.push(`        <label>Sample Var ${i}</label>`);
+    lines.push('    </contextVariables>');
+  }
+  lines.push('    <description>Synthetic bot for performance testing.</description>');
+  lines.push('    <label>Mega Bot</label>');
+  lines.push('    <logPrivateConversationData>false</logPrivateConversationData>');
+  lines.push('    <richContentEnabled>false</richContentEnabled>');
+  lines.push('    <sessionTimeout>0</sessionTimeout>');
+  lines.push('    <type>Bot</type>');
+  lines.push('</Bot>');
+  return lines.join('\n') + '\n';
+}
+
+function genBotVersion(spec: SizeSpec['bot']): string {
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<BotVersion${NS}>`);
+  lines.push('    <fullName>v1</fullName>');
+  lines.push('    <articleAnswersGPTEnabled>false</articleAnswersGPTEnabled>');
+
+  let stepCounter = 0;
+
+  for (let d = 1; d <= spec.dialogs; d++) {
+    lines.push('    <botDialogs>');
+    const stepsInDialog = (d % 3) + 1;
+    for (let s = 0; s < stepsInDialog; s++) {
+      stepCounter += 1;
+      lines.push('        <botSteps>');
+      if (s === 0) {
+        lines.push('            <botMessages>');
+        lines.push(`                <message>Synthetic message ${stepCounter} for dialog ${d}.</message>`);
+        lines.push(`                <messageIdentifier>${detId(stepCounter * 2)}</messageIdentifier>`);
+        lines.push('            </botMessages>');
+        lines.push(`            <stepIdentifier>${detId(stepCounter * 2 + 1)}</stepIdentifier>`);
+        lines.push('            <type>Message</type>');
+      } else {
+        lines.push(`            <stepIdentifier>${detId(stepCounter * 2 + 1)}</stepIdentifier>`);
+        lines.push('            <type>Wait</type>');
+      }
+      lines.push('        </botSteps>');
+    }
+    lines.push(`        <developerName>Sample_Dialog_${pad(d, 4)}</developerName>`);
+    lines.push('        <isPlaceholderDialog>false</isPlaceholderDialog>');
+    lines.push(`        <label>Sample Dialog ${d}</label>`);
+    lines.push('        <showInFooterMenu>false</showInFooterMenu>');
+    lines.push('    </botDialogs>');
+  }
+
+  for (let i = 1; i <= spec.mlIntents; i++) {
+    lines.push('    <conversationVariableOperations>');
+    lines.push(`        <invocationActionName>Sample_Action_${pad(i, 4)}</invocationActionName>`);
+    lines.push('        <invocationActionType>SetVariable</invocationActionType>');
+    for (let p = 1; p <= 3; p++) {
+      lines.push('        <parameters>');
+      lines.push(`            <parameterName>Sample_Param_${pad(p, 2)}</parameterName>`);
+      lines.push(`            <parameterValue>Value_${pad(i, 5)}_${p}</parameterValue>`);
+      lines.push('        </parameters>');
+    }
+    lines.push(`        <stepIdentifier>${detId(1_000_000 + i)}</stepIdentifier>`);
+    lines.push('    </conversationVariableOperations>');
+  }
+
+  lines.push('    <citationsEnabled>false</citationsEnabled>');
+  lines.push(`    <entryDialog>Sample_Dialog_${pad(1, 4)}</entryDialog>`);
+  lines.push('    <intentDisambiguationEnabled>false</intentDisambiguationEnabled>');
+  lines.push('    <intentV3Enabled>false</intentV3Enabled>');
+  lines.push('    <isScriptCompatibleAgent>false</isScriptCompatibleAgent>');
+  lines.push('    <knowledgeActionEnabled>false</knowledgeActionEnabled>');
+  lines.push(`    <mainMenuDialog>Sample_Dialog_${pad(1, 4)}</mainMenuDialog>`);
+  lines.push('    <nlpProviders>');
+  lines.push('        <language>en_US</language>');
+  lines.push('        <nlpProviderType>EinsteinAi</nlpProviderType>');
+  lines.push('    </nlpProviders>');
+  lines.push('    <smallTalkEnabled>false</smallTalkEnabled>');
+  lines.push('    <stopRecPrompts>false</stopRecPrompts>');
+  lines.push('    <stopWelcomePrompts>false</stopWelcomePrompts>');
+  lines.push('    <surfacesEnabled>false</surfacesEnabled>');
+
+  lines.push('</BotVersion>');
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Layout / driver
+// ---------------------------------------------------------------------------
+
+const SFDX_PROJECT_JSON = {
+  packageDirectories: [{ path: 'force-app', default: true }],
+  namespace: '',
+  sfdcLoginUrl: 'https://login.salesforce.com',
+  sourceApiVersion: '62.0',
+};
+
+interface FileRecord {
+  relPath: string;
+  bytes: number;
+}
+
+async function writeOut(outDir: string, relPath: string, content: string, files: FileRecord[]): Promise<void> {
+  const abs = join(outDir, relPath);
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, content, 'utf8');
+  files.push({ relPath, bytes: Buffer.byteLength(content, 'utf8') });
+}
+
+export interface GenerateOptions {
+  outDir: string;
+  profile?: Profile;
+  cleanFirst?: boolean;
+}
+
+export interface GenerateResult {
+  outDir: string;
+  profile: Profile;
+  files: FileRecord[];
+  totalBytes: number;
+}
+
+export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
+  const profile: Profile = opts.profile ?? 'large';
+  const spec = PROFILES[profile];
+  const outDir = resolve(opts.outDir);
+
+  if (opts.cleanFirst) {
+    await rm(outDir, { recursive: true, force: true });
+  }
+  await mkdir(outDir, { recursive: true });
+
+  const files: FileRecord[] = [];
+  const base = 'force-app/main/default';
+
+  await writeFile(join(outDir, 'sfdx-project.json'), JSON.stringify(SFDX_PROJECT_JSON, null, 2) + '\n', 'utf8');
+
+  await writeOut(
+    outDir,
+    `${base}/permissionsets/Mega.permissionset-meta.xml`,
+    genPermissionSet(spec.permissionSet),
+    files,
+  );
+  // mutingpermissionset shares PermissionSet's child shape, just swap the root tag.
+  await writeOut(
+    outDir,
+    `${base}/mutingpermissionsets/Mega.mutingpermissionset-meta.xml`,
+    genPermissionSet(spec.permissionSet)
+      .replace('<PermissionSet', '<MutingPermissionSet')
+      .replace('</PermissionSet>', '</MutingPermissionSet>'),
+    files,
+  );
+  await writeOut(outDir, `${base}/profiles/Mega.profile-meta.xml`, genProfile(spec.profile), files);
+  await writeOut(outDir, `${base}/flows/Mega_Flow.flow-meta.xml`, genFlow(spec.flow), files);
+  await writeOut(outDir, `${base}/workflows/Account.workflow-meta.xml`, genWorkflow(spec.workflow), files);
+  await writeOut(outDir, `${base}/labels/CustomLabels.labels-meta.xml`, genCustomLabels(spec.labels), files);
+  await writeOut(outDir, `${base}/applications/Mega.app-meta.xml`, genApplication(spec.application), files);
+  await writeOut(
+    outDir,
+    `${base}/globalValueSets/MegaValues.globalValueSet-meta.xml`,
+    genGlobalValueSet(spec.globalValueSet),
+    files,
+  );
+  await writeOut(outDir, `${base}/bots/Mega_Bot/Mega_Bot.bot-meta.xml`, genBot(), files);
+  await writeOut(outDir, `${base}/bots/Mega_Bot/v1.botVersion-meta.xml`, genBotVersion(spec.bot), files);
+
+  const totalBytes = files.reduce((s, f) => s + f.bytes, 0);
+  return { outDir, profile, files, totalBytes };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): { profile: Profile; outDir: string; clean: boolean } {
+  let profile: Profile = 'large';
+  let outDir = 'perf-fixtures';
+  let clean = true;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--profile' && argv[i + 1]) {
+      const next = argv[++i] as Profile;
+      if (!(next in PROFILES))
+        throw new Error(`Unknown profile: ${next}. Use one of: ${Object.keys(PROFILES).join(', ')}.`);
+      profile = next;
+    } else if (arg === '--out' && argv[i + 1]) {
+      outDir = argv[++i] as string;
+    } else if (arg === '--no-clean') {
+      clean = false;
+    } else if (arg === '--help' || arg === '-h') {
+      process.stdout.write(
+        [
+          'gen-perf-fixtures.ts',
+          '',
+          'Options:',
+          '  --profile <small|medium|large|xlarge>   Default: large',
+          '  --out <dir>                             Default: perf-fixtures',
+          '  --no-clean                              Do not wipe out dir first',
+          '',
+        ].join('\n') + '\n',
+      );
+      process.exit(0);
+    }
+  }
+  return { profile, outDir, clean };
+}
+
+function isDirectInvocation(): boolean {
+  if (!process.argv[1]) return false;
+  const here = fileURLToPath(import.meta.url);
+  return resolve(process.argv[1]) === resolve(here);
+}
+
+if (isDirectInvocation()) {
+  const { profile, outDir, clean } = parseArgs(process.argv.slice(2));
+  const start = Date.now();
+  generate({ outDir, profile, cleanFirst: clean })
+    .then((res) => {
+      const elapsed = Date.now() - start;
+      const mb = (res.totalBytes / (1024 * 1024)).toFixed(2);
+      process.stdout.write(
+        `Generated ${res.files.length} files (${mb} MB) into ${res.outDir} using profile "${res.profile}" in ${elapsed}ms.\n`,
+      );
+      for (const f of res.files) {
+        const kb = (f.bytes / 1024).toFixed(1).padStart(10, ' ');
+        process.stdout.write(`  ${kb} KB  ${f.relPath}\n`);
+      }
+    })
+    .catch((err: unknown) => {
+      process.stderr.write(`Error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../lib/scripts",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["../node_modules"]
+}

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -1,0 +1,113 @@
+# Performance tests
+
+Heavy, slow round-trip tests against synthetic fixtures sized like real,
+long-lived Salesforce orgs. Deliberately separated from `npm test` (unit) and
+`npm run test:nuts` (non-unit) so:
+
+- they don't bloat regular CI runtime,
+- they don't influence coverage thresholds,
+- their fixtures stay out of the published npm tarball.
+
+## Running
+
+```bash
+npm run test:perf                            # large profile, all four formats, default types
+PERF_PROFILE=medium npm run test:perf
+PERF_FORMATS=xml,json npm run test:perf
+PERF_PROFILE=xlarge PERF_FORMATS=xml npm run test:perf
+PERF_TYPES=permissionset,profile npm run test:perf   # only time these two types
+```
+
+### Type selection
+
+The default type list matches `test/utils/constants.ts#METADATA_UNDER_TEST` minus
+the loyalty/escalation samples that have small fixtures already:
+
+```
+permissionset, mutingpermissionset, profile, flow, workflow, labels, bot
+```
+
+These are the types whose nested elements have unique-id mappings configured
+in `src/metadata/uniqueIdElements.ts` faithfully enough that decompose +
+recompose is byte-stable.
+
+The generator also produces fixtures for `globalValueSet` and `app`, but those
+are **not in the default perf list** because some of their child elements
+(notably `CustomApplication.actionOverrides` /
+`CustomApplication.profileActionOverrides`) have neither `<fullName>` nor
+`<name>` and therefore fall back to a SHA-256 hash that collapses many
+distinct items into one shard. Add unique-id coverage for those types in
+`src/metadata/uniqueIdElements.ts` first, then opt them into the perf run with
+`PERF_TYPES=...,app,globalValueSet`.
+
+A perf run with a lossy type still passes the idempotence check (pass2 is
+byte-equal to pass1) but the timing reflects the _shrunken_ file, not the
+original size, so it is not a useful performance signal.
+
+Profiles:
+
+| Profile  | Fixture total | Notes                                                      |
+| -------- | ------------- | ---------------------------------------------------------- |
+| `small`  | ~1 MB         | sanity check; finishes in seconds                          |
+| `medium` | ~10 MB        | local dev iteration                                        |
+| `large`  | ~30 MB        | default; calibrated to mimic a 10+ year-old enterprise org |
+| `xlarge` | ~80 MB        | stress test; can take many minutes                         |
+
+## What the test asserts
+
+For each format (`xml`, `json`, `json5`, `yaml`):
+
+1. Decompose the synthetic fixture (timed).
+2. Recompose it back to deployment-ready XML (timed).
+3. Decompose again, recompose again (timed).
+4. **Idempotence:** the bytes after the second round-trip must match the bytes
+   after the first round-trip exactly.
+
+The first round-trip may reorder elements relative to the generator's raw
+output (the decomposer owns sort order). The second round-trip must be
+byte-identical to the first; that's the regression guard.
+
+## Output
+
+Each test writes a JSON report to
+`perf-results/<timestamp>-<profile>-<format>.json`:
+
+```json
+{
+  "timestamp": "2026-05-01T12:34:56.789Z",
+  "node": "v20.11.1",
+  "platform": "win32",
+  "arch": "x64",
+  "profile": "large",
+  "format": "xml",
+  "fixtureBytes": 31457280,
+  "fixtureFiles": 9,
+  "samples": [
+    { "label": "xml.decompose.pass1", "elapsedMs": 12345.6, "rssDeltaBytes": 1048576, ... },
+    ...
+  ]
+}
+```
+
+These files are gitignored. Plot them, diff them between branches, or commit
+them to a separate repo to track perf trends over time.
+
+## Generating fixtures standalone
+
+```bash
+npm run test:perf:gen                              # large profile -> perf-fixtures/
+npm run test:perf:gen -- --profile xlarge --out tmp/perf
+```
+
+## Why synthetic fixtures?
+
+Real customer metadata leaks competitive intelligence even when it looks
+innocuous: custom object names, field naming conventions, app structure, label
+inventories, and integration patterns all reveal architecture. The generator
+in `scripts/gen-perf-fixtures.ts` produces files with the _same shape and
+scale_ as those large orgs but populated with deterministic counter-based
+identifiers (`Sample_Object_001__c`, `Sample_Field_000001__c`, etc.) so:
+
+- nothing proprietary ever reaches the repo,
+- byte-for-byte reproducible runs across machines,
+- contributors can run perf tests without a Salesforce org.

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -1,0 +1,241 @@
+'use strict';
+
+import { cp, mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+
+import { decomposeMetadataTypes } from '../../src/core/decomposeMetadataTypes.js';
+import { recomposeMetadataTypes } from '../../src/core/recomposeMetadataTypes.js';
+import { generate, type Profile } from '../../scripts/gen-perf-fixtures.js';
+import { dirBytes, formatBytes, formatMs, measure, writeReport, type MeasureResult } from './utils/measure.js';
+
+// Performance tests are intentionally heavy and DO NOT run as part of `npm test`.
+// They:
+//   1. generate large synthetic fixtures (deterministic, no proprietary data)
+//   2. measure decompose + recompose wall-clock time and memory deltas
+//   3. perform a second round-trip and assert idempotence (byte-stable output)
+//   4. emit timing artifacts to perf-results/<stamp>-<profile>-<format>.json
+//
+// Env vars:
+//   PERF_PROFILE=small|medium|large|xlarge   (default: large)
+//   PERF_FORMATS=xml,json,json5,yaml         (default: all four)
+//   PERF_TYPES=permissionset,flow,...        (default: types known to round-trip)
+//
+// The default type list mirrors `test/utils/constants.ts#METADATA_UNDER_TEST` -
+// the types whose unique-id elements are configured in src/metadata/uniqueIdElements.ts
+// well enough that decompose+recompose is faithful.
+//
+// Other types the generator produces (app, globalValueSet) currently lack
+// per-type unique-id coverage for some of their child elements (e.g. CustomApplication's
+// actionOverrides has no <fullName>/<name>), so the SHA-256 fallback collapses
+// many distinct elements into one shard. They are NOT in the default list, but
+// you can include them via PERF_TYPES to time the (lossy) round-trip on the
+// shapes you intend to support next.
+const PROFILE = (process.env.PERF_PROFILE ?? 'large') as Profile;
+const FORMATS = (process.env.PERF_FORMATS ?? 'xml,json,json5,yaml')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const DEFAULT_METADATA_TYPES = ['permissionset', 'mutingpermissionset', 'profile', 'flow', 'workflow', 'labels', 'bot'];
+const METADATA_TYPES = (process.env.PERF_TYPES ?? DEFAULT_METADATA_TYPES.join(','))
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const FIXTURE_ROOT = resolve('perf-fixtures');
+
+// We populate the fixture directory once for the whole suite. It is gitignored
+// and lives outside the test session so multiple format tests can reuse it
+// without paying the generation cost more than once.
+let fixtureBytes = 0;
+let fixtureFiles = 0;
+
+describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
+  beforeAll(async () => {
+    const result = await generate({ outDir: FIXTURE_ROOT, profile: PROFILE, cleanFirst: true });
+    fixtureBytes = result.totalBytes;
+    fixtureFiles = result.files.length;
+    // eslint-disable-next-line no-console
+    console.log(
+      `\n[perf] generated ${fixtureFiles} fixture files (${formatBytes(fixtureBytes)}) using profile "${PROFILE}".\n` +
+        `[perf] testing types: ${METADATA_TYPES.join(', ')}\n` +
+        `[perf] testing formats: ${FORMATS.join(', ')}`,
+    );
+  });
+
+  for (const format of FORMATS) {
+    describe(`format=${format}`, () => {
+      let workDir: string;
+      let originalCwd: string;
+      const samples: MeasureResult[] = [];
+
+      beforeEach(async () => {
+        originalCwd = process.cwd();
+        workDir = await mkdtemp(join(tmpdir(), `sf-decomposer-perf-${format}-`));
+        // copy generated fixtures into a clean working dir so we never mutate the source
+        await cp(FIXTURE_ROOT, workDir, { recursive: true, force: true });
+        // generated sfdx-project.json already points at force-app
+        process.chdir(workDir);
+      });
+
+      afterEach(async () => {
+        process.chdir(originalCwd);
+        await rm(workDir, { recursive: true, force: true });
+      });
+
+      it(`round-trips and is idempotent in ${format.toUpperCase()}`, async () => {
+        // Swallow CLI chatter; perf samples are the artifact we care about.
+        const log = (): void => {};
+
+        // ---- pass 1: decompose then recompose -------------------------------
+        const { sample: decompose1 } = await measure(`${format}.decompose.pass1`, async () => {
+          await decomposeMetadataTypes({
+            metadataTypes: METADATA_TYPES,
+            prepurge: true,
+            postpurge: true,
+            format,
+            strategy: 'unique-id',
+            decomposeNestedPerms: false,
+            log,
+          });
+        });
+        samples.push(decompose1);
+
+        const decomposedSnapshot = await dirBytes(join(workDir, 'force-app'));
+
+        const { sample: recompose1 } = await measure(`${format}.recompose.pass1`, async () => {
+          await recomposeMetadataTypes({
+            metadataTypes: METADATA_TYPES,
+            postpurge: true,
+            log,
+          });
+        });
+        samples.push(recompose1);
+
+        // Capture the recomposed XML so we can compare to a second round-trip.
+        const firstRoundtrip = await snapshotFiles(workDir);
+
+        // ---- pass 2: decompose then recompose (idempotence) ----------------
+        const { sample: decompose2 } = await measure(`${format}.decompose.pass2`, async () => {
+          await decomposeMetadataTypes({
+            metadataTypes: METADATA_TYPES,
+            prepurge: true,
+            postpurge: true,
+            format,
+            strategy: 'unique-id',
+            decomposeNestedPerms: false,
+            log,
+          });
+        });
+        samples.push(decompose2);
+
+        const { sample: recompose2 } = await measure(`${format}.recompose.pass2`, async () => {
+          await recomposeMetadataTypes({
+            metadataTypes: METADATA_TYPES,
+            postpurge: true,
+            log,
+          });
+        });
+        samples.push(recompose2);
+
+        const secondRoundtrip = await snapshotFiles(workDir);
+
+        // Pass 1 output may differ from the generator's raw bytes (sort order
+        // is decided by the decomposer, not the generator). Pass 2 must match
+        // pass 1 byte-for-byte; that's the contract this perf test enforces.
+        expect(secondRoundtrip.size).toBe(firstRoundtrip.size);
+        for (const [path, bytes] of firstRoundtrip) {
+          const other = secondRoundtrip.get(path);
+          expect(other, `missing on second round-trip: ${path}`).toBeDefined();
+          expect(other, `byte drift on second round-trip: ${path}`).toBe(bytes);
+        }
+
+        // ---- write report --------------------------------------------------
+        const reportFile = await writeReport({
+          timestamp: new Date().toISOString(),
+          node: process.version,
+          platform: process.platform,
+          arch: process.arch,
+          profile: PROFILE,
+          format,
+          fixtureBytes,
+          fixtureFiles,
+          samples,
+        });
+
+        printSummary(format, fixtureBytes, samples, decomposedSnapshot, reportFile);
+      });
+    });
+  }
+
+  // Note: perf-fixtures/ is intentionally left in place after the suite so it
+  // can be inspected or reused. The next `npm run test:perf` regenerates it
+  // with cleanFirst: true.
+});
+
+async function snapshotFiles(root: string): Promise<Map<string, string>> {
+  // Walk breadth-first so we can read files in parallel batches per level.
+  // Sequential await-in-loop would be needlessly slow on a 30+MB tree and
+  // also trips eslint's no-await-in-loop rule.
+  const out = new Map<string, string>();
+  let queue: string[] = [root];
+  while (queue.length > 0) {
+    const dirsThisLevel = queue;
+    queue = [];
+    // eslint-disable-next-line no-await-in-loop -- breadth-first walk drains a level before descending
+    const entriesPerDir = await Promise.all(
+      dirsThisLevel.map(async (d) => ({ d, entries: await readdir(d, { withFileTypes: true }) })),
+    );
+    const filesToRead: string[] = [];
+    for (const { d, entries } of entriesPerDir) {
+      for (const entry of entries) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) {
+          queue.push(full);
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        // Only snapshot the recomposed (parent) metadata files, not decomposed
+        // shards. After recompose --postpurge there shouldn't be any shards
+        // left, but be defensive in case a future change leaves them.
+        const rel = full.substring(root.length + 1).replace(/\\/g, '/');
+        if (rel.endsWith('-meta.xml') || rel === 'sfdx-project.json') {
+          filesToRead.push(full);
+        }
+      }
+    }
+    // eslint-disable-next-line no-await-in-loop -- read every file at this level before descending
+    const contents = await Promise.all(filesToRead.map(async (f) => ({ f, c: await readFile(f, 'utf8') })));
+    for (const { f, c } of contents) {
+      const rel = f.substring(root.length + 1).replace(/\\/g, '/');
+      out.set(rel, c);
+    }
+  }
+  return out;
+}
+
+function printSummary(
+  format: string,
+  inputBytes: number,
+  samples: MeasureResult[],
+  decomposedSnapshot: { files: number; bytes: number },
+  reportFile: string,
+): void {
+  const totalElapsed = samples.reduce((s, x) => s + x.elapsedMs, 0);
+  const peakRssDelta = samples.reduce((m, x) => Math.max(m, x.rssDeltaBytes), 0);
+  const lines = [
+    '',
+    `[perf] format=${format.padEnd(5)} input=${formatBytes(inputBytes)} ` +
+      `decomposed=${decomposedSnapshot.files} files / ${formatBytes(decomposedSnapshot.bytes)}`,
+  ];
+  for (const s of samples) {
+    lines.push(
+      `[perf]   ${s.label.padEnd(28)} ${formatMs(s.elapsedMs).padStart(10)}   ` +
+        `rssΔ ${formatBytes(s.rssDeltaBytes).padStart(10)}`,
+    );
+  }
+  lines.push(`[perf]   total=${formatMs(totalElapsed)}  peak rssΔ=${formatBytes(peakRssDelta)}  report=${reportFile}`);
+  // eslint-disable-next-line no-console
+  console.log(lines.join('\n'));
+}

--- a/test/perf/utils/measure.ts
+++ b/test/perf/utils/measure.ts
@@ -1,0 +1,110 @@
+'use strict';
+
+import { mkdir, writeFile, readdir, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+export type MeasureResult = {
+  label: string;
+  elapsedMs: number;
+  rssBeforeBytes: number;
+  rssAfterBytes: number;
+  rssDeltaBytes: number;
+  heapUsedBeforeBytes: number;
+  heapUsedAfterBytes: number;
+};
+
+/** Run an async block, capturing wall time and process memory deltas. */
+export async function measure<T>(label: string, fn: () => Promise<T>): Promise<{ result: T; sample: MeasureResult }> {
+  const memBefore = process.memoryUsage();
+  const start = performance.now();
+  const result = await fn();
+  const elapsedMs = performance.now() - start;
+  const memAfter = process.memoryUsage();
+  return {
+    result,
+    sample: {
+      label,
+      elapsedMs,
+      rssBeforeBytes: memBefore.rss,
+      rssAfterBytes: memAfter.rss,
+      rssDeltaBytes: memAfter.rss - memBefore.rss,
+      heapUsedBeforeBytes: memBefore.heapUsed,
+      heapUsedAfterBytes: memAfter.heapUsed,
+    },
+  };
+}
+
+/** Recursively sum byte sizes of all files under a directory. */
+export async function dirBytes(dir: string): Promise<{ files: number; bytes: number }> {
+  // Walk the tree breadth-first and stat in parallel batches. The naive
+  // sequential walk hits eslint's no-await-in-loop rule and is also slower on
+  // large fixture trees because every readdir/stat blocks the next.
+  let files = 0;
+  let bytes = 0;
+  let queue: string[] = [dir];
+  while (queue.length > 0) {
+    const dirsThisLevel = queue;
+    queue = [];
+    // eslint-disable-next-line no-await-in-loop -- breadth-first walk needs to drain each level before the next
+    const entriesPerDir = await Promise.all(
+      dirsThisLevel.map(async (d) => ({ d, entries: await readdir(d, { withFileTypes: true }) })),
+    );
+    for (const { d, entries } of entriesPerDir) {
+      for (const entry of entries) {
+        const full = join(d, entry.name);
+        if (entry.isDirectory()) queue.push(full);
+        else if (entry.isFile()) files += 1;
+      }
+    }
+    const allFiles = entriesPerDir.flatMap(({ d, entries }) =>
+      entries.filter((e) => e.isFile()).map((e) => join(d, e.name)),
+    );
+    // eslint-disable-next-line no-await-in-loop -- size sum needs each level's stats before continuing
+    const sizes = await Promise.all(allFiles.map(async (f) => (await stat(f)).size));
+    bytes += sizes.reduce((a, b) => a + b, 0);
+  }
+  return { files, bytes };
+}
+
+export type PerfReport = {
+  timestamp: string;
+  node: string;
+  platform: string;
+  arch: string;
+  profile: string;
+  format: string;
+  fixtureBytes: number;
+  fixtureFiles: number;
+  samples: MeasureResult[];
+};
+
+const RESULTS_DIR = resolve(process.cwd(), 'perf-results');
+
+export async function writeReport(report: PerfReport): Promise<string> {
+  await mkdir(RESULTS_DIR, { recursive: true });
+  const safeStamp = report.timestamp.replace(/[:.]/g, '-');
+  const file = join(RESULTS_DIR, `${safeStamp}-${report.profile}-${report.format}.json`);
+  await writeFile(file, JSON.stringify(report, null, 2) + '\n', 'utf8');
+  return file;
+}
+
+/** Pretty-print a numeric byte count, e.g. 12345 -> "12.06 KB". Handles negatives for memory deltas. */
+export function formatBytes(bytes: number): string {
+  const sign = bytes < 0 ? '-' : '';
+  const abs = Math.abs(bytes);
+  if (abs < 1024) return `${sign}${abs} B`;
+  if (abs < 1024 * 1024) return `${sign}${(abs / 1024).toFixed(2)} KB`;
+  return `${sign}${(abs / 1024 / 1024).toFixed(2)} MB`;
+}
+
+/** Pretty-print a millisecond duration, e.g. 75123 -> "75.1 s". */
+export function formatMs(ms: number): string {
+  const ONE_SECOND_MS = 1000;
+  const ONE_MINUTE_MS = 60_000;
+  if (ms < ONE_SECOND_MS) return `${ms.toFixed(1)} ms`;
+  if (ms < ONE_MINUTE_MS) return `${(ms / ONE_SECOND_MS).toFixed(2)} s`;
+  const m = Math.floor(ms / ONE_MINUTE_MS);
+  const s = ((ms % ONE_MINUTE_MS) / ONE_SECOND_MS).toFixed(1);
+  return `${m}m ${s}s`;
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@salesforce/dev-config/tsconfig-test-strict-esm",
-  "include": ["./**/*.ts"],
+  "include": ["./**/*.ts", "../scripts/**/*.ts"],
   "compilerOptions": {
     "skipLibCheck": true
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    exclude: ['test/perf/**', 'node_modules/**'],
     clearMocks: true,
     testTimeout: 600_000,
     hookTimeout: 600_000,

--- a/vitest.perf.config.ts
+++ b/vitest.perf.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+// Performance tests are deliberately separated from unit tests and non-unit (NUT)
+// tests because they:
+//   - operate on multi-megabyte synthetic fixtures (see scripts/gen-perf-fixtures.ts)
+//   - take minutes, not seconds, to complete
+//   - emit JSON timing artifacts to perf-results/ for trend tracking
+//   - should not influence coverage thresholds
+//
+// Run with: npm run test:perf
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['test/perf/**/*.perf.ts'],
+    fileParallelism: false,
+    maxWorkers: 1,
+    testTimeout: 1_800_000, // 30 min per test - the xlarge profile can take a while
+    hookTimeout: 1_800_000,
+    clearMocks: true,
+    reporters: ['verbose'],
+  },
+});


### PR DESCRIPTION
Adds a third test track separate from unit tests and NUTs, intended for measuring decompose/recompose throughput against large-org-shaped metadata without bringing proprietary fixtures into the repo.

* scripts/gen-perf-fixtures.ts: deterministic generator producing synthetic XML for permissionset, mutingpermissionset, profile, flow, workflow, labels, bot, app and globalValueSet across small/medium/ large/xlarge size profiles. Identifiers are counter-based so output is byte-stable across runs and contributors.
* test/perf/decompose.perf.ts: runs each format through two full decompose+recompose passes and asserts pass-2 bytes equal pass-1 (idempotence), so the suite stays meaningful even for types whose unique-id coverage is incomplete. Default type list mirrors METADATA_UNDER_TEST; PERF_TYPES/PERF_FORMATS/PERF_PROFILE override.
* vitest.perf.config.ts: 30-min timeouts, serial execution, no coverage. Excluded from the default vitest.config.ts include glob so npm test stays fast.
* test/perf/utils/measure.ts: timing + RSS deltas, JSON reports written to perf-results/ for trend tracking.
* .github/workflows/perf.yml: workflow_dispatch + Monday-morning cron
  + workflow_call from release.yml after smoke-test, so every published version gets a baseline artifact. Single OS / single Node pinned for reproducibility; emits step-summary table and uploads perf-results/ as a 90-day retention artifact. Does not gate releases - observability first, thresholds later once baselines exist.
* package.json: adds test:perf and test:perf:gen scripts.
* perf-fixtures/ and perf-results/ are gitignored.