### PR TITLE
chore(ci): post perf-vs-baseline comparison comments on PRs

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -7,10 +7,16 @@
 #                          updates, runner-image refreshes, V8/Rust upstream.
 #   - workflow_call      : invoked by release.yml after a successful publish so
 #                          every version on npm has a perf artifact attached.
-#
-# Intentionally NOT run on every push - perf needs the same OS/Node every time
-# to be comparable, and PR feedback should stay fast. Contributors who suspect
-# their PR regresses perf can `gh workflow run perf.yml --ref <branch>`.
+#   - pull_request       : compares the PR head against the gh-pages baseline
+#                          and posts a sticky comment with the deltas. Runs the
+#                          same profile/formats as the baseline so bench names
+#                          line up; otherwise the action would render the PR's
+#                          metrics as brand-new charts instead of new points on
+#                          the existing series. Skipped for fork PRs because
+#                          GITHUB_TOKEN is read-only there - re-introduce via
+#                          a workflow_run companion if/when external
+#                          contributions need this. Doc-only PRs are filtered
+#                          out so they don't pay the ~3-4 minute cost.
 name: Performance
 
 on:
@@ -40,6 +46,16 @@ on:
   schedule:
     # Mondays 05:00 UTC - quiet hours on the GitHub-hosted runner pool.
     - cron: '0 5 * * 1'
+  pull_request:
+    # Skip cosmetic/doc-only PRs so they don't burn ~3-4 minutes of CI per push.
+    # Code that can plausibly affect runtime/memory lives outside these paths.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.gitignore'
+      - 'LICENSE'
   workflow_call:
     inputs:
       profile:
@@ -63,18 +79,36 @@ on:
 permissions:
   contents: read
 
+# Cancel in-progress perf runs for the same PR/branch when a new commit lands.
+# Without this, force-pushing N times to a PR queues N x ~3-4 minute jobs. The
+# release/schedule/dispatch flows run on main or detached refs, where each run
+# gets a unique group key, so this only collapses redundant PR runs.
+concurrency:
+  group: perf-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   perf:
     name: Perf (${{ inputs.profile || 'large' }})
+    # Skip fork PRs: GITHUB_TOKEN is read-only on PRs from forks, so the
+    # comment step would fail and the publish steps couldn't push anyway.
+    # If/when external contributions need PR perf comments, split this into a
+    # pull_request_target / workflow_run companion that runs in the base repo
+    # context with elevated perms.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     # Single OS, single Node version: cross-runner / cross-Node perf is too
     # noisy to be useful. Correctness is already covered by test.yml's matrix.
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # contents:write is needed only by the benchmark-action publish steps
-    # below, which push to the gh-pages branch. Read-only triggers (PR-style
-    # workflow_dispatch) skip those steps via their `if:` guard.
+    # contents:write    - benchmark-action publish steps push to gh-pages.
+    # pull-requests:write - PR comparison step posts/updates the sticky comment.
+    # Steps that don't need a given perm just don't use it; GitHub doesn't
+    # downgrade per-step.
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -203,5 +237,64 @@ jobs:
           # Memory deltas are noisier than wall-time; use a wider band.
           alert-threshold: '200%'
           fail-on-alert: false
+          summary-always: true
+          benchmark-data-dir-path: dev/bench/memory
+
+      # ---------------------------------------------------------------------
+      # PR comparison comment (Phase 2).
+      #
+      # On pull_request events, generate the same benchmark JSON as the
+      # publish path, but instead of pushing to gh-pages we ask the action
+      # to read the existing baseline, render a sticky comment with the
+      # per-bench deltas, and discard the new data point. comment-always
+      # (vs comment-on-alert) is intentional: even green runs are useful
+      # signal on perf-sensitive PRs, and a single sticky comment beats
+      # scrolling for a status check.
+      #
+      # auto-push:false + save-data-file:false ensures the timeline on
+      # gh-pages stays a clean record of merged code; PR runs never appear
+      # there. fail-on-alert stays false to match the publish steps - perf
+      # regressions surface as a comment, not a required-check failure.
+      #
+      # If the bench names emitted by this run don't already exist on
+      # gh-pages (e.g. someone changed PERF_FORMATS / PERF_TYPES to something
+      # the baseline doesn't cover), the action posts the values without a
+      # delta. That's fine - it just means there's no apples-to-apples
+      # comparison yet, not that anything is broken.
+      # ---------------------------------------------------------------------
+      - name: Convert perf-results for PR comparison
+        if: github.event_name == 'pull_request'
+        run: node scripts/perf-to-benchmark.mjs
+
+      - name: Compare runtime against baseline (PR)
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Decompose Runtime
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-runtime.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          save-data-file: false
+          alert-threshold: '150%'
+          fail-on-alert: false
+          comment-always: true
+          summary-always: true
+          benchmark-data-dir-path: dev/bench/runtime
+
+      - name: Compare memory against baseline (PR)
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Decompose Memory
+          tool: customSmallerIsBetter
+          output-file-path: ./perf-memory.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          save-data-file: false
+          skip-fetch-gh-pages: true
+          alert-threshold: '200%'
+          fail-on-alert: false
+          comment-always: true
           summary-always: true
           benchmark-data-dir-path: dev/bench/memory

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -104,8 +104,8 @@ to the `gh-pages` branch:
 The conversion is done by `scripts/perf-to-benchmark.mjs`, which collapses
 `perf-results/*.json` into `perf-runtime.json` (`elapsedMs`) and
 `perf-memory.json` (`rssDeltaBytes` in MB). Ad-hoc `workflow_dispatch` runs
