### PR TITLE
chore(ci): publish perf trends to gh-pages dashboard

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -61,6 +61,11 @@ jobs:
     # noisy to be useful. Correctness is already covered by test.yml's matrix.
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # contents:write is needed only by the benchmark-action publish steps
+    # below, which push to the gh-pages branch. Read-only triggers (PR-style
+    # workflow_dispatch) skip those steps via their `if:` guard.
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -136,3 +141,53 @@ jobs:
             perf-results/
           retention-days: 90
           if-no-files-found: warn
+
+      # ---------------------------------------------------------------------
+      # Publish runtime + memory trends to the gh-pages dashboard.
+      #
+      # Gated to schedule (weekly) and workflow_call (release.yml) only so
+      # ad-hoc workflow_dispatch runs - which often vary the profile/types/
+      # formats inputs - don't pollute the timeline. The dashboard renders at
+      #   https://<owner>.github.io/sf-decomposer/dev/bench/runtime/
+      #   https://<owner>.github.io/sf-decomposer/dev/bench/memory/
+      # First publish creates the gh-pages branch automatically. Pages must
+      # be enabled in repo settings (Source: Deploy from branch -> gh-pages).
+      # ---------------------------------------------------------------------
+      - name: Convert perf-results to benchmark-action JSON
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_call'
+        run: node scripts/perf-to-benchmark.mjs
+
+      - name: Publish runtime benchmark
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_call'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Decompose Runtime
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-runtime.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # GH-hosted runners can swing 20-30% on the same workload; 150% is
+          # loose enough to avoid noise but still flag a genuine 1.5x regression.
+          alert-threshold: '150%'
+          fail-on-alert: false
+          comment-on-alert: true
+          summary-always: true
+          benchmark-data-dir-path: dev/bench/runtime
+
+      - name: Publish memory benchmark
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_call'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Decompose Memory
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # gh-pages was already fetched by the runtime step above; skip the
+          # second fetch to halve checkout time.
+          skip-fetch-gh-pages: true
+          # Memory deltas are noisier than wall-time; use a wider band.
+          alert-threshold: '200%'
+          fail-on-alert: false
+          summary-always: true
+          benchmark-data-dir-path: dev/bench/memory

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ node_modules
 # performance fixtures (generated, large, deterministic) and timing artifacts
 perf-fixtures
 perf-results
+# benchmark-action/github-action-benchmark inputs (built from perf-results in CI)
+perf-runtime.json
+perf-memory.json
 
 # --
 # put files here you don't want cleaned with sf-clean

--- a/scripts/perf-to-benchmark.mjs
+++ b/scripts/perf-to-benchmark.mjs
@@ -1,0 +1,54 @@
+// Convert perf-results/<stamp>-<profile>-<format>.json reports written by
+// test/perf/utils/measure.ts#writeReport into the flat metric arrays consumed
+// by benchmark-action/github-action-benchmark (customSmallerIsBetter mode).
+//
+// Inputs:  perf-results/*.json
+// Outputs: perf-runtime.json - sample.elapsedMs in ms, one entry per
+//                              (profile, format, sample.label)
+//          perf-memory.json  - sample.rssDeltaBytes in MB, same keys
+//
+// One metric per (profile, format, label) tuple; if multiple reports cover
+// the same tuple (e.g. a re-run within the same job) only the most recent
+// timestamp is kept so the dashboard timeline stays one datapoint per run.
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const dir = 'perf-results';
+let files;
+try {
+  files = (await readdir(dir)).filter((f) => f.endsWith('.json'));
+} catch {
+  console.error(`No ${dir}/ directory; nothing to convert.`);
+  process.exit(0);
+}
+if (files.length === 0) {
+  console.error(`${dir}/ has no JSON reports; nothing to convert.`);
+  process.exit(0);
+}
+
+const latest = new Map();
+for (const f of files.sort()) {
+  const r = JSON.parse(await readFile(join(dir, f), 'utf8'));
+  latest.set(`${r.profile}|${r.format}`, r);
+}
+
+const runtime = [];
+const memory = [];
+for (const r of latest.values()) {
+  for (const s of r.samples) {
+    // sample.label already begins with the format (e.g. "xml.decompose.pass1");
+    // prefix only the profile to avoid stuttering.
+    const name = `${r.profile}.${s.label}`;
+    runtime.push({ name, unit: 'ms', value: Number(s.elapsedMs.toFixed(2)) });
+    memory.push({
+      name,
+      unit: 'MB',
+      value: Number((s.rssDeltaBytes / 1024 / 1024).toFixed(3)),
+    });
+  }
+}
+
+await writeFile('perf-runtime.json', JSON.stringify(runtime, null, 2) + '\n', 'utf8');
+await writeFile('perf-memory.json', JSON.stringify(memory, null, 2) + '\n', 'utf8');
+console.log(`perf-to-benchmark: wrote ${runtime.length} runtime + ${memory.length} memory metrics.`);

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -91,6 +91,31 @@ Each test writes a JSON report to
 These files are gitignored. Plot them, diff them between branches, or commit
 them to a separate repo to track perf trends over time.
 
+## Published trend dashboard
+
+CI runs that originate from `schedule` (weekly) or `workflow_call`
+(release.yml) also convert the per-run reports into the flat metric arrays
+consumed by [`benchmark-action/github-action-benchmark`][bench] and push them
+to the `gh-pages` branch:
+
+- Runtime: `https://<owner>.github.io/sf-decomposer/dev/bench/runtime/`
+- Memory: `https://<owner>.github.io/sf-decomposer/dev/bench/memory/`
+
+The conversion is done by `scripts/perf-to-benchmark.mjs`, which collapses
+`perf-results/*.json` into `perf-runtime.json` (`elapsedMs`) and
+`perf-memory.json` (`rssDeltaBytes` in MB). Ad-hoc `workflow_dispatch` runs
+intentionally **do not** publish, since they often vary profile/types/formats
+inputs and would pollute the timeline.
+
+To enable on first run:
+
+1. Settings -> Pages -> Source: Deploy from branch -> Branch: `gh-pages`
+   (the workflow creates the branch on first publish).
+2. Trigger one publish-eligible run (e.g. `gh workflow run perf.yml` from a
+   release tag, or wait for the next Monday cron).
+
+[bench]: https://github.com/benchmark-action/github-action-benchmark
+
 ## Generating fixtures standalone
 
 ```bash


### PR DESCRIPTION
Add a phase-1 perf trend dashboard via benchmark-action/github-action- benchmark, modeled after sf-git-merge-driver's reusable-perf workflow.

- scripts/perf-to-benchmark.mjs: flatten perf-results/*.json reports into the customSmallerIsBetter shape the action expects, one metric per (profile, sample.label) tuple, deduped to the most recent run.
- .github/workflows/perf.yml: add converter step and two publish steps (runtime + memory) gated to schedule + workflow_call only, so ad-hoc workflow_dispatch runs don't pollute the timeline. alert-threshold is 150% for runtime and 200% for memory to absorb GH-hosted runner noise.
- Job-level permissions: contents: write so the action can push to gh-pages. Pages must be enabled in repo settings on first publish.
- test/perf/README.md: document the dashboard URLs and setup.
- .gitignore: ignore the transient perf-runtime.json / perf-memory.json CI artifacts.