### PR TITLE
fix(decompose): bump config-disassembler to 1.1.3 and add approval/entitlement uniqueIdElements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "^8.26.3",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.0",
-        "config-disassembler": "^1.1.2",
+        "config-disassembler": "^1.1.3",
         "fast-xml-parser": "^5.7.2",
         "p-limit": "^7.3.0"
       },
@@ -5448,9 +5448,9 @@
       "dev": true
     },
     "node_modules/config-disassembler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.1.2.tgz",
-      "integrity": "sha512-N3CffiPXYcZrhhsYE0jLSKKOOR5J8Dxtk0JbLo2x6WeKm4Z6OxYLAXql+FVOK6i0GbiiYNGu1ilezcRRXbNkxw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.1.3.tgz",
+      "integrity": "sha512-wAEkUQgKQjBMGKUTKwJRsHCwS2Xg0pQSKSX6CCJx5BmehUCdtiKQEkk5Unbcal/VuDKXuWAQNnRul+teSN9U9A==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "^8.26.3",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.0",
-    "config-disassembler": "^1.1.2",
+    "config-disassembler": "^1.1.3",
     "fast-xml-parser": "^5.7.2",
     "p-limit": "^7.3.0"
   },

--- a/src/metadata/uniqueIdElements.ts
+++ b/src/metadata/uniqueIdElements.ts
@@ -71,6 +71,21 @@ export default [
     loyaltyProgramSetup: {
       uniqueIdElements: ['processName'],
     },
+    entitlementProcess: {
+      // `<milestones>` items have no `<fullName>`/`<name>`; the canonical key
+      // is `<milestoneName>`. Without this, every milestone shard falls back
+      // to a SHA-256 hash filename.
+      uniqueIdElements: ['milestoneName'],
+    },
+    approvalProcess: {
+      // `<approvalStep>` already keys off `<name>` via the default list, but
+      // `<allowedSubmitters>` items only carry `<type>` (e.g. `creator`,
+      // `owner`, `queue`). Multiple submitters with the same `<type>` in one
+      // process will collide and fall back to SHA-256, which is acceptable
+      // (and rare in practice) compared to *every* allowedSubmitters shard
+      // hashing today.
+      uniqueIdElements: ['type'],
+    },
     mutingpermissionset: {
       uniqueIdElements: [
         'application',

--- a/test/units/uniqueIdElements.test.ts
+++ b/test/units/uniqueIdElements.test.ts
@@ -1,0 +1,59 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import uniqueIdElements from '../../src/metadata/uniqueIdElements.js';
+import { getUniqueIdElements } from '../../src/metadata/getUniqueIdElements.js';
+
+describe('uniqueIdElements registry', () => {
+  it('returns the documented list for `entitlementProcess` (covers <milestones>/<milestoneName>)', () => {
+    expect(getUniqueIdElements('entitlementProcess')).toBe('milestoneName');
+  });
+
+  it('returns the documented list for `approvalProcess` (covers <allowedSubmitters>/<type>)', () => {
+    expect(getUniqueIdElements('approvalProcess')).toBe('type');
+  });
+
+  it('preserves existing entries for backwards compatibility', () => {
+    expect(getUniqueIdElements('bot')).toContain('developerName');
+    expect(getUniqueIdElements('bot')).toContain('stepIdentifier');
+    expect(getUniqueIdElements('loyaltyProgramSetup')).toBe('processName');
+    expect(getUniqueIdElements('marketingappextension')).toBe('apiName');
+    expect(getUniqueIdElements('globalValueSetTranslation')).toBe('masterLabel');
+  });
+
+  it('returns undefined for suffixes with no override (default fullName/name list applies)', () => {
+    expect(getUniqueIdElements('layout')).toBeUndefined();
+    expect(getUniqueIdElements('flexipage')).toBeUndefined();
+    expect(getUniqueIdElements('globalValueSet')).toBeUndefined();
+    expect(getUniqueIdElements('not_a_real_suffix')).toBeUndefined();
+  });
+
+  it('every registered list is a non-empty array of unique non-empty strings', () => {
+    const merged: Record<string, { uniqueIdElements: string[] }> = {};
+    for (const obj of uniqueIdElements) Object.assign(merged, obj);
+
+    for (const [suffix, { uniqueIdElements: ids }] of Object.entries(merged)) {
+      expect(Array.isArray(ids), `entry "${suffix}" must be a string[]`).toBe(true);
+      expect(ids.length, `entry "${suffix}" must not be empty`).toBeGreaterThan(0);
+      for (const id of ids) {
+        expect(typeof id, `entry "${suffix}" contains a non-string id`).toBe('string');
+        expect(id.trim().length, `entry "${suffix}" contains an empty id`).toBeGreaterThan(0);
+      }
+      expect(new Set(ids).size, `entry "${suffix}" has duplicate ids: ${ids.join(', ')}`).toBe(ids.length);
+    }
+  });
+
+  it('does not duplicate the default `fullName`/`name` keys (those are prepended at lookup time)', () => {
+    // src/metadata/getRegistryValuesBySuffix.ts always prefixes DEFAULT_UNIQUE_ID_ELEMENTS
+    // ("fullName,name") to the per-suffix list. Listing them again would be redundant
+    // and obscures which suffixes actually need extra coverage.
+    const merged: Record<string, { uniqueIdElements: string[] }> = {};
+    for (const obj of uniqueIdElements) Object.assign(merged, obj);
+
+    for (const [suffix, { uniqueIdElements: ids }] of Object.entries(merged)) {
+      expect(ids, `entry "${suffix}" should not duplicate the default "fullName"`).not.toContain('fullName');
+      expect(ids, `entry "${suffix}" should not duplicate the default "name"`).not.toContain('name');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Bumps `config-disassembler` 1.1.2 → 1.1.3**, picking up the upstream fix that preserves dotted fullNames in the disassembled output directory name. Two files like `Account_Merge__c.ProcessA.approvalProcess-meta.xml` and `Account_Merge__c.ProcessB.approvalProcess-meta.xml` previously collapsed into a single `Account_Merge__c/` directory and silently merged on recompose; each now lands in its own per-process directory and round-trips losslessly.
- **Adds `uniqueIdElements` defaults for two metadata types** whose nested items don't carry `<fullName>`/`<name>`:
  - `entitlementProcess` → `milestoneName` (every `<milestones>` shard previously fell back to a SHA-256 hash filename)
  - `approvalProcess` → `type` (every `<allowedSubmitters>` shard previously fell back to a SHA-256 hash filename)
- Adds `test/units/uniqueIdElements.test.ts` covering the new and existing entries, structural integrity of the export, and the non-duplication of `fullName`/`name` (which the underlying disassembler already prepends).

## Why

Salesforce metadata commonly uses a `<SObject>.<Component>` fullName pattern for a handful of types — most notably `approvalProcess`, `quickAction`, and `customMetadata` records. Before this PR, multiple components for the same parent SObject would silently merge into one file on recompose, causing data loss in roughly **569 / 580** approval processes in a representative repo.

The new `uniqueIdElements` defaults are a smaller-but-related quality-of-life improvement: they replace SHA-256 hash filenames with the actual Salesforce identifier for milestones and allowed submitters, making the decomposed tree readable and diff-friendly.

## Test plan

- [x] `npm install` resolves `config-disassembler@1.1.3` cleanly (verified in `package-lock.json`)
- [x] `npm run compile` and `npm run lint` clean
- [x] `npx vitest run` — **201 / 201 tests pass** across 13 spec files (1 new spec added)
- [x] Empirical end-to-end validation on a 580-file approval-process corpus from a real Salesforce repo:
  - Decompose produces **580 distinct per-process directories**, **zero** shared sobject-only directories
  - Recompose emits **580 distinct files** (no merging)
  - **580 / 580 files: identical sorted set of `<name>` elements** vs original (no data loss)
  - **580 / 580 files: identical `<approvalStep>` count** vs original
  - 432 files differ from originals by exactly **1 byte** (pre-existing trailing-newline gap on recompose)
  - 148 files differ by other byte counts due to **expected reordering of repeating elements** (no content loss)
- [x] New unit tests in `test/units/uniqueIdElements.test.ts` exercise both new entries (`entitlementProcess`, `approvalProcess`), regress against accidental removals of existing entries, validate that no entry duplicates the `fullName`/`name` defaults, and confirm `getUniqueIdElements` returns `undefined` for unknown suffixes.

## Notes

- This is a transitive fix of an upstream Rust crate bug — the long-term fix landed in `config-disassembler` 0.4.4 → published as `config-disassembler` (Node) 1.1.3. The full chain is:
  - `config-disassembler` (Rust crate) 0.4.4
  - `config-disassembler` (Node bindings) 1.1.3
  - `sf-decomposer` (this PR)
- No on-disk migration is required for users with existing decomposed approval processes today; on next decompose, the new per-process directories will appear next to (or instead of) the old shared `<sobject>/` layout depending on `--prepurge`.