-intentionally **do not** publish, since they often vary profile/types/formats
-inputs and would pollute the timeline.
+intentionally do not publish unless `publish: true` is checked, since they
+often vary profile/types/formats inputs and would pollute the timeline.
 
 To enable on first run:
 
@@ -113,6 +113,28 @@ To enable on first run:
    (the workflow creates the branch on first publish).
 2. Trigger one publish-eligible run (e.g. `gh workflow run perf.yml` from a
    release tag, or wait for the next Monday cron).
+
+## Pull-request comparison comment
+
+PRs that touch non-doc files automatically run the same `large` profile and
+post a sticky comment showing per-bench deltas vs the latest gh-pages
+baseline. The comment updates in place on subsequent pushes (the action keys
+off the bench name + PR number).
+
+Behavior:
+
+- Runs only on PRs from branches in this repo. Fork PRs are skipped because
+  `GITHUB_TOKEN` is read-only there and can't post comments.
+- Concurrency-limited: a new push cancels the in-progress perf run for the
+  same PR so we don't queue redundant ~3-4 minute jobs.
+- Does **not** push to `gh-pages` (`auto-push: false`, `save-data-file:
+false`). The PR's numbers are compared against the baseline and discarded;
+  the trend dashboard only contains merged-code data points.
+- Does **not** fail the check on regression (`fail-on-alert: false`). The
+  comment surfaces it; reviewers decide. Tune via `alert-threshold` in
+  `.github/workflows/perf.yml` if the noise floor changes.
+- Honors the same paths-ignore filter the workflow uses, so doc-only PRs
+  skip the run entirely rather than posting a stale comment.
 
 [bench]: https://github.com/benchmark-action/github-action-benchmark
 


### PR DESCRIPTION
## Summary

Phase 2 of the perf system, building on the gh-pages dashboard from #425. PRs that touch non-doc files now run the same `large` profile we publish to the dashboard, compare against the latest baseline on `gh-pages`, and post a sticky `github-action-benchmark` comment with the per-bench deltas.

- **Trigger:** `pull_request` with `paths-ignore` for `**/*.md`, `docs/**`, and the usual repo plumbing so doc-only PRs don't pay the ~3-4 minute cost.
- **Concurrency:** new commits cancel in-progress perf runs for the same PR (`cancel-in-progress` keyed off `pull_request.number`); release/schedule/dispatch flows are unaffected because their group keys differ.
- **Forks:** the job `if:` skips PRs from forks. `GITHUB_TOKEN` is read-only on those, so the comment step would fail anyway. If/when external contributions need this, it can be split into a `pull_request_target` / `workflow_run` companion that runs in the base-repo context.
- **No timeline pollution:** the two new `Compare ... (PR)` steps run with `auto-push: false` and `save-data-file: false`. They read the existing `dev/bench/{runtime,memory}/data.js` to render the comparison and discard the new entry. The published timeline only ever contains merged code.
- **Sticky comment:** `comment-always: true` so green runs also drop a comment - a single sticky comment per PR is easier than scrolling for a status check. `fail-on-alert: false` matches the publish-path policy: regressions surface in the comment, reviewers decide.
- **Permissions:** added `pull-requests: write` alongside the existing `contents: write` on the job.
- **Docs:** `test/perf/README.md` gets a new "Pull-request comparison comment" section.

## Notable trade-offs / things to revisit before merging

- **PR cost.** Every code-affecting PR will trigger a ~3-4 minute job. If that turns out to be too much, the cheapest knob is gating on a `perf` label (`if: contains(github.event.pull_request.labels.*.name, 'perf')`) so contributors opt in. Default-on is friendlier for catching drift; default-off is friendlier on minutes.
- **Profile alignment.** The PR run uses `large` (matching the published baseline) so bench names line up. Switching the PR run to `medium` would halve runtime but break apples-to-apples - `medium.xml.decompose.pass1` would render as a brand-new chart with no historical context. If you want both, you'd need a second baseline series.
- **Alert thresholds.** Carried over from the publish steps unchanged (150% runtime / 200% memory). On a `pull_request` they govern the `:warning:` annotations in the comment. They may need tightening once we have real signal on PR-time variance.
- **Forks.** Documented and skipped, not solved. The `workflow_run` pattern is the right fix if you start accepting external contribs - happy to draft Phase 2.5 for that.

## Test plan

- [ ] Open a small no-op PR against this branch (or rebase a real PR onto it once merged) and confirm the perf job runs, posts a single sticky comment, and updates the comment in place on a follow-up push.
- [ ] Confirm a doc-only PR (`README.md` only) does **not** trigger perf.
- [ ] Force-push twice in quick succession and confirm only the latest run completes (older runs cancelled).
- [ ] Check `gh-pages` after a PR run and confirm no new commit was added (the PR comparison must not push).
- [ ] After next release, confirm the publish path still works (no regression to Phase 1).
