### PR TITLE
fix(deps): bump config-disassembler to 1.1.2 and harden perf suite

### DIFF
--- a/fixtures/package-dir-2/bots/Sample_Chat_Bot/v1.botVersion-meta.xml
+++ b/fixtures/package-dir-2/bots/Sample_Chat_Bot/v1.botVersion-meta.xml
@@ -108,6 +108,14 @@
     </botDialogs>
     <botDialogs>
         <botSteps>
+            <botMessages>
+                <message>Hi! How can i help you?</message>
+                <messageIdentifier>b2c94289-f1e6-449c-8ebf-bc959c14190a</messageIdentifier>
+            </botMessages>
+            <stepIdentifier>81b89693-bce3-4b5c-a5b7-4798e232cb27</stepIdentifier>
+            <type>Message</type>
+        </botSteps>
+        <botSteps>
             <botNavigation>
                 <botNavigationLinks>
                     <targetBotDialog>Main_Menu</targetBotDialog>
@@ -116,14 +124,6 @@
             </botNavigation>
             <stepIdentifier>b2096c4c-4821-4c43-ac2b-34b01413fd23</stepIdentifier>
             <type>Navigation</type>
-        </botSteps>
-        <botSteps>
-            <botMessages>
-                <message>Hi! How can i help you?</message>
-                <messageIdentifier>b2c94289-f1e6-449c-8ebf-bc959c14190a</messageIdentifier>
-            </botMessages>
-            <stepIdentifier>81b89693-bce3-4b5c-a5b7-4798e232cb27</stepIdentifier>
-            <type>Message</type>
         </botSteps>
         <developerName>Welcome</developerName>
         <isPlaceholderDialog>false</isPlaceholderDialog>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "^8.26.3",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.0",
-        "config-disassembler": "^1.1.1",
+        "config-disassembler": "^1.1.2",
         "fast-xml-parser": "^5.7.2",
         "p-limit": "^7.3.0"
       },
@@ -5448,9 +5448,9 @@
       "dev": true
     },
     "node_modules/config-disassembler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.1.1.tgz",
-      "integrity": "sha512-axNS360Utp5QrIC78GIvOZfNHP+ZKUbXn4Kd2i+dkwcpu5EktoDRxM+WuUZcD4sIrBzdws+VKEAODFWuSGGfvQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.1.2.tgz",
+      "integrity": "sha512-N3CffiPXYcZrhhsYE0jLSKKOOR5J8Dxtk0JbLo2x6WeKm4Z6OxYLAXql+FVOK6i0GbiiYNGu1ilezcRRXbNkxw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "^8.26.3",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.0",
-    "config-disassembler": "^1.1.1",
+    "config-disassembler": "^1.1.2",
     "fast-xml-parser": "^5.7.2",
     "p-limit": "^7.3.0"
   },

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -20,29 +20,22 @@ PERF_TYPES=permissionset,profile npm run test:perf   # only time these two types
 
 ### Type selection
 
-The default type list matches `test/utils/constants.ts#METADATA_UNDER_TEST` minus
-the loyalty/escalation samples that have small fixtures already:
+The default type list covers every shape the generator produces:
 
 ```
-permissionset, mutingpermissionset, profile, flow, workflow, labels, bot
+permissionset, mutingpermissionset, profile, flow, workflow, labels, bot,
+app, globalValueSet
 ```
 
-These are the types whose nested elements have unique-id mappings configured
-in `src/metadata/uniqueIdElements.ts` faithfully enough that decompose +
-recompose is byte-stable.
+These all round-trip faithfully: types with `uniqueIdElements` configured in
+`src/metadata/uniqueIdElements.ts` use those fields, and types without (or
+sub-elements like `CustomApplication.actionOverrides` /
+`profileActionOverrides` that have neither `<fullName>` nor `<name>`) fall back
+to a SHA-256 hash of the full outer element. Since `config-disassembler@1.1.2`
+that hash is computed over the entire element rather than the first text-leaf
+child, so distinct siblings get distinct shards and no data is lost.
 
