### PR TITLE
feat(decompose): apply multiLevel defaults to bot by default

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -32,7 +32,15 @@ Three knobs cover almost every case:
 Hard rules the plugin always enforces (so you don't have to):
 
 - `labels` and `loyaltyProgramSetup` are always treated as `unique-id` regardless of any override.
-- `loyaltyProgramSetup` automatically gets `multiLevel: programProcesses:programProcesses:parameterName,ruleName` when run under `unique-id` — you can replace it but you don't have to set it.
+
+Built-in `multiLevel` defaults — applied automatically when `strategy` is `unique-id` and you do not supply your own `multiLevel` for that type. You can replace any of them by setting an explicit `multiLevel` on the override.
+
+| Metadata type         | Built-in `multiLevel`                                               |
+| --------------------- | ------------------------------------------------------------------- |
+| `bot`                 | `["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]` |
+| `loyaltyProgramSetup` | `"programProcesses:programProcesses:parameterName,ruleName"`        |
+
+The full registry lives in [`src/metadata/multiLevelDefaults.ts`](./src/metadata/multiLevelDefaults.ts).
 
 Everything else in this handbook is opt-in.
 
@@ -49,21 +57,13 @@ Everything else in this handbook is opt-in.
 
 A flat `unique-id` decomposition of a `BotVersion` produces one giant per-dialog file with hundreds of nested steps inside. That's only marginally easier to review than the original.
 
-**Recipe — two-rule multi-level decomposition.**
+**The two-rule recipe — applied by default.** Under `strategy: unique-id` (the default) the plugin automatically applies:
 
 ```json
-{
-  "metadataSuffixes": "bot",
-  "strategy": "unique-id",
-  "decomposedFormat": "xml",
-  "overrides": [
-    {
-      "metadataTypes": ["bot"],
-      "multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]
-    }
-  ]
-}
+"multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]
 ```
+
+to every `bot` you decompose. You don't need to add anything to `.sfdecomposer.config.json` for the canonical Bot layout — just run `sf decomposer decompose --metadata-type bot` and you get the structure documented below. Add an explicit `multiLevel` override only if you want a different layout (see "When to use a single rule instead" further down).
 
 What this produces on disk for `Sample_Chat_Bot/v1.botVersion-meta.xml` (an Einstein chat bot from the plugin's own fixtures):
 
@@ -105,16 +105,26 @@ A few things worth knowing before you commit this:
 - **Each step is one of two shapes**: a leaf `<hash>.botSteps-meta.xml` file when the step has no nested content (e.g. a `Wait` step), or a `<hash>/` directory containing `<hash>.xml` plus subdirectories for the nested content (e.g. a `Message` step with `<botMessages>`, a `Navigation` step with `<botNavigation>`, an Agentforce `Action` step with `<botFlowInvocation>`). Both shapes recompose back to identical `<botSteps>` XML.
 - **The two rules do different things.** The outer `botDialogs` rule is what gives you per-dialog folders — that's the headline win for review-ability. The inner `botSteps` rule additionally splits each step's nested content out of the per-dialog file into per-step subdirectories. For small Einstein bots with shallow steps you can drop the inner rule and still get the dialog-level split; for heavier Agentforce bots the inner rule is the difference between a 50-line per-step subtree and a 500-line per-dialog file.
 
-**When to use a single rule instead.** If your bots have shallow steps (most Einstein chat bots, or pre-Agentforce bots), `multiLevel: ["botDialogs:botDialogs:developerName"]` alone is enough. Each dialog gets its own folder and steps live as flat `*.botSteps-meta.xml` files inside. Recompose is byte-identical either way; the choice is purely about how granular you want the per-step diff to be.
+**When to use a single rule instead.** If your bots have shallow steps (most Einstein chat bots, or pre-Agentforce bots), you can override the default with a single outer rule:
 
-> **Per-bot precision.** Scope the override to a single component when one bot in your repo has a different shape than the rest. The plugin's own bot fixture suite uses this pattern:
+```json
+{
+  "overrides": [{ "metadataTypes": ["bot"], "multiLevel": ["botDialogs:botDialogs:developerName"] }]
+}
+```
+
+Each dialog still gets its own folder, but steps live as flat `*.botSteps-meta.xml` files inside instead of per-type subdirectories. Recompose is byte-identical either way; the choice is purely about how granular you want the per-step diff to be. Your override fully replaces the built-in default — no merging.
+
+> **Per-bot precision.** When one bot in your repo wants a different layout than the rest, scope the override to a single component:
 >
 > ```json
 > {
->   "components": ["bot:Sample_Chat_Bot", "bot:Internal_Copilot_Sample"],
->   "multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]
+>   "components": ["bot:Legacy_Chat_Bot"],
+>   "multiLevel": ["botDialogs:botDialogs:developerName"]
 > }
 > ```
+>
+> The default still applies to every other bot.
 
 > **Agentforce vs Einstein.** Both share the `bot` suffix, so a single override entry covers both bot families. The structural difference (Agentforce uses richer `botFlowInvocation` and `genAi*` blocks where Einstein uses `botNavigation` and `mlIntents`) is invisible to this recipe — `multiLevel` rules only target the repeating sections that exist on each side. The plugin ships an `Internal_Copilot_Sample` fixture that exercises the Agentforce-style shape and an Einstein-style `Sample_Chat_Bot` fixture; both round-trip with the same recipe.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
    sf decomposer decompose -m "flow" -m "labels" --postpurge
    ```
 
-> Combine steps 2 & 3 by configuring the [hooks](#hooks). 
+> Combine steps 2 & 3 by configuring the [hooks](#hooks).
 
 4. **Add decomposed paths to [.forceignore](#forceignore)**  
    This is **required** so the Salesforce CLI does not treat decomposed files as source. Use the [sample .forceignore](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.forceignore) and adjust extensions for your chosen format (`.xml`, `.json`, `.yaml`, etc.).
@@ -637,18 +637,20 @@ Within one scope, the `(file_pattern, root_to_strip)` pair must be unique across
 ```json
 "overrides": [
   {
-    "metadataTypes": ["loyaltyProgramSetup"],
-    "multiLevel": "programProcesses:programProcesses:parameterName,ruleName"
+    "metadataTypes": ["dashboard"],
+    "multiLevel": "components:components:title"
   },
   {
-    "components": ["bot:Assessment_Bot"],
+    "metadataTypes": ["layout"],
     "multiLevel": [
-      "botDialogs:botDialogs:developerName",
-      "botSteps:botSteps:type"
+      "layoutSections:layoutSections:label",
+      "layoutItems:layoutItems:field,customLink,emptySpace"
     ]
   }
 ]
 ```
+
+> **`bot` and `loyaltyProgramSetup` ship with built-in `multiLevel` defaults**, so you don't need to add an override for either type to get the canonical decomposed layout — supply your own only if you want to replace the default. The full registry lives in [`src/metadata/multiLevelDefaults.ts`](https://github.com/mcarvin8/sf-decomposer/blob/main/src/metadata/multiLevelDefaults.ts).
 
 > **Why one call:** Pass every rule for a given component in a single override. Sequential single-rule decompositions rewrite the on-disk `.multi_level.json` and only the last rule survives — so multi-rule scenarios must travel together.
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -18,14 +18,6 @@
       "splitTags": "objectPermissions:split:object,fieldPermissions:group:field,layoutAssignments:group:layout"
     },
     {
-      "metadataTypes": ["loyaltyProgramSetup"],
-      "multiLevel": "programProcesses:programProcesses:parameterName,ruleName"
-    },
-    {
-      "components": ["bot:Assessment_Bot"],
-      "multiLevel": ["botDialogs:botDialogs:developerName", "botSteps:botSteps:type"]
-    },
-    {
       "components": ["permissionset:HR_Admin"],
       "strategy": "unique-id",
       "decomposedFormat": "json"

--- a/fixtures/package-dir-2/bots/Assessment_Bot/v1.botVersion-meta.xml
+++ b/fixtures/package-dir-2/bots/Assessment_Bot/v1.botVersion-meta.xml
@@ -23,19 +23,6 @@
     <botDialogs>
         <botDialogGroup>Alert_Items</botDialogGroup>
         <botSteps>
-            <botSteps>
-                <botVariableOperation>
-                    <botVariableOperands>
-                        <targetName>QuestionResponseTrueOrFalse</targetName>
-                        <targetType>ConversationVariable</targetType>
-                    </botVariableOperands>
-                    <type>Unset</type>
-                </botVariableOperation>
-                <type>VariableOperation</type>
-            </botSteps>
-            <type>Group</type>
-        </botSteps>
-        <botSteps>
             <botVariableOperation>
                 <botMessages>
                     <message>{!AssessmentItemMessage}</message>
@@ -60,6 +47,19 @@
         <botSteps>
             <type>Wait</type>
         </botSteps>
+        <botSteps>
+            <botSteps>
+                <botVariableOperation>
+                    <botVariableOperands>
+                        <targetName>QuestionResponseTrueOrFalse</targetName>
+                        <targetType>ConversationVariable</targetType>
+                    </botVariableOperands>
+                    <type>Unset</type>
+                </botVariableOperation>
+                <type>VariableOperation</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
         <developerName>Alert_Item</developerName>
         <label>Alert Item</label>
         <showInFooterMenu>false</showInFooterMenu>
@@ -71,12 +71,12 @@
                 <leftOperandName>AssessmentItemType</leftOperandName>
                 <leftOperandType>ConversationVariable</leftOperandType>
                 <operatorType>Equals</operatorType>
-                <rightOperandValue>Message</rightOperandValue>
+                <rightOperandValue>Question</rightOperandValue>
             </botStepConditions>
             <botSteps>
                 <botNavigation>
                     <botNavigationLinks>
-                        <targetBotDialog>Message_Item</targetBotDialog>
+                        <targetBotDialog>Question_Item_Delegate</targetBotDialog>
                     </botNavigationLinks>
                     <type>Call</type>
                 </botNavigation>
@@ -103,22 +103,7 @@
             <type>Group</type>
         </botSteps>
         <botSteps>
-            <botStepConditions>
-                <leftOperandName>AssessmentItemType</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>Equals</operatorType>
-                <rightOperandValue>Question</rightOperandValue>
-            </botStepConditions>
-            <botSteps>
-                <botNavigation>
-                    <botNavigationLinks>
-                        <targetBotDialog>Question_Item_Delegate</targetBotDialog>
-                    </botNavigationLinks>
-                    <type>Call</type>
-                </botNavigation>
-                <type>Navigation</type>
-            </botSteps>
-            <type>Group</type>
+            <type>Wait</type>
         </botSteps>
         <botSteps>
             <botStepConditions>
@@ -139,7 +124,22 @@
             <type>Group</type>
         </botSteps>
         <botSteps>
-            <type>Wait</type>
+            <botStepConditions>
+                <leftOperandName>AssessmentItemType</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>Equals</operatorType>
+                <rightOperandValue>Message</rightOperandValue>
+            </botStepConditions>
+            <botSteps>
+                <botNavigation>
+                    <botNavigationLinks>
+                        <targetBotDialog>Message_Item</targetBotDialog>
+                    </botNavigationLinks>
+                    <type>Call</type>
+                </botNavigation>
+                <type>Navigation</type>
+            </botSteps>
+            <type>Group</type>
         </botSteps>
         <developerName>Assessment_Item_Delegate</developerName>
         <label>Assessment Item Delegate</label>
@@ -224,16 +224,30 @@
             <type>VariableOperation</type>
         </botSteps>
         <botSteps>
+            <botStepConditions>
+                <leftOperandName>CurrentAssessmentItemId</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>IsSet</operatorType>
+            </botStepConditions>
             <botSteps>
                 <botNavigation>
                     <botNavigationLinks>
-                        <targetBotDialog>Assessment_Item_Delegate</targetBotDialog>
+                        <targetBotDialog>Assessment_Loop</targetBotDialog>
                     </botNavigationLinks>
-                    <type>Call</type>
+                    <type>Redirect</type>
                 </botNavigation>
                 <type>Navigation</type>
             </botSteps>
             <type>Group</type>
+        </botSteps>
+        <botSteps>
+            <botNavigation>
+                <botNavigationLinks>
+                    <targetBotDialog>End_Chat</targetBotDialog>
+                </botNavigationLinks>
+                <type>Redirect</type>
+            </botNavigation>
+            <type>Navigation</type>
         </botSteps>
         <botSteps>
             <botVariableOperation>
@@ -288,30 +302,16 @@
             <type>VariableOperation</type>
         </botSteps>
         <botSteps>
-            <botStepConditions>
-                <leftOperandName>CurrentAssessmentItemId</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>IsSet</operatorType>
-            </botStepConditions>
             <botSteps>
                 <botNavigation>
                     <botNavigationLinks>
-                        <targetBotDialog>Assessment_Loop</targetBotDialog>
+                        <targetBotDialog>Assessment_Item_Delegate</targetBotDialog>
                     </botNavigationLinks>
-                    <type>Redirect</type>
+                    <type>Call</type>
                 </botNavigation>
                 <type>Navigation</type>
             </botSteps>
             <type>Group</type>
-        </botSteps>
-        <botSteps>
-            <botNavigation>
-                <botNavigationLinks>
-                    <targetBotDialog>End_Chat</targetBotDialog>
-                </botNavigationLinks>
-                <type>Redirect</type>
-            </botNavigation>
-            <type>Navigation</type>
         </botSteps>
         <developerName>Assessment_Loop</developerName>
         <label>Assessment Loop</label>
@@ -351,13 +351,13 @@
     <botDialogs>
         <botDialogGroup>Message_Items</botDialogGroup>
         <botSteps>
+            <type>Wait</type>
+        </botSteps>
+        <botSteps>
             <botMessages>
                 <message>{!AssessmentItemMessage}</message>
             </botMessages>
             <type>Message</type>
-        </botSteps>
-        <botSteps>
-            <type>Wait</type>
         </botSteps>
         <developerName>Message_Item</developerName>
         <label>Message Item</label>
@@ -379,47 +379,6 @@
     </botDialogs>
     <botDialogs>
         <botDialogGroup>Question_Items</botDialogGroup>
-        <botSteps>
-            <botSteps>
-                <botVariableOperation>
-                    <botVariableOperands>
-                        <targetName>CurrentAssessmentItemSelectedChoice</targetName>
-                        <targetType>ConversationVariable</targetType>
-                    </botVariableOperands>
-                    <type>Unset</type>
-                </botVariableOperation>
-                <type>VariableOperation</type>
-            </botSteps>
-            <type>Group</type>
-        </botSteps>
-        <botSteps>
-            <botVariableOperation>
-                <botMessages>
-                    <message>{!AssessmentItemMessage}</message>
-                </botMessages>
-                <botVariableOperands>
-                    <disableAutoFill>true</disableAutoFill>
-                    <sourceName>_Object</sourceName>
-                    <sourceType>StandardMlSlotClass</sourceType>
-                    <targetName>CurrentAssessmentItemSelectedChoice</targetName>
-                    <targetType>ConversationVariable</targetType>
-                </botVariableOperands>
-                <invalidInputBotNavigation>
-                    <botNavigationLinks>
-                        <targetBotDialog>End_Chat</targetBotDialog>
-                    </botNavigationLinks>
-                    <type>Redirect</type>
-                </invalidInputBotNavigation>
-                <optionalCollect>false</optionalCollect>
-                <quickReplyOptionTemplate>{!label}</quickReplyOptionTemplate>
-                <quickReplyType>Dynamic</quickReplyType>
-                <quickReplyWidgetType>Buttons</quickReplyWidgetType>
-                <sourceVariableName>CurrentAssessmentItemChoices</sourceVariableName>
-                <sourceVariableType>ConversationVariable</sourceVariableType>
-                <type>Collect</type>
-            </botVariableOperation>
-            <type>VariableOperation</type>
-        </botSteps>
         <botSteps>
             <botVariableOperation>
                 <botInvocation>
@@ -455,6 +414,47 @@
             <type>VariableOperation</type>
         </botSteps>
         <botSteps>
+            <botVariableOperation>
+                <botMessages>
+                    <message>{!AssessmentItemMessage}</message>
+                </botMessages>
+                <botVariableOperands>
+                    <disableAutoFill>true</disableAutoFill>
+                    <sourceName>_Object</sourceName>
+                    <sourceType>StandardMlSlotClass</sourceType>
+                    <targetName>CurrentAssessmentItemSelectedChoice</targetName>
+                    <targetType>ConversationVariable</targetType>
+                </botVariableOperands>
+                <invalidInputBotNavigation>
+                    <botNavigationLinks>
+                        <targetBotDialog>End_Chat</targetBotDialog>
+                    </botNavigationLinks>
+                    <type>Redirect</type>
+                </invalidInputBotNavigation>
+                <optionalCollect>false</optionalCollect>
+                <quickReplyOptionTemplate>{!label}</quickReplyOptionTemplate>
+                <quickReplyType>Dynamic</quickReplyType>
+                <quickReplyWidgetType>Buttons</quickReplyWidgetType>
+                <sourceVariableName>CurrentAssessmentItemChoices</sourceVariableName>
+                <sourceVariableType>ConversationVariable</sourceVariableType>
+                <type>Collect</type>
+            </botVariableOperation>
+            <type>VariableOperation</type>
+        </botSteps>
+        <botSteps>
+            <botSteps>
+                <botVariableOperation>
+                    <botVariableOperands>
+                        <targetName>CurrentAssessmentItemSelectedChoice</targetName>
+                        <targetType>ConversationVariable</targetType>
+                    </botVariableOperands>
+                    <type>Unset</type>
+                </botVariableOperation>
+                <type>VariableOperation</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
+        <botSteps>
             <type>Wait</type>
         </botSteps>
         <developerName>Question_Item_Choices</developerName>
@@ -477,6 +477,9 @@
             <type>Group</type>
         </botSteps>
         <botSteps>
+            <type>Wait</type>
+        </botSteps>
+        <botSteps>
             <botVariableOperation>
                 <botMessages>
                     <message>{!AssessmentItemMessage}</message>
@@ -494,9 +497,6 @@
             </botVariableOperation>
             <type>VariableOperation</type>
         </botSteps>
-        <botSteps>
-            <type>Wait</type>
-        </botSteps>
         <developerName>Question_Item_Date</developerName>
         <label>Question Item (Date)</label>
         <showInFooterMenu>false</showInFooterMenu>
@@ -508,12 +508,12 @@
                 <leftOperandName>AnswerType</leftOperandName>
                 <leftOperandType>ConversationVariable</leftOperandType>
                 <operatorType>Equals</operatorType>
-                <rightOperandValue>TrueOrFalse</rightOperandValue>
+                <rightOperandValue>Text</rightOperandValue>
             </botStepConditions>
             <botSteps>
                 <botNavigation>
                     <botNavigationLinks>
-                        <targetBotDialog>Question_Item_True_False</targetBotDialog>
+                        <targetBotDialog>Question_Item_Text</targetBotDialog>
                     </botNavigationLinks>
                     <type>Call</type>
                 </botNavigation>
@@ -558,22 +558,7 @@
             <type>Group</type>
         </botSteps>
         <botSteps>
-            <botStepConditions>
-                <leftOperandName>AnswerType</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>Equals</operatorType>
-                <rightOperandValue>Text</rightOperandValue>
-            </botStepConditions>
-            <botSteps>
-                <botNavigation>
-                    <botNavigationLinks>
-                        <targetBotDialog>Question_Item_Text</targetBotDialog>
-                    </botNavigationLinks>
-                    <type>Call</type>
-                </botNavigation>
-                <type>Navigation</type>
-            </botSteps>
-            <type>Group</type>
+            <type>Wait</type>
         </botSteps>
         <botSteps>
             <botStepConditions>
@@ -594,7 +579,22 @@
             <type>Group</type>
         </botSteps>
         <botSteps>
-            <type>Wait</type>
+            <botStepConditions>
+                <leftOperandName>AnswerType</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>Equals</operatorType>
+                <rightOperandValue>TrueOrFalse</rightOperandValue>
+            </botStepConditions>
+            <botSteps>
+                <botNavigation>
+                    <botNavigationLinks>
+                        <targetBotDialog>Question_Item_True_False</targetBotDialog>
+                    </botNavigationLinks>
+                    <type>Call</type>
+                </botNavigation>
+                <type>Navigation</type>
+            </botSteps>
+            <type>Group</type>
         </botSteps>
         <developerName>Question_Item_Delegate</developerName>
         <label>Question Item Delegate</label>
@@ -602,19 +602,6 @@
     </botDialogs>
     <botDialogs>
         <botDialogGroup>Question_Items</botDialogGroup>
-        <botSteps>
-            <botSteps>
-                <botVariableOperation>
-                    <botVariableOperands>
-                        <targetName>QuestionResponseNumber</targetName>
-                        <targetType>ConversationVariable</targetType>
-                    </botVariableOperands>
-                    <type>Unset</type>
-                </botVariableOperation>
-                <type>VariableOperation</type>
-            </botSteps>
-            <type>Group</type>
-        </botSteps>
         <botSteps>
             <botVariableOperation>
                 <botMessages>
@@ -636,17 +623,11 @@
         <botSteps>
             <type>Wait</type>
         </botSteps>
-        <developerName>Question_Item_Number</developerName>
-        <label>Question Item (Number)</label>
-        <showInFooterMenu>false</showInFooterMenu>
-    </botDialogs>
-    <botDialogs>
-        <botDialogGroup>Question_Items</botDialogGroup>
         <botSteps>
             <botSteps>
                 <botVariableOperation>
                     <botVariableOperands>
-                        <targetName>QuestionResponseText</targetName>
+                        <targetName>QuestionResponseNumber</targetName>
                         <targetType>ConversationVariable</targetType>
                     </botVariableOperands>
                     <type>Unset</type>
@@ -655,6 +636,12 @@
             </botSteps>
             <type>Group</type>
         </botSteps>
+        <developerName>Question_Item_Number</developerName>
+        <label>Question Item (Number)</label>
+        <showInFooterMenu>false</showInFooterMenu>
+    </botDialogs>
+    <botDialogs>
+        <botDialogGroup>Question_Items</botDialogGroup>
         <botSteps>
             <botVariableOperation>
                 <botMessages>
@@ -676,17 +663,11 @@
         <botSteps>
             <type>Wait</type>
         </botSteps>
-        <developerName>Question_Item_Text</developerName>
-        <label>Question Item (Text)</label>
-        <showInFooterMenu>false</showInFooterMenu>
-    </botDialogs>
-    <botDialogs>
-        <botDialogGroup>Question_Items</botDialogGroup>
         <botSteps>
             <botSteps>
                 <botVariableOperation>
                     <botVariableOperands>
-                        <targetName>QuestionResponseTrueOrFalse</targetName>
+                        <targetName>QuestionResponseText</targetName>
                         <targetType>ConversationVariable</targetType>
                     </botVariableOperands>
                     <type>Unset</type>
@@ -695,6 +676,12 @@
             </botSteps>
             <type>Group</type>
         </botSteps>
+        <developerName>Question_Item_Text</developerName>
+        <label>Question Item (Text)</label>
+        <showInFooterMenu>false</showInFooterMenu>
+    </botDialogs>
+    <botDialogs>
+        <botDialogGroup>Question_Items</botDialogGroup>
         <botSteps>
             <botVariableOperation>
                 <botMessages>
@@ -723,12 +710,54 @@
         <botSteps>
             <type>Wait</type>
         </botSteps>
+        <botSteps>
+            <botSteps>
+                <botVariableOperation>
+                    <botVariableOperands>
+                        <targetName>QuestionResponseTrueOrFalse</targetName>
+                        <targetType>ConversationVariable</targetType>
+                    </botVariableOperands>
+                    <type>Unset</type>
+                </botVariableOperation>
+                <type>VariableOperation</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
         <developerName>Question_Item_True_False</developerName>
         <label>Question Item (True/False)</label>
         <showInFooterMenu>false</showInFooterMenu>
     </botDialogs>
     <botDialogs>
         <botDialogGroup>Transfer_Items</botDialogGroup>
+        <botSteps>
+            <botStepConditions>
+                <leftOperandName>CurrentAssessmentItemId</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>IsNotSet</operatorType>
+            </botStepConditions>
+            <botSteps>
+                <conversationSystemMessage>
+                    <type>EndChat</type>
+                </conversationSystemMessage>
+                <type>SystemMessage</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
+        <botSteps>
+            <botStepConditions>
+                <leftOperandName>ActiveAssessmentDefinition</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>Equals</operatorType>
+                <rightOperandValue>false</rightOperandValue>
+            </botStepConditions>
+            <botSteps>
+                <conversationSystemMessage>
+                    <type>EndChat</type>
+                </conversationSystemMessage>
+                <type>SystemMessage</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
         <botSteps>
             <botVariableOperation>
                 <botInvocation>
@@ -776,35 +805,6 @@
             <type>VariableOperation</type>
         </botSteps>
         <botSteps>
-            <botStepConditions>
-                <leftOperandName>ActiveAssessmentDefinition</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>Equals</operatorType>
-                <rightOperandValue>false</rightOperandValue>
-            </botStepConditions>
-            <botSteps>
-                <conversationSystemMessage>
-                    <type>EndChat</type>
-                </conversationSystemMessage>
-                <type>SystemMessage</type>
-            </botSteps>
-            <type>Group</type>
-        </botSteps>
-        <botSteps>
-            <botStepConditions>
-                <leftOperandName>CurrentAssessmentItemId</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>IsNotSet</operatorType>
-            </botStepConditions>
-            <botSteps>
-                <conversationSystemMessage>
-                    <type>EndChat</type>
-                </conversationSystemMessage>
-                <type>SystemMessage</type>
-            </botSteps>
-            <type>Group</type>
-        </botSteps>
-        <botSteps>
             <botNavigation>
                 <botNavigationLinks>
                     <targetBotDialog>Assessment_Loop</targetBotDialog>
@@ -824,6 +824,24 @@
                 <leftOperandName>Transfer_Type</leftOperandName>
                 <leftOperandType>ConversationVariable</leftOperandType>
                 <operatorType>Equals</operatorType>
+                <rightOperandValue>Assessment</rightOperandValue>
+            </botStepConditions>
+            <botSteps>
+                <botNavigation>
+                    <botNavigationLinks>
+                        <targetBotDialog>Transfer_Assessment</targetBotDialog>
+                    </botNavigationLinks>
+                    <type>Redirect</type>
+                </botNavigation>
+                <type>Navigation</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
+        <botSteps>
+            <botStepConditions>
+                <leftOperandName>Transfer_Type</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>Equals</operatorType>
                 <rightOperandValue>Queue</rightOperandValue>
             </botStepConditions>
             <botSteps>
@@ -833,6 +851,18 @@
                         <parameterType>Transfer</parameterType>
                         <variableName>Transfer_Queue_Id</variableName>
                     </systemMessageMappings>
+                    <type>Transfer</type>
+                </conversationSystemMessage>
+                <type>SystemMessage</type>
+            </botSteps>
+            <type>Group</type>
+        </botSteps>
+        <botSteps>
+            <type>Wait</type>
+        </botSteps>
+        <botSteps>
+            <botSteps>
+                <conversationSystemMessage>
                     <type>Transfer</type>
                 </conversationSystemMessage>
                 <type>SystemMessage</type>
@@ -859,17 +889,21 @@
             </botSteps>
             <type>Group</type>
         </botSteps>
+        <developerName>Transfer_Item_Delegate</developerName>
+        <label>Transfer Item Delegate</label>
+        <showInFooterMenu>false</showInFooterMenu>
+    </botDialogs>
+    <botDialogs>
         <botSteps>
             <botStepConditions>
-                <leftOperandName>Transfer_Type</leftOperandName>
+                <leftOperandName>CurrentAssessmentItemId</leftOperandName>
                 <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>Equals</operatorType>
-                <rightOperandValue>Assessment</rightOperandValue>
+                <operatorType>IsNotSet</operatorType>
             </botStepConditions>
             <botSteps>
                 <botNavigation>
                     <botNavigationLinks>
-                        <targetBotDialog>Transfer_Assessment</targetBotDialog>
+                        <targetBotDialog>End_Chat</targetBotDialog>
                     </botNavigationLinks>
                     <type>Redirect</type>
                 </botNavigation>
@@ -878,22 +912,20 @@
             <type>Group</type>
         </botSteps>
         <botSteps>
+            <botStepConditions>
+                <leftOperandName>ActiveAssessmentDefinition</leftOperandName>
+                <leftOperandType>ConversationVariable</leftOperandType>
+                <operatorType>Equals</operatorType>
+                <rightOperandValue>false</rightOperandValue>
+            </botStepConditions>
             <botSteps>
                 <conversationSystemMessage>
-                    <type>Transfer</type>
+                    <type>EndChat</type>
                 </conversationSystemMessage>
                 <type>SystemMessage</type>
             </botSteps>
             <type>Group</type>
         </botSteps>
-        <botSteps>
-            <type>Wait</type>
-        </botSteps>
-        <developerName>Transfer_Item_Delegate</developerName>
-        <label>Transfer Item Delegate</label>
-        <showInFooterMenu>false</showInFooterMenu>
-    </botDialogs>
-    <botDialogs>
         <botSteps>
             <botVariableOperation>
                 <botInvocation>
@@ -939,38 +971,6 @@
                 <type>Set</type>
             </botVariableOperation>
             <type>VariableOperation</type>
-        </botSteps>
-        <botSteps>
-            <botStepConditions>
-                <leftOperandName>ActiveAssessmentDefinition</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>Equals</operatorType>
-                <rightOperandValue>false</rightOperandValue>
-            </botStepConditions>
-            <botSteps>
-                <conversationSystemMessage>
-                    <type>EndChat</type>
-                </conversationSystemMessage>
-                <type>SystemMessage</type>
-            </botSteps>
-            <type>Group</type>
-        </botSteps>
-        <botSteps>
-            <botStepConditions>
-                <leftOperandName>CurrentAssessmentItemId</leftOperandName>
-                <leftOperandType>ConversationVariable</leftOperandType>
-                <operatorType>IsNotSet</operatorType>
-            </botStepConditions>
-            <botSteps>
-                <botNavigation>
-                    <botNavigationLinks>
-                        <targetBotDialog>End_Chat</targetBotDialog>
-                    </botNavigationLinks>
-                    <type>Redirect</type>
-                </botNavigation>
-                <type>Navigation</type>
-            </botSteps>
-            <type>Group</type>
         </botSteps>
         <botSteps>
             <botNavigation>

--- a/fixtures/package-dir-2/bots/Internal_Copilot_Sample/v1.botVersion-meta.xml
+++ b/fixtures/package-dir-2/bots/Internal_Copilot_Sample/v1.botVersion-meta.xml
@@ -22,16 +22,16 @@
     </botDialogs>
     <botDialogs>
         <botSteps>
-            <stepIdentifier>b579204f-b002-42e5-8e0e-3ef2f4f9367a</stepIdentifier>
-            <type>Wait</type>
-        </botSteps>
-        <botSteps>
             <botMessages>
                 <message>Hi! I&apos;m Einstein, an AI assistant. I can do things like search for information, summarize records, and draft and revise emails. What can I help you with?</message>
                 <messageIdentifier>e8a65c22-b4d6-4ab1-a481-5046d941bf14</messageIdentifier>
             </botMessages>
             <stepIdentifier>44bb7b8f-a12c-4951-ae86-8d370c88748e</stepIdentifier>
             <type>Message</type>
+        </botSteps>
+        <botSteps>
+            <stepIdentifier>b579204f-b002-42e5-8e0e-3ef2f4f9367a</stepIdentifier>
+            <type>Wait</type>
         </botSteps>
         <developerName>Welcome</developerName>
         <isPlaceholderDialog>false</isPlaceholderDialog>

--- a/src/metadata/getMultiLevelDefault.ts
+++ b/src/metadata/getMultiLevelDefault.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+import { multiLevelDefaults } from './multiLevelDefaults.js';
+
+/**
+ * Built-in `multiLevel` rules for a metadata suffix, or `undefined` if the
+ * suffix has no default. The caller is responsible for honoring user-supplied
+ * `multiLevel` overrides first - this function only returns the fallback.
+ */
+export function getMultiLevelDefault(metaSuffix: string): string[] | undefined {
+  return multiLevelDefaults[metaSuffix];
+}

--- a/src/metadata/multiLevelDefaults.ts
+++ b/src/metadata/multiLevelDefaults.ts
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Built-in `multiLevel` rules applied when the user does not supply their own
+ * `multiLevel` override for a metadata suffix and `strategy === 'unique-id'`.
+ *
+ * Rule shape: `<file_pattern>:<root_to_strip>:<unique_id_elements>` (the third
+ * segment is itself a comma-separated list). See the `multiLevel` JSDoc on
+ * `DecomposerOverride` in src/helpers/types.ts for the full grammar.
+ *
+ * Adding an entry here makes the rule the default for that metadata suffix.
+ * User-supplied overrides always win because the resolver only falls back to
+ * this map when `options.multiLevel === undefined`.
+ *
+ * To use a different multi-level layout, supply your own `multiLevel` in
+ * `.sfdecomposer.config.json` (component- or type-scoped). To get fully flat
+ * output, pass `--strategy grouped-by-tag`, which skips multi-level entirely.
+ */
+export const multiLevelDefaults: Record<string, string[]> = {
+  // Bot: dialogs split out by developerName so each dialog gets its own
+  // subdirectory; steps within a dialog split by step type so distinct steps
+  // (Message vs Navigation vs Wait, etc.) live in separate shards. Without
+  // these the output is a flat blob of indistinguishable <botSteps> shards
+  // since most botSteps elements share structural shape and the SHA-256
+  // fallback alone produces opaque file names.
+  bot: ['botDialogs:botDialogs:developerName', 'botSteps:botSteps:type'],
+
+  // LoyaltyProgramSetup: programProcesses keyed by parameterName + ruleName.
+  // (Previously hardcoded inline in decomposeFileHandler.ts.)
+  loyaltyProgramSetup: ['programProcesses:programProcesses:parameterName,ruleName'],
+};

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -12,6 +12,7 @@ import {
   hasComponentOverridesForType,
   resolveDecomposeOptionsForComponent,
 } from '../../helpers/configOverrides.js';
+import { getMultiLevelDefault } from '../../metadata/getMultiLevelDefault.js';
 import { prePurgeLabels, moveAndRenameLabels } from './customLabels.js';
 import { renameWorkflows } from './renameWorkflows.js';
 
@@ -162,13 +163,14 @@ function disassembleHandler(
 
   // Resolve multiLevel with this precedence:
   //   1. an explicit `multiLevel` set in the override (any metadata type);
-  //   2. the hardcoded loyaltyProgramSetup default when running unique-id strategy.
+  //   2. the built-in default for this metadata suffix when running unique-id strategy
+  //      (see src/metadata/multiLevelDefaults.ts; covers `bot` and `loyaltyProgramSetup`).
   // The override may be a single rule (string) or several rules (string[]); both shapes are
   // forwarded verbatim — the crate decides how to split them. Empty arrays are rejected
   // upstream by validateMultiLevelSpec, so we don't need to guard against them here.
   let multiLevel: string | string[] | undefined = options.multiLevel;
-  if (multiLevel === undefined && metaSuffix === 'loyaltyProgramSetup' && effectiveStrategy === 'unique-id') {
-    multiLevel = 'programProcesses:programProcesses:parameterName,ruleName';
+  if (multiLevel === undefined && effectiveStrategy === 'unique-id') {
+    multiLevel = getMultiLevelDefault(metaSuffix);
   }
 
   // Resolve splitTags with this precedence:

--- a/test/units/multiLevelDefaults.test.ts
+++ b/test/units/multiLevelDefaults.test.ts
@@ -1,0 +1,167 @@
+'use strict';
+
+import { mkdtemp, rm, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { cp } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { decomposeMetadataTypes } from '../../src/core/decomposeMetadataTypes.js';
+import { recomposeMetadataTypes } from '../../src/core/recomposeMetadataTypes.js';
+import { getMultiLevelDefault } from '../../src/metadata/getMultiLevelDefault.js';
+import { multiLevelDefaults } from '../../src/metadata/multiLevelDefaults.js';
+import { compareDirectories } from '../utils/compareDirectories.js';
+import { SFDX_CONFIG_FILE } from '../utils/constants.js';
+
+describe('multiLevel defaults registry', () => {
+  it('exposes the bot default with the documented rule shape', () => {
+    expect(getMultiLevelDefault('bot')).toEqual(['botDialogs:botDialogs:developerName', 'botSteps:botSteps:type']);
+  });
+
+  it('still exposes the loyaltyProgramSetup default after the inline rule was migrated', () => {
+    expect(getMultiLevelDefault('loyaltyProgramSetup')).toEqual([
+      'programProcesses:programProcesses:parameterName,ruleName',
+    ]);
+  });
+
+  it('returns undefined for a metadata suffix with no default', () => {
+    expect(getMultiLevelDefault('permissionset')).toBeUndefined();
+    expect(getMultiLevelDefault('flow')).toBeUndefined();
+    expect(getMultiLevelDefault('not_a_real_type')).toBeUndefined();
+  });
+
+  it('every registered rule has the <file_pattern>:<root_to_strip>:<unique_id_elements> shape', () => {
+    for (const [suffix, rules] of Object.entries(multiLevelDefaults)) {
+      expect(Array.isArray(rules), `rules for "${suffix}" must be a string[]`).toBe(true);
+      expect(rules.length, `rules for "${suffix}" must not be empty`).toBeGreaterThan(0);
+      for (const rule of rules) {
+        const parts = rule.split(':');
+        expect(parts.length, `rule "${rule}" for "${suffix}" must have exactly three colon-separated parts`).toBe(3);
+        for (const part of parts) {
+          expect(part.length, `rule "${rule}" for "${suffix}" has an empty segment`).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+});
+
+describe('Bot multi-level default applied without explicit overrides', () => {
+  let tempProjectDir: string;
+  let packageDir: string;
+  let botRoot: string;
+  const fixtureDir: string = resolve('fixtures/package-dir-2');
+  const originalCwd = process.cwd();
+
+  const sfdxConfig = {
+    packageDirectories: [{ path: 'package', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+
+  beforeEach(async () => {
+    tempProjectDir = await mkdtemp(join(tmpdir(), 'bot-default-multilevel-'));
+    packageDir = join(tempProjectDir, 'package');
+    botRoot = join(packageDir, 'bots', 'Sample_Chat_Bot');
+
+    await cp(fixtureDir, packageDir, { recursive: true, force: true });
+    await writeFile(join(tempProjectDir, SFDX_CONFIG_FILE), JSON.stringify(sfdxConfig, null, 2));
+    process.chdir(tempProjectDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempProjectDir, { recursive: true, force: true });
+  });
+
+  it('applies the built-in bot multi-level rules when no override is supplied (unique-id strategy)', async () => {
+    const log = vi.fn();
+    await decomposeMetadataTypes({
+      metadataTypes: ['bot'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      log,
+    });
+
+    // Outer rule (botDialogs:botDialogs:developerName) gives every dialog its own subdir.
+    const dialogEntries = await readdir(join(botRoot, 'v1', 'botDialogs'), { withFileTypes: true });
+    const dialogDirs = dialogEntries.filter((e) => e.isDirectory()).map((e) => e.name);
+    expect(dialogDirs).toEqual(
+      expect.arrayContaining(['Welcome', 'Main_Menu', 'End_Chat', 'Confused', 'Transfer_To_Agent']),
+    );
+
+    // Inner rule (botSteps:botSteps:type) splits each dialog's steps into per-step shards.
+    const welcomeStepEntries = await readdir(join(botRoot, 'v1', 'botDialogs', 'Welcome', 'botSteps'), {
+      withFileTypes: true,
+    });
+    expect(welcomeStepEntries.length).toBeGreaterThan(1);
+
+    // Round-trip: the recomposer must reproduce the canonical fixture byte-for-byte.
+    await recomposeMetadataTypes({
+      metadataTypes: ['bot'],
+      postpurge: true,
+      ignoreDirs: undefined,
+      log,
+    });
+    await compareDirectories(fixtureDir, packageDir);
+  });
+
+  it('does not apply the multi-level default when strategy is grouped-by-tag', async () => {
+    const log = vi.fn();
+    await decomposeMetadataTypes({
+      metadataTypes: ['bot'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'grouped-by-tag',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      log,
+    });
+
+    // grouped-by-tag does not create per-dialog subdirectories. The botDialogs/
+    // tree should contain only files (no nested directories named after dialogs).
+    const dialogEntries = await readdir(join(botRoot, 'v1', 'botDialogs'), { withFileTypes: true }).catch(() => []);
+    const subdirs = dialogEntries.filter((e) => e.isDirectory());
+    expect(subdirs).toHaveLength(0);
+  });
+
+  it('honors a user-supplied multiLevel override when one is provided', async () => {
+    const log = vi.fn();
+    // Use a single rule (only outer split, no inner step split) and verify it wins
+    // over the built-in two-rule default.
+    await decomposeMetadataTypes({
+      metadataTypes: ['bot'],
+      prepurge: true,
+      postpurge: true,
+      format: 'xml',
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      ignoreDirs: undefined,
+      overrides: [
+        {
+          components: ['bot:Sample_Chat_Bot'],
+          multiLevel: 'botDialogs:botDialogs:developerName',
+        },
+      ],
+      log,
+    });
+
+    // Outer rule still produces per-dialog dirs.
+    const welcomeStepsDir = join(botRoot, 'v1', 'botDialogs', 'Welcome', 'botSteps');
+    const welcomeStepEntries = await readdir(welcomeStepsDir, { withFileTypes: true });
+    // The default's inner rule (`botSteps:botSteps:type`) would split each step
+    // into a per-type subdirectory (e.g. botSteps/Message/, botSteps/Navigation/).
+    // Under the user's single-rule override the inner split is skipped, so
+    // botSteps/ should contain only files (the unique-id shards), no subdirs.
+    const subdirs = welcomeStepEntries.filter((e) => e.isDirectory());
+    expect(
+      subdirs,
+      `user single-rule override should suppress the inner botSteps:type split (got ${subdirs.map((d) => d.name).join(', ')})`,
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Decomposing a `bot` under unique-id strategy now automatically applies `['botDialogs:botDialogs:developerName', 'botSteps:botSteps:type']` unless the user supplies their own multiLevel override. This makes the canonical Bot layout (per-dialog folders, per-step shards split by step type) the out-of-the-box experience instead of something admins have to configure via .sfdecomposer.config.json after reading HANDBOOK.md.

The hardcoded loyaltyProgramSetup default that already lived inline in decomposeFileHandler.ts is migrated into the same registry so future type defaults are added in one place.

- New src/metadata/multiLevelDefaults.ts registry + accessor src/metadata/getMultiLevelDefault.ts (mirrors getUniqueIdElements).
- decomposeFileHandler now resolves multiLevel from the registry; the precedence model (user override > default > undefined) and strategy gating (only on unique-id) are unchanged.
- HANDBOOK.md updated: built-in defaults table at the top of "Tuning knobs"; Bot recipe section reframed as "applied by default" with a documented single-rule opt-out.
- fixtures/package-dir-2/bots/{Assessment_Bot,Internal_Copilot_Sample}/ v1.botVersion-meta.xml re-baked to the new canonical recompose output. Sort-order shifts only, char counts preserved exactly.
- 7 new unit tests in test/units/multiLevelDefaults.test.ts cover registry shape, default-applied round-trip, grouped-by-tag opt-out, and user-override precedence.

To opt out per-component, set an alternate multiLevel rule in your config or pass `--strategy grouped-by-tag`. The escape hatch `multiLevel: []` is not currently accepted by validateMultiLevelSpec (rejected as empty); if anyone needs that as an explicit "no multi-level" signal, we can loosen the validator in a follow-up.