### PR TITLE
feat(deps): bump config-disassembler to 1.3.0 (sanitize + collision detection)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "^8.26.3",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.0",
-        "config-disassembler": "^1.2.1",
+        "config-disassembler": "^1.3.0",
         "fast-xml-parser": "^5.7.2",
         "p-limit": "^7.3.0"
       },
@@ -5448,9 +5448,9 @@
       "dev": true
     },
     "node_modules/config-disassembler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.2.1.tgz",
-      "integrity": "sha512-POJprmhmqW71F6hLoNpnMMbYedFMi9rtTFJKgXyN3zcyL6MTbcit60mFNMFbDyqnEogWIYFsWcaWc0LiQtagbw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.3.0.tgz",
+      "integrity": "sha512-XfSYBvD2jeqZAoizAoy7DRqQBRtUQtXI3nOM+3o+O02f+5CkSLST0ZfpQEMamGXxWp0iLDvI9fKyRxWmCIiEww==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "^8.26.3",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.0",
-    "config-disassembler": "^1.2.1",
+    "config-disassembler": "^1.3.0",
     "fast-xml-parser": "^5.7.2",
     "p-limit": "^7.3.0"
   },


### PR DESCRIPTION
## Summary

Bumps the `config-disassembler` Node binding from **^1.2.1** to **^1.3.0** to pick up the two upstream fixes for silent data-loss bugs in `uniqueIdElements`-driven decomposition ([config-disassembler-node#13](https://github.com/mcarvin8/config-disassembler-node/pull/13), [config-disassembler#26](https://github.com/mcarvin8/config-disassembler/pull/26)).

## What changed upstream

- **Path-segment sanitization** — resolved `uniqueIdElements` values are passed through a sanitizer before being used as a filename. Path separators (`/`, `\`), Windows-reserved chars (`:`, `*`, `?`, `"`, `<`, `>`, `|`), and ASCII control bytes are each replaced with `_`; trailing dots and spaces are stripped (Windows would strip them silently on write, creating cross-platform name drift). So a Salesforce `EntitlementProcess` milestone named `TrustFile Transaction Sync/Import Complete` now produces the shard `TrustFile Transaction Sync_Import Complete.milestones-meta.xml` on every platform instead of the `/` being interpreted as a directory separator and dropping the milestone on round-trip.
- **Sibling-collision detection** — when two or more nested siblings derive the same unique-id (because the configured `uniqueIdElements` is too narrow for the metadata type, or because sanitization folded distinct values into the same form), the disassembler falls back to per-element 8-character SHA-256 hashes for the **entire** colliding group. Each colliding sibling lands in its own shard, a `WARN` log names the parent tag and the collided id, and no row is silently overwritten on disk.

Both behaviors are applied automatically with no plugin-side configuration change. Existing readable `uniqueIdElements` configurations (single-field, compound) keep producing identical filenames — the sanitizer is a no-op for safe identifiers, and the collision detector only fires when siblings actually collide.

## Why it matters

Both bugs were originally surfaced by the audit harness in #435 against a real-world Salesforce metadata archive. The two failure modes pre-fix:

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Two `<actionOverrides>` resolve to the same compound key | Second write overwrites the first; one row vanishes | Both rows fall back to SHA-256 hashes; both written; `WARN` logged |
| `<milestoneName>` contains `/` | Interpreted as a path separator at shard-write time; milestone vanishes from disassembled output | `/` mapped to `_`; round-trip preserves the original `/` in the rebuilt XML |
| `<fullName>` ends in `.` or space | Windows silently strips trailing char on write; collides with the un-trailed peer | Trailing `.` or space stripped deterministically before write; same filename on Linux and Windows |

## Verification

- [x] `npm test` — 100% pass against `config-disassembler@1.3.0`.
- [x] `npm run audit:roundtrip` against `it-business-process` (the archive whose audit run originally flagged both bugs) confirms the previously-observed data loss in `entitlementProcesses` (one milestone dropped per round-trip due to `/` in `milestoneName`) is resolved.
- [x] No plugin code changes required — the upgrade is purely transitive.

## Backwards compatibility

No public API changes. `uniqueIdElements` strings that worked before continue to produce identical output. The sanitizer borrows rather than allocates for the vast majority of Salesforce identifiers (`fullName`, `name`, `developerName`, etc. — all alphanumeric + `_` + `-` + `.`), and collision detection is a pre-pass that only kicks in when two siblings actually derive the same id.

## Follow-up

Considering a CI/CD job that runs the audit harness against a curated set of synthetic metadata fixtures designed to exercise the failure-mode shapes (collision, illegal char, dotted fullName, multi-level). This would gate future regressions to the same bug classes without requiring access to a private metadata archive. Tracking separately so this PR stays a clean dependency bump.