-The generator also produces fixtures for `globalValueSet` and `app`, but those
-are **not in the default perf list** because some of their child elements
-(notably `CustomApplication.actionOverrides` /
-`CustomApplication.profileActionOverrides`) have neither `<fullName>` nor
-`<name>` and therefore fall back to a SHA-256 hash that collapses many
-distinct items into one shard. Add unique-id coverage for those types in
-`src/metadata/uniqueIdElements.ts` first, then opt them into the perf run with
-`PERF_TYPES=...,app,globalValueSet`.
-
-A perf run with a lossy type still passes the idempotence check (pass2 is
-byte-equal to pass1) but the timing reflects the _shrunken_ file, not the
-original size, so it is not a useful performance signal.
+Override the list with `PERF_TYPES=permissionset,profile` to time a subset.
 
 Profiles:
 
@@ -59,13 +52,19 @@ For each format (`xml`, `json`, `json5`, `yaml`):
 
 1. Decompose the synthetic fixture (timed).
 2. Recompose it back to deployment-ready XML (timed).
-3. Decompose again, recompose again (timed).
-4. **Idempotence:** the bytes after the second round-trip must match the bytes
-   after the first round-trip exactly.
+3. **Non-shrinkage:** every recomposed `-meta.xml` retains at least 99% of
+   the original generator-emitted bytes. Catches mass element-collapse
+   regressions (e.g. the `actionOverrides` SHA-256 hash collision bug fixed
+   in `config-disassembler@0.4.3`) that would otherwise still pass step 4.
+4. Decompose again, recompose again (timed).
+5. **Idempotence:** the bytes after the second round-trip must match the
+   bytes after the first round-trip exactly.
 
 The first round-trip may reorder elements relative to the generator's raw
