### PR TITLE
chore(audit): port round-trip audit harness from PowerShell to Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,9 @@
     "test:only": "wireit",
     "test:perf": "vitest run --config ./vitest.perf.config.ts",
     "test:perf:gen": "node --import ts-node/esm scripts/gen-perf-fixtures.ts",
+    "audit": "node --loader ts-node/esm --no-warnings=ExperimentalWarning scripts/audit/audit.ts",
+    "audit:sweep": "node --loader ts-node/esm --no-warnings=ExperimentalWarning scripts/audit/sweep.ts",
+    "audit:roundtrip": "node --loader ts-node/esm --no-warnings=ExperimentalWarning scripts/audit/roundtrip.ts",
     "version": "oclif readme"
   },
   "publishConfig": {

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,89 @@
+# sf-decomposer audit harness
+
+Three Node.js scripts that catch silent decompose / recompose bugs by exercising
+the local CLI against real Salesforce metadata. They were originally written
+as one-off PowerShell scripts during the Phase-1 / Phase-2 audit that drove
+PR #430, #432, and #433; this is the portable, dependency-free Node port so
+anyone can run them on macOS / Linux / CI without a PowerShell host.
+
+The harness is **not** part of the published plugin — it lives under
+`scripts/audit/` and is invoked via `npm run audit*`. None of these scripts
+mutate the source archive; everything happens in a per-type workspace under
+`<os.tmpdir()>/sfd-audit/`.
+
+## Indicators each script reports
+
+| Indicator                            | What it catches                                                                                                                            |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `origFiles != rebuiltFiles`          | A whole metadata file was lost on round-trip (severe).                                                                                     |
+| `contentSetDiff > 0`                 | Per-file `<name>` multiset differs between original and rebuilt — a uniqueIdElements collision dropped child elements.                     |
+| `parentOnlyDirs > 0`                 | A dotted-fullName type produced parent-only output dirs — the merge bug fixed by config-disassembler 0.4.4.                                |
+| `hashFiles > 0`                      | One or more shards fell back to SHA-256 hash filenames — a uniqueIdElements coverage opportunity (correctness is fine, readability isn't). |
+| `exitDecompose / exitRecompose != 0` | The CLI logged hard errors. Non-zero alone is not always a bug (leaf-only files are skipped at ERROR-level), but should be inspected.      |
+
+## Scripts
+
+### `npm run audit` — single-type focused audit
+
+Drives one (type, suffix) pair end-to-end. Useful for iterating on a new
+`uniqueIdElements` entry against a known-good archive.
+
+```bash
+npm run audit -- \
+  --type quickActions \
+  --suffix quickAction \
+  --source-root /path/to/force-app/main/default \
+  --sample 50
+```
+
+Exits `2` if `contentSetDiff > 0` or `parentOnlyDirs > 0`, otherwise `0`.
+
+### `npm run audit:sweep` — broad decompose-only sweep
+
+Iterates over a curated list of metadata types (see `type-pairs.ts`), runs
+decompose-only with a per-type sample cap, and ranks types by hash-filename
+count. Used to surface uniqueIdElements coverage opportunities across the
+whole archive.
+
+```bash
+npm run audit:sweep -- \
+  --source-root /path/to/force-app/main/default \
+  --sample 30
+```
+
+### `npm run audit:roundtrip` — multi-type round-trip integrity
+
+Iterates a focused list of high-risk types and runs the full decompose +
+recompose pair, asserting `origFiles == rebuiltFiles` and `contentSetDiff == 0`.
+Exits `2` when any type shows data loss, so this can gate CI against a real
+metadata archive.
+
+```bash
+npm run audit:roundtrip -- \
+  --source-root /path/to/force-app/main/default
+```
+
+## Adjusting the type lists
+
+The two curated lists live in `scripts/audit/type-pairs.ts`:
+
+- `SWEEP_PAIRS` — broad coverage for hash-filename surveys.
+- `ROUNDTRIP_PAIRS` — focused list for round-trip integrity, with per-type
+  sample caps for the slow ones (`customMetadata`, `reportTypes`).
+
+Add or remove rows directly. The directory name is what Salesforce CLI emits
+into `force-app/main/default/`, and the suffix is what `decomposer (de|re)compose -m`
+expects (matches `MetadataResolver` in `source-deploy-retrieve`).
+
+## Implementation notes
+
+- Pure Node builtins (no extra deps). Same `node --import ts-node/esm` runner
+  pattern as `scripts/gen-perf-fixtures.ts`.
+- Each run stages files into `<tmp>/sfd-audit/<type>/`. The harness wipes that
+  dir on every invocation; pass `--work-root` to relocate.
+- The CLI subprocess inherits the parent env minus `NODE_OPTIONS` so the
+  ts-node loader doesn't leak into the spawned `bin/run.js`.
+- The `<name>`-multiset comparison is intentionally weaker than a byte
+  comparison: XML round-tripping legitimately reorders elements and adjusts
+  trailing whitespace. For byte-level guarantees see `test/perf/decompose.perf.ts`,
+  which checks `recomposed.bytes >= 0.99 * original.bytes`.

--- a/scripts/audit/audit.ts
+++ b/scripts/audit/audit.ts
@@ -1,0 +1,208 @@
+/*
+ * Single-type round-trip audit.
+ *
+ * Stages a (capped) sample of files for one metadata type into a fresh SFDX
+ * project, runs decompose then recompose via the local CLI entrypoint, and
+ * reports a one-row summary that catches:
+ *
+ *   - file-count mismatches      (orig vs rebuilt)
+ *   - <name>-multiset mismatches (per-file data loss)
+ *   - SHA-256 hash filenames     (uniqueIdElements coverage opportunity)
+ *   - parent-only output dirs    (dotted-fullName merge bug)
+ *
+ * Usage:
+ *   npm run audit -- \
+ *     --type quickActions \
+ *     --suffix quickAction \
+ *     --source-root C:/path/to/force-app/main/default \
+ *     [--sample 50] \
+ *     [--unique-id-elements value] \
+ *     [--plugin /path/to/sf-decomposer]
+ *
+ * The script exits non-zero only when the source dir is missing or the CLI
+ * failed to produce any output dirs at all. Hash filenames and content-set
+ * mismatches are surfaced via the returned row, not via exit code, so this
+ * harness can be wrapped in a sweeping driver (see roundtrip.ts).
+ */
+
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type AuditRow,
+  DEFAULT_PLUGIN_ROOT,
+  DEFAULT_WORK_ROOT,
+  countHashFiles,
+  formatTable,
+  listFlatXml,
+  listSubdirs,
+  listXmlFilesRecursive,
+  nameMultisetMatches,
+  optionalInt,
+  parseFlags,
+  requireString,
+  runCli,
+  stageProject,
+} from './lib.js';
+
+const HELP_HINT = 'Run with --help for full usage.';
+
+const HELP_TEXT = `Usage: npm run audit -- [options]
+
+Required:
+  --type <dirName>           Source directory name (e.g. quickActions, applications)
+  --suffix <metadataSuffix>  CLI -m value (e.g. quickAction, app, md)
+  --source-root <path>       Path to force-app/main/default (or equivalent)
+
+Optional:
+  --sample <n>               Cap input file count (default: 0 = no cap)
+  --unique-id-elements <s>   Override uniqueIdElements for this run
+  --plugin <path>            Path to sf-decomposer repo root (default: cwd)
+  --work-root <path>         Workspace root for staging (default: <tmp>/sfd-audit)
+  --quiet                    Suppress per-file CLI logs
+  --help, -h                 Show this help
+`;
+
+export interface AuditOptions {
+  type: string;
+  suffix: string;
+  sourceRoot: string;
+  pluginRoot: string;
+  workRoot: string;
+  sample: number;
+  uniqueIdElements?: string;
+  quiet: boolean;
+}
+
+export function runAudit(opts: AuditOptions): AuditRow {
+  const sourceDir = join(opts.sourceRoot, opts.type);
+  if (!existsSync(sourceDir)) {
+    throw new Error(`No source dir for type "${opts.type}": ${sourceDir}`);
+  }
+
+  const workDir = join(opts.workRoot, opts.type);
+  const { destDir, stagedCount } = stageProject({
+    workDir,
+    sourceDir,
+    typeDirName: opts.type,
+    sample: opts.sample,
+  });
+
+  if (!opts.quiet) {
+    process.stdout.write(`[${opts.type}] staged ${stagedCount} files\n`);
+  }
+
+  const decomposeArgv = ['decomposer', 'decompose', '-m', opts.suffix, '--postpurge'];
+  if (opts.uniqueIdElements) decomposeArgv.push('-u', opts.uniqueIdElements);
+
+  const decomposeResult = runCli({
+    pluginRoot: opts.pluginRoot,
+    cwd: workDir,
+    argv: decomposeArgv,
+    logFile: join(workDir, 'decompose.log'),
+  });
+  // Exit code 1 is non-fatal: config-disassembler logs at ERROR for leaf-only
+  // files it correctly skips. We only care whether output dirs were produced.
+
+  const allDirs = listSubdirs(destDir);
+  // Heuristic: in dotted-fullName types (approvalProcess, customMetadata,
+  // quickAction), per-component output dirs contain a `.`. The pre-0.4.4
+  // merge bug produced parent-only dirs (no dot) by collapsing siblings.
+  const perComponentDirs = allDirs.filter((d) => d.name.includes('.')).length;
+  const parentOnlyDirs = allDirs.length - perComponentDirs;
+
+  const allXml = listXmlFilesRecursive(destDir);
+  const hashFiles = countHashFiles(allXml);
+
+  const recomposeResult = runCli({
+    pluginRoot: opts.pluginRoot,
+    cwd: workDir,
+    argv: ['decomposer', 'recompose', '-m', opts.suffix, '--postpurge'],
+    logFile: join(workDir, 'recompose.log'),
+  });
+
+  const rebuilt = listFlatXml(destDir);
+  let contentMatch = 0;
+  let contentDiff = 0;
+  let missing = 0;
+  for (const r of rebuilt) {
+    const orig = join(sourceDir, basename(r));
+    if (!existsSync(orig)) {
+      missing++;
+      continue;
+    }
+    if (nameMultisetMatches(orig, r)) contentMatch++;
+    else contentDiff++;
+  }
+
+  return {
+    type: opts.type,
+    suffix: opts.suffix,
+    origFiles: stagedCount,
+    rebuiltFiles: rebuilt.length,
+    decomposedDirs: allDirs.length,
+    perComponentDirs,
+    parentOnlyDirs,
+    hashFiles,
+    contentSetMatch: contentMatch,
+    contentSetDiff: contentDiff,
+    missing,
+    exitDecompose: decomposeResult.status ?? -1,
+    exitRecompose: recomposeResult.status ?? -1,
+  };
+}
+
+function basename(p: string): string {
+  const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+  return idx === -1 ? p : p.slice(idx + 1);
+}
+
+function parseCli(argv: readonly string[]): AuditOptions {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(HELP_TEXT);
+    process.exit(0);
+  }
+  const flags = parseFlags(argv);
+  const type = requireString(flags, 'type', HELP_HINT);
+  const suffix = requireString(flags, 'suffix', HELP_HINT);
+  const sourceRoot = requireString(flags, 'source-root', HELP_HINT);
+  const pluginRoot = (flags.get('plugin') as string | undefined) ?? DEFAULT_PLUGIN_ROOT;
+  const workRoot = (flags.get('work-root') as string | undefined) ?? DEFAULT_WORK_ROOT;
+  const sample = optionalInt(flags, 'sample', 0);
+  const uniqueIdElements = flags.get('unique-id-elements');
+  return {
+    type,
+    suffix,
+    sourceRoot,
+    pluginRoot,
+    workRoot,
+    sample,
+    uniqueIdElements: typeof uniqueIdElements === 'string' ? uniqueIdElements : undefined,
+    quiet: flags.has('quiet'),
+  };
+}
+
+function isDirectInvocation(): boolean {
+  if (!process.argv[1]) return false;
+  return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+}
+
+if (isDirectInvocation()) {
+  try {
+    const opts = parseCli(process.argv.slice(2));
+    const row = runAudit(opts);
+    process.stdout.write('\n' + formatTable([row]) + '\n');
+    // Hard fail only on real data-loss signals: a per-file <name> multiset
+    // mismatch, or a rebuilt-file count that disagrees with the staged
+    // count. `parentOnlyDirs` is intentionally informational: types whose
+    // fullNames legitimately contain no dot (e.g. quickActions on Global,
+    // most non-dotted types) report parentOnlyDirs > 0 by design.
+    if (row.contentSetDiff > 0 || (row.origFiles > 0 && row.rebuiltFiles !== row.origFiles)) {
+      process.exitCode = 2;
+    }
+  } catch (err) {
+    process.stderr.write(`audit error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/audit/lib.ts
+++ b/scripts/audit/lib.ts
@@ -1,0 +1,317 @@
+/*
+ * Shared helpers for the round-trip audit harness.
+ *
+ * The audit scripts stage real Salesforce metadata into a clean SFDX project,
+ * run `decomposer decompose` and `decomposer recompose` via the local CLI
+ * entrypoint (`bin/run.js`), and report indicators that catch silent bugs:
+ *
+ *   - file-count parity (orig vs rebuilt)
+ *   - <name>-multiset parity (catches data loss within a file)
+ *   - SHA-256 hash-filename count (uniqueIdElements coverage opportunity)
+ *   - parent-only output dir count (catches the dotted-fullName merge bug)
+ *
+ * These helpers are intentionally dependency-free (only Node builtins) so the
+ * harness can run in any CI environment without an extra install step.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * One row in the audit summary. Mirrors the PowerShell pscustomobject so the
+ * output table is comparable across platforms.
+ */
+export interface AuditRow {
+  type: string;
+  suffix: string;
+  origFiles: number;
+  rebuiltFiles: number;
+  decomposedDirs: number;
+  perComponentDirs: number;
+  /** > 0 indicates a potential dotted-fullName merge bug (config-disassembler < 0.4.4). */
+  parentOnlyDirs: number;
+  /** > 0 indicates a uniqueIdElements coverage opportunity. */
+  hashFiles: number;
+  contentSetMatch: number;
+  /** > 0 indicates real data loss on round-trip (collision). */
+  contentSetDiff: number;
+  missing: number;
+  exitDecompose: number;
+  exitRecompose: number;
+}
+
+/**
+ * One row in the decompose-only sweep summary. We do not run recompose here
+ * because the goal is to quickly tally hash-filename counts across many types.
+ */
+export interface SweepRow {
+  type: string;
+  suffix: string;
+  staged: number;
+  decomposedDirs: number;
+  parentOnlyDirs: number;
+  hashFiles: number;
+  /** Top 3 inner directories by hash-filename count, formatted as `name(count)`. */
+  topHashDirs: string;
+  exit: number;
+}
+
+/** A (directory-name, metadata-suffix) pair. The two diverge for some types. */
+export interface TypePair {
+  type: string;
+  suffix: string;
+  /** Per-pair sample cap override; falls back to the CLI-level `--sample` if unset. */
+  sample?: number;
+}
+
+const SFDX_PROJECT_JSON = JSON.stringify(
+  {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '61.0',
+  },
+  null,
+  0,
+);
+
+/** Lowercase 8-hex-digit prefix produced by config-disassembler's hash fallback. */
+const HASH_FILE_RE = /^[a-f0-9]{8}\./;
+
+/** Pull all `<name>...</name>` text values from raw XML, ignoring whitespace. */
+const NAME_TAG_RE = /<name>([^<]+)<\/name>/g;
+
+/** Default plugin root: the sf-decomposer repo we're invoking from. */
+export const DEFAULT_PLUGIN_ROOT = process.cwd();
+
+/** Default work root under the OS tmp dir. */
+export const DEFAULT_WORK_ROOT = join(tmpdir(), 'sfd-audit');
+
+/** Resolve the local CLI entrypoint (`bin/run.js`) from a plugin root. */
+export function resolveCliBin(pluginRoot: string): string {
+  return resolve(pluginRoot, 'bin', 'run.js');
+}
+
+/** Recursively remove a directory if it exists. No-op if missing. */
+export function rmDir(dir: string): void {
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * Stage a clean SFDX project at `workDir` and copy *.xml files from
+ * `sourceDir` into `<workDir>/force-app/main/default/<typeDirName>/`.
+ * Returns the destination dir and the count of files actually staged.
+ *
+ * Pass `sample > 0` to randomly cap the staged set (useful for sweep runs).
+ */
+export function stageProject(args: { workDir: string; sourceDir: string; typeDirName: string; sample: number }): {
+  destDir: string;
+  stagedCount: number;
+} {
+  const { workDir, sourceDir, typeDirName, sample } = args;
+  rmDir(workDir);
+  const destDir = join(workDir, 'force-app', 'main', 'default', typeDirName);
+  mkdirSync(destDir, { recursive: true });
+  writeFileSync(join(workDir, 'sfdx-project.json'), SFDX_PROJECT_JSON, 'utf8');
+
+  // Only stage flat *.xml files at the top of the type dir. Pre-decomposed
+  // sub-directories (e.g. SDR-decomposed bots) exercise a different code path
+  // that the round-trip audit isn't designed to cover.
+  let candidates = readdirSync(sourceDir, { withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.xml'))
+    .map((d) => join(sourceDir, d.name));
+
+  if (sample > 0 && candidates.length > sample) {
+    candidates = sampleRandom(candidates, sample);
+  }
+
+  for (const src of candidates) {
+    cpSync(src, join(destDir, basename(src)));
+  }
+  return { destDir, stagedCount: candidates.length };
+}
+
+/** Fisher-Yates partial shuffle: returns the first `n` elements. */
+function sampleRandom<T>(arr: readonly T[], n: number): T[] {
+  const copy = arr.slice();
+  for (let i = 0; i < n; i++) {
+    const j = i + Math.floor(Math.random() * (copy.length - i));
+    [copy[i], copy[j]] = [copy[j] as T, copy[i] as T];
+  }
+  return copy.slice(0, n);
+}
+
+function basename(p: string): string {
+  const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+  return idx === -1 ? p : p.slice(idx + 1);
+}
+
+/**
+ * Run the local CLI as a subprocess. Captures stdout+stderr so the harness
+ * can dump them on failure but stays quiet on the happy path. Exit code 1 is
+ * non-fatal here: config-disassembler legitimately writes ERROR-level logs
+ * for leaf-only files it correctly skips, and we only care whether output
+ * dirs were produced at all.
+ */
+export function runCli(args: {
+  pluginRoot: string;
+  cwd: string;
+  argv: string[];
+  logFile?: string;
+}): SpawnSyncReturns<string> {
+  const { pluginRoot, cwd, argv, logFile } = args;
+  const result = spawnSync('node', [resolveCliBin(pluginRoot), ...argv], {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: false,
+    // Inherit env (PATH, etc.) without leaking caller-set NODE_OPTIONS that
+    // could change ts-node loader behavior unpredictably.
+    env: { ...process.env, NODE_OPTIONS: '' },
+  });
+  if (logFile) {
+    writeFileSync(logFile, `${result.stdout ?? ''}\n${result.stderr ?? ''}`, 'utf8');
+  }
+  return result;
+}
+
+/** Recursively list all *.xml files under a directory. */
+export function listXmlFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listXmlFilesRecursive(full));
+    } else if (entry.isFile() && entry.name.endsWith('.xml')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** List immediate-child directories of `dir`. Returns empty array if missing. */
+export function listSubdirs(dir: string): Array<{ name: string; path: string }> {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => ({ name: e.name, path: join(dir, e.name) }));
+}
+
+/** List flat *.xml files at the top level of `dir`. */
+export function listFlatXml(dir: string): string[] {
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.xml'))
+    .map((e) => join(dir, e.name));
+}
+
+/** Count files whose basename matches the SHA-256 hash-fallback pattern. */
+export function countHashFiles(files: readonly string[]): number {
+  let n = 0;
+  for (const f of files) if (HASH_FILE_RE.test(basename(f))) n++;
+  return n;
+}
+
+/**
+ * Group hash-named files by the leaf segment of their parent directory and
+ * return the top-N groups by count, formatted as `dirName(count)` joined by
+ * spaces. Mirrors the PowerShell sweep output for at-a-glance comparison.
+ */
+export function topHashDirs(files: readonly string[], top = 3): string {
+  const counts = new Map<string, number>();
+  for (const f of files) {
+    if (!HASH_FILE_RE.test(basename(f))) continue;
+    const parent = leafDir(f);
+    counts.set(parent, (counts.get(parent) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, top)
+    .map(([name, count]) => `${name}(${count})`)
+    .join(' ');
+}
+
+function leafDir(filePath: string): string {
+  const idx = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  if (idx === -1) return '';
+  const dir = filePath.slice(0, idx);
+  const idx2 = Math.max(dir.lastIndexOf('/'), dir.lastIndexOf('\\'));
+  return idx2 === -1 ? dir : dir.slice(idx2 + 1);
+}
+
+/**
+ * Compare the sorted multiset of `<name>` values between two XML files.
+ * Returns true when both files contain the same set (with the same
+ * cardinality) of name values. We deliberately do NOT compare bytes
+ * because XML round-tripping legitimately reorders elements and adjusts
+ * trailing whitespace.
+ */
+export function nameMultisetMatches(origPath: string, rebuiltPath: string): boolean {
+  const orig = extractNames(readFileSync(origPath, 'utf8'));
+  const rebuilt = extractNames(readFileSync(rebuiltPath, 'utf8'));
+  return orig.length === rebuilt.length && orig.every((v, i) => v === rebuilt[i]);
+}
+
+function extractNames(xml: string): string[] {
+  const out: string[] = [];
+  for (const m of xml.matchAll(NAME_TAG_RE)) out.push(m[1] as string);
+  return out.sort();
+}
+
+/** Render an array of plain objects as a fixed-width ASCII table. */
+export function formatTable<T extends object>(rows: readonly T[], columns?: ReadonlyArray<keyof T & string>): string {
+  if (rows.length === 0) return '(no rows)';
+  const cols: string[] = columns ? columns.slice() : Object.keys(rows[0] as object);
+  const cell = (row: T, col: string): string => String((row as Record<string, unknown>)[col] ?? '');
+  const widths = cols.map((c) => Math.max(c.length, ...rows.map((r) => cell(r, c).length)));
+  const fmtRow = (vals: string[]): string => '  ' + vals.map((v, i) => v.padEnd(widths[i] ?? 0)).join('  ') + '  ';
+  const lines = [fmtRow(cols), '  ' + cols.map((_c, i) => '-'.repeat(widths[i] ?? 0)).join('  ') + '  '];
+  for (const r of rows) lines.push(fmtRow(cols.map((c) => cell(r, c))));
+  return lines.join('\n');
+}
+
+/** Tiny `--name value` parser for the audit CLIs (no external dep). */
+export function parseFlags(argv: readonly string[]): Map<string, string | true> {
+  const out = new Map<string, string | true>();
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a) continue;
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        out.set(key, next);
+        i++;
+      } else {
+        out.set(key, true);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a flag value to a string, throwing with a helpful message if the
+ * flag is missing OR was passed without a value (`--source-root` alone).
+ */
+export function requireString(flags: Map<string, string | true>, key: string, helpHint: string): string {
+  const v = flags.get(key);
+  if (v === undefined) throw new Error(`Missing required --${key}. ${helpHint}`);
+  if (v === true) throw new Error(`--${key} requires a value. ${helpHint}`);
+  return v;
+}
+
+/** Resolve a flag to a number, defaulting if missing. Throws on non-numeric input. */
+export function optionalInt(flags: Map<string, string | true>, key: string, fallback: number): number {
+  const v = flags.get(key);
+  if (v === undefined) return fallback;
+  if (v === true) throw new Error(`--${key} requires a numeric value.`);
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n) || n < 0) throw new Error(`--${key} must be a non-negative integer (got "${v}").`);
+  return n;
+}
+
+export const FILE_PATTERNS = { HASH_FILE_RE };

--- a/scripts/audit/roundtrip.ts
+++ b/scripts/audit/roundtrip.ts
@@ -1,0 +1,135 @@
+/*
+ * Round-trip integrity audit across a curated list of metadata types.
+ *
+ * For each (type, suffix) pair, runs the single-type audit (decompose +
+ * recompose) and reports a one-row-per-type summary. A non-zero
+ * `contentSetDiff` or `parentOnlyDirs` count, or a `rebuiltFiles != origFiles`
+ * mismatch, indicates a uniqueIdElements collision or a structural bug.
+ *
+ * The driver exits non-zero when ANY row in the summary shows data loss, so
+ * this can be wired into CI as a regression gate against real metadata
+ * archives.
+ *
+ * Usage:
+ *   npm run audit:roundtrip -- --source-root C:/path/to/force-app/main/default \
+ *     [--sample 0] [--plugin /path/to/sf-decomposer]
+ */
+
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type AuditRow,
+  DEFAULT_PLUGIN_ROOT,
+  DEFAULT_WORK_ROOT,
+  formatTable,
+  optionalInt,
+  parseFlags,
+  requireString,
+} from './lib.js';
+import { runAudit } from './audit.js';
+import { ROUNDTRIP_PAIRS } from './type-pairs.js';
+
+const HELP_TEXT = `Usage: npm run audit:roundtrip -- [options]
+
+Required:
+  --source-root <path>     Path to force-app/main/default (or equivalent)
+
+Optional:
+  --sample <n>             Default per-type cap (overridden by per-pair cap; default: 0)
+  --plugin <path>          Path to sf-decomposer repo root (default: cwd)
+  --work-root <path>       Workspace root for staging (default: <tmp>/sfd-audit)
+  --help, -h               Show this help
+`;
+
+interface RoundtripOptions {
+  sourceRoot: string;
+  pluginRoot: string;
+  workRoot: string;
+  defaultSample: number;
+}
+
+function runRoundtrip(opts: RoundtripOptions): AuditRow[] {
+  const rows: AuditRow[] = [];
+  for (const pair of ROUNDTRIP_PAIRS) {
+    const sourceDir = join(opts.sourceRoot, pair.type);
+    if (!existsSync(sourceDir)) {
+      process.stdout.write(`[skip] ${pair.type} (no source dir)\n`);
+      continue;
+    }
+    const sample = pair.sample ?? opts.defaultSample;
+    process.stdout.write(`[audit] ${pair.type} (suffix=${pair.suffix}, sample=${sample})\n`);
+    try {
+      const row = runAudit({
+        type: pair.type,
+        suffix: pair.suffix,
+        sourceRoot: opts.sourceRoot,
+        pluginRoot: opts.pluginRoot,
+        workRoot: opts.workRoot,
+        sample,
+        quiet: true,
+      });
+      rows.push(row);
+    } catch (err) {
+      process.stderr.write(`  failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+  return rows;
+}
+
+function parseCli(argv: readonly string[]): RoundtripOptions {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(HELP_TEXT);
+    process.exit(0);
+  }
+  const flags = parseFlags(argv);
+  const sourceRoot = requireString(flags, 'source-root', 'Run with --help for full usage.');
+  const pluginRoot = (flags.get('plugin') as string | undefined) ?? DEFAULT_PLUGIN_ROOT;
+  const workRoot = (flags.get('work-root') as string | undefined) ?? DEFAULT_WORK_ROOT;
+  const defaultSample = optionalInt(flags, 'sample', 0);
+  return { sourceRoot, pluginRoot, workRoot, defaultSample };
+}
+
+function isDirectInvocation(): boolean {
+  if (!process.argv[1]) return false;
+  return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+}
+
+if (isDirectInvocation()) {
+  try {
+    const opts = parseCli(process.argv.slice(2));
+    const rows = runRoundtrip(opts);
+    process.stdout.write('\n=== ROUND-TRIP SUMMARY ===\n');
+    process.stdout.write(
+      formatTable(rows, [
+        'type',
+        'origFiles',
+        'rebuiltFiles',
+        'decomposedDirs',
+        'parentOnlyDirs',
+        'hashFiles',
+        'contentSetMatch',
+        'contentSetDiff',
+        'missing',
+      ]) + '\n',
+    );
+    // Hard fail only on real data-loss signals (see audit.ts for rationale).
+    // `parentOnlyDirs` stays in the table for inspection but does not gate.
+    const failing = rows.filter((r) => r.contentSetDiff > 0 || (r.origFiles > 0 && r.rebuiltFiles !== r.origFiles));
+    if (failing.length > 0) {
+      process.stderr.write(`\nFAIL: ${failing.length} type(s) showed data loss:\n`);
+      for (const r of failing) {
+        process.stderr.write(
+          `  - ${r.type}: orig=${r.origFiles} rebuilt=${r.rebuiltFiles} ` +
+            `diff=${r.contentSetDiff} parentOnly=${r.parentOnlyDirs} hashFiles=${r.hashFiles}\n`,
+        );
+      }
+      process.exit(2);
+    }
+    process.stdout.write('\nOK: all audited types round-tripped cleanly.\n');
+  } catch (err) {
+    process.stderr.write(`roundtrip error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/audit/sweep.ts
+++ b/scripts/audit/sweep.ts
@@ -1,0 +1,144 @@
+/*
+ * Decompose-only sweep across a curated list of metadata types.
+ *
+ * For each (type, suffix) pair, stages a capped sample, runs decompose, and
+ * tallies SHA-256 hash filenames per inner directory. Used to surface
+ * uniqueIdElements coverage opportunities at scale: a high HashFiles count
+ * for a given type means its repeating child elements are falling back to
+ * content hashes for filenames, which is correct but suboptimal for human
+ * readability and source-control diffs.
+ *
+ * Usage:
+ *   npm run audit:sweep -- --source-root C:/path/to/force-app/main/default \
+ *     [--sample 30] [--plugin /path/to/sf-decomposer]
+ */
+
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  type SweepRow,
+  DEFAULT_PLUGIN_ROOT,
+  DEFAULT_WORK_ROOT,
+  countHashFiles,
+  formatTable,
+  listSubdirs,
+  listXmlFilesRecursive,
+  optionalInt,
+  parseFlags,
+  requireString,
+  runCli,
+  stageProject,
+  topHashDirs,
+} from './lib.js';
+import { SWEEP_PAIRS } from './type-pairs.js';
+
+const HELP_TEXT = `Usage: npm run audit:sweep -- [options]
+
+Required:
+  --source-root <path>     Path to force-app/main/default (or equivalent)
+
+Optional:
+  --sample <n>             Per-type input file cap (default: 30)
+  --plugin <path>          Path to sf-decomposer repo root (default: cwd)
+  --work-root <path>       Workspace root for staging (default: <tmp>/sfd-audit)
+  --help, -h               Show this help
+`;
+
+interface SweepOptions {
+  sourceRoot: string;
+  pluginRoot: string;
+  workRoot: string;
+  sample: number;
+}
+
+function runSweep(opts: SweepOptions): SweepRow[] {
+  const rows: SweepRow[] = [];
+
+  for (const pair of SWEEP_PAIRS) {
+    const sourceDir = join(opts.sourceRoot, pair.type);
+    if (!existsSync(sourceDir)) continue;
+
+    const workDir = join(opts.workRoot, `sweep-${pair.type}`);
+    const { destDir, stagedCount } = stageProject({
+      workDir,
+      sourceDir,
+      typeDirName: pair.type,
+      sample: opts.sample,
+    });
+
+    const decomposeResult = runCli({
+      pluginRoot: opts.pluginRoot,
+      cwd: workDir,
+      argv: ['decomposer', 'decompose', '-m', pair.suffix],
+      logFile: join(workDir, 'decompose.log'),
+    });
+
+    const allXml = listXmlFilesRecursive(destDir);
+    const hashFiles = countHashFiles(allXml);
+    const top = topHashDirs(allXml, 3);
+    const allDirs = listSubdirs(destDir);
+    const parentOnlyDirs = allDirs.filter((d) => !d.name.includes('.')).length;
+
+    const row: SweepRow = {
+      type: pair.type,
+      suffix: pair.suffix,
+      staged: stagedCount,
+      decomposedDirs: allDirs.length,
+      parentOnlyDirs,
+      hashFiles,
+      topHashDirs: top,
+      exit: decomposeResult.status ?? -1,
+    };
+    rows.push(row);
+
+    process.stdout.write(
+      `[done] ${pair.type.padEnd(22)} staged=${String(stagedCount).padEnd(3)} ` +
+        `hashes=${String(hashFiles).padEnd(4)} top=${top}\n`,
+    );
+  }
+
+  return rows;
+}
+
+function parseCli(argv: readonly string[]): SweepOptions {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(HELP_TEXT);
+    process.exit(0);
+  }
+  const flags = parseFlags(argv);
+  const sourceRoot = requireString(flags, 'source-root', 'Run with --help for full usage.');
+  const pluginRoot = (flags.get('plugin') as string | undefined) ?? DEFAULT_PLUGIN_ROOT;
+  const workRoot = (flags.get('work-root') as string | undefined) ?? DEFAULT_WORK_ROOT;
+  const sample = optionalInt(flags, 'sample', 30);
+  return { sourceRoot, pluginRoot, workRoot, sample };
+}
+
+function isDirectInvocation(): boolean {
+  if (!process.argv[1]) return false;
+  return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+}
+
+if (isDirectInvocation()) {
+  try {
+    const opts = parseCli(process.argv.slice(2));
+    const rows = runSweep(opts).sort((a, b) => b.hashFiles - a.hashFiles);
+    process.stdout.write('\n=== HASH-FILENAME SWEEP ===\n');
+    process.stdout.write(
+      formatTable(rows, [
+        'type',
+        'suffix',
+        'staged',
+        'decomposedDirs',
+        'parentOnlyDirs',
+        'hashFiles',
+        'topHashDirs',
+        'exit',
+      ]) + '\n',
+    );
+  } catch (err) {
+    process.stderr.write(`sweep error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/audit/type-pairs.ts
+++ b/scripts/audit/type-pairs.ts
@@ -1,0 +1,82 @@
+/*
+ * (DirectoryName, MetadataSuffix) pairs used by the audit harness.
+ *
+ * The directory name is what Salesforce CLI plops into force-app/main/default/
+ * during retrieve; the suffix is what `decomposer (de|re)compose -m <suffix>`
+ * expects (matches MetadataResolver / source-deploy-retrieve registration).
+ *
+ * The two diverge for several types — `customMetadata` uses suffix `md`,
+ * `applications` uses `app`, and so on — which is why we keep this as
+ * explicit data rather than deriving one from the other.
+ *
+ * Per-pair `sample` overrides exist for types that round-trip slowly enough
+ * (custom metadata records, report types) that capping speeds up CI without
+ * losing signal.
+ */
+
+import type { TypePair } from './lib.js';
+
+/**
+ * Decompose-only sweep: tally hash-filename counts across many types to
+ * surface uniqueIdElements coverage opportunities. This is the broad net.
+ */
+export const SWEEP_PAIRS: readonly TypePair[] = [
+  { type: 'reportTypes', suffix: 'reportType' },
+  { type: 'flexipages', suffix: 'flexipage' },
+  { type: 'territory2Models', suffix: 'territory2Model' },
+  { type: 'globalValueSets', suffix: 'globalValueSet' },
+  { type: 'standardValueSets', suffix: 'standardValueSet' },
+  { type: 'applications', suffix: 'app' },
+  { type: 'networks', suffix: 'network' },
+  { type: 'duplicateRules', suffix: 'duplicateRule' },
+  { type: 'queueRoutingConfigs', suffix: 'queueRoutingConfig' },
+  { type: 'liveChatButtons', suffix: 'liveChatButton' },
+  { type: 'liveChatDeployments', suffix: 'liveChatDeployment' },
+  { type: 'liveChatAgentConfigs', suffix: 'liveChatAgentConfig' },
+  { type: 'presenceUserConfigs', suffix: 'presenceUserConfig' },
+  { type: 'connectedApps', suffix: 'connectedApp' },
+  { type: 'cspTrustedSites', suffix: 'cspTrustedSite' },
+  { type: 'customPermissions', suffix: 'customPermission' },
+  { type: 'genAiFunctions', suffix: 'genAiFunction' },
+  { type: 'genAiPromptTemplates', suffix: 'genAiPromptTemplate' },
+  { type: 'genAiPlugins', suffix: 'genAiPlugin' },
+  { type: 'omniSupervisorConfigs', suffix: 'omniSupervisorConfig' },
+  { type: 'pathAssistants', suffix: 'pathAssistant' },
+  { type: 'skills', suffix: 'skill' },
+  { type: 'groups', suffix: 'group' },
+  { type: 'queues', suffix: 'queue' },
+  { type: 'remoteSiteSettings', suffix: 'remoteSite' },
+  { type: 'samlssoconfigs', suffix: 'samlssoconfig' },
+  { type: 'mlDomains', suffix: 'mlDomain' },
+  { type: 'milestoneTypes', suffix: 'milestoneType' },
+  { type: 'pages', suffix: 'page' },
+  { type: 'tabs', suffix: 'tab' },
+  { type: 'sites', suffix: 'site' },
+  { type: 'experiences', suffix: 'experience' },
+  { type: 'serviceChannels', suffix: 'serviceChannel' },
+  { type: 'externalCredentials', suffix: 'externalCredentials' },
+  { type: 'roles', suffix: 'role' },
+];
+
+/**
+ * Round-trip integrity audit: decompose then recompose and assert
+ * (origFiles == rebuiltFiles && contentSetDiff == 0). This is the focused
+ * net for types that carry the highest collision risk, with per-type sample
+ * caps for the slow ones.
+ */
+export const ROUNDTRIP_PAIRS: readonly TypePair[] = [
+  { type: 'quickActions', suffix: 'quickAction' },
+  { type: 'customMetadata', suffix: 'md', sample: 200 },
+  { type: 'pathAssistants', suffix: 'pathAssistant' },
+  { type: 'omniSupervisorConfigs', suffix: 'omniSupervisorConfig' },
+  { type: 'genAiPromptTemplates', suffix: 'genAiPromptTemplate' },
+  { type: 'mlDomains', suffix: 'mlDomain' },
+  { type: 'liveChatAgentConfigs', suffix: 'liveChatAgentConfig' },
+  { type: 'liveChatButtons', suffix: 'liveChatButton' },
+  { type: 'duplicateRules', suffix: 'duplicateRule' },
+  { type: 'queues', suffix: 'queue' },
+  { type: 'reportTypes', suffix: 'reportType', sample: 100 },
+  { type: 'applications', suffix: 'app' },
+  { type: 'entitlementProcesses', suffix: 'entitlementProcess' },
+  { type: 'approvalProcesses', suffix: 'approvalProcess' },
+];


### PR DESCRIPTION
## Summary

Replaces the temporary PowerShell scripts that drove PR #430, #432, and #433 with three portable Node.js scripts under `scripts/audit/`. Pure Node builtins, no extra dependencies, runs on macOS / Linux / Windows.

Wires the harness via three new npm scripts:

- `npm run audit` — single (type, suffix) round-trip with detailed per-file indicators.
- `npm run audit:sweep` — broad decompose-only sweep across 35 metadata types, ranks them by SHA-256 hash-filename count to surface `uniqueIdElements` coverage opportunities.
- `npm run audit:roundtrip` — focused round-trip integrity audit across 14 high-risk types with per-type sample caps. Exits non-zero when any type shows real data loss (`contentSetDiff > 0` or file-count mismatch).

The audit indicators are unchanged from the PowerShell version (`origFiles`, `rebuiltFiles`, `decomposedDirs`, `perComponentDirs`, `parentOnlyDirs`, `hashFiles`, `contentSetMatch`, `contentSetDiff`, `missing`). One refinement: the exit code now gates only on signals that always indicate a real bug — `contentSetDiff > 0` or `rebuiltFiles != origFiles`. `parentOnlyDirs` stays in the table for inspection but doesn't gate, because types whose fullNames legitimately contain no dot (e.g. `quickActions` on `Global`, most non-dotted types) would otherwise produce false positives.

## Validation

Smoke-tested against a real Salesforce metadata archive. The harness immediately surfaced two follow-up bugs in the upstream `config-disassembler` Rust crate, both already filed:

| Issue | Trigger | Status |
|---|---|---|
| [config-disassembler#24](https://github.com/mcarvin8/config-disassembler/issues/24) | Compound `unique_id_elements` resolves to the same filename for two siblings → silent overwrite | Filed before this PR (motivated by PR #433 perf fixture). |
| [config-disassembler#25](https://github.com/mcarvin8/config-disassembler/issues/25) | Unique-ID value contains `/` (illegal path char) → silent data loss. Surfaced by the new harness on an `EntitlementProcess` whose `milestoneName` was `TrustFile Transaction Sync/Import Complete`. | Filed by this PR. |

Both are outside this PR's scope — they live in the Rust crate, will be addressed in a future `config-disassembler` release, and the harness flags them clearly when they fire.

## Test plan

- [x] `npx tsc -p scripts/tsconfig.json --noEmit` (clean)
- [x] Lint passes (auto-formatted on commit by the existing wireit lint hook)
- [x] `npm run audit -- --type quickActions --suffix quickAction --source-root <real-archive> --sample 20` → exits 0, `contentSetDiff=0`
- [x] `npm run audit:sweep -- --source-root <real-archive> --sample 5` → completes across 35 types, sorts by hash count
- [x] `npm run audit:roundtrip -- --source-root <real-archive> --sample 10` → exits 2 with a clear FAIL message naming the offending type (issue 25 above), passes for all 13 other audited types
- [x] `--help` / `-h` works on all three scripts
- [x] Cross-file imports work via `node --loader ts-node/esm` (Node 22 compatible)