-output (the decomposer owns sort order). The second round-trip must be
-byte-identical to the first; that's the regression guard.
+output (the decomposer owns sort order) and may differ by a few bytes from
+trailing-newline normalization, hence the 99% threshold rather than 100%.
+The second round-trip must be byte-identical to the first; that's the
+canonical-form regression guard.
 
 ## Output
 

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -22,23 +22,22 @@ import { dirBytes, formatBytes, formatMs, measure, writeReport, type MeasureResu
 //   PERF_FORMATS=xml,json,json5,yaml         (default: all four)
 //   PERF_TYPES=permissionset,flow,...        (default: types known to round-trip)
 //
-// The default type list mirrors `test/utils/constants.ts#METADATA_UNDER_TEST` -
-// the types whose unique-id elements are configured in src/metadata/uniqueIdElements.ts
-// well enough that decompose+recompose is faithful.
-//
-// Other types the generator produces (app, globalValueSet) currently lack
-// per-type unique-id coverage for some of their child elements (e.g. CustomApplication's
-// actionOverrides has no <fullName>/<name>), so the SHA-256 fallback collapses
-// many distinct elements into one shard. They are NOT in the default list, but
-// you can include them via PERF_TYPES to time the (lossy) round-trip on the
-// shapes you intend to support next.
+// The default type list covers the types we generate fixtures for. Since
+// config-disassembler 1.1.2 (Rust crate 0.4.3), the SHA-256 fallback hashes
+// the full outer element rather than the first text-leaf child, so types
+// without per-type unique-id coverage - notably CustomApplication's
+// actionOverrides / profileActionOverrides - now round-trip faithfully
+// (one shard per distinct sibling) and produce meaningful perf signal.
 // Treat unset OR empty-string env vars as "use default". GitHub Actions
 // workflow_dispatch inputs come through as the empty string when not
 // provided, which `??` does not catch.
 function envList(name: string, fallback: string[]): string[] {
   const raw = process.env[name];
   if (!raw || raw.trim() === '') return fallback;
-  return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 function envString<T extends string>(name: string, fallback: T): T {
   const raw = process.env[name];
@@ -47,7 +46,17 @@ function envString<T extends string>(name: string, fallback: T): T {
 
 const PROFILE = envString<Profile>('PERF_PROFILE', 'large');
 const FORMATS = envList('PERF_FORMATS', ['xml', 'json', 'json5', 'yaml']);
-const DEFAULT_METADATA_TYPES = ['permissionset', 'mutingpermissionset', 'profile', 'flow', 'workflow', 'labels', 'bot'];
+const DEFAULT_METADATA_TYPES = [
+  'permissionset',
+  'mutingpermissionset',
+  'profile',
+  'flow',
+  'workflow',
+  'labels',
+  'bot',
+  'app',
+  'globalValueSet',
+];
 const METADATA_TYPES = envList('PERF_TYPES', DEFAULT_METADATA_TYPES);
 
 const FIXTURE_ROOT = resolve('perf-fixtures');
@@ -57,12 +66,27 @@ const FIXTURE_ROOT = resolve('perf-fixtures');
 // without paying the generation cost more than once.
 let fixtureBytes = 0;
 let fixtureFiles = 0;
+// Per-file byte sizes of the generator output, keyed by path relative to
+// FIXTURE_ROOT (e.g. "force-app/main/default/applications/Mega.app-meta.xml").
+// Used to guard against round-trip data loss: pass-1 recomposed bytes must
+// stay within RETENTION_THRESHOLD of the original. Anything below means the
+// decomposer collapsed distinct elements into one shard (the
+// `actionOverrides` hash collision bug fixed in config-disassembler 0.4.3).
+const fixtureFileBytes = new Map<string, number>();
+const RETENTION_THRESHOLD = 0.99;
 
 describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
   beforeAll(async () => {
     const result = await generate({ outDir: FIXTURE_ROOT, profile: PROFILE, cleanFirst: true });
     fixtureBytes = result.totalBytes;
     fixtureFiles = result.files.length;
+    fixtureFileBytes.clear();
+    for (const f of result.files) {
+      // generator emits POSIX-style relative paths already (e.g.
+      // "force-app/main/default/applications/Mega.app-meta.xml"), matching
+      // what snapshotFiles() produces below.
+      fixtureFileBytes.set(f.relPath, f.bytes);
+    }
     // eslint-disable-next-line no-console
     console.log(
       `\n[perf] generated ${fixtureFiles} fixture files (${formatBytes(fixtureBytes)}) using profile "${PROFILE}".\n` +
@@ -122,6 +146,24 @@ describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
 
         // Capture the recomposed XML so we can compare to a second round-trip.
         const firstRoundtrip = await snapshotFiles(workDir);
+
+        // ---- non-shrinkage guard ------------------------------------------
+        // Each recomposed -meta.xml must retain at least RETENTION_THRESHOLD
+        // of the original generator-emitted bytes for that file. This catches
+        // mass element-collapse regressions (e.g. the actionOverrides hash
+        // collision bug fixed in config-disassembler 0.4.3) that would still
+        // pass the pass1 == pass2 idempotence check below since both passes
+        // would produce the same shrunken output.
+        for (const [path, content] of firstRoundtrip) {
+          const original = fixtureFileBytes.get(path);
+          if (original === undefined) continue; // sfdx-project.json, generated files
+          const recomposed = Buffer.byteLength(content, 'utf8');
+          const ratio = recomposed / original;
+          expect(
+            ratio,
+            `data loss on round-trip for ${path}: ${recomposed}/${original} bytes (${(ratio * 100).toFixed(2)}%)`,
+          ).toBeGreaterThanOrEqual(RETENTION_THRESHOLD);
+        }
 
         // ---- pass 2: decompose then recompose (idempotence) ----------------
         const { sample: decompose2 } = await measure(`${format}.decompose.pass2`, async () => {


### PR DESCRIPTION
- Bump config-disassembler ^1.1.1 -> ^1.1.2 to pick up the Rust crate 0.4.3 UID-hash fix (full-element SHA-256 instead of first-text-leaf), which makes CustomApplication.actionOverrides / profileActionOverrides and other un-keyed siblings round-trip without data loss.
- Add `app` and `globalValueSet` to the default PERF_TYPES list now that they round-trip faithfully; update test/perf/README.md.
- Add a per-file non-shrinkage guard to test/perf/decompose.perf.ts: every recomposed -meta.xml must retain >=99% of the generator's original bytes. Catches mass element-collapse regressions that the pre-existing pass1 == pass2 idempotence check would have missed.
- Resort the two un-keyed <botSteps> siblings in the Welcome dialog of fixtures/package-dir-2/bots/Sample_Chat_Bot/v1.botVersion-meta.xml to match the new deterministic hash order. Only fixture affected.