### PR TITLE
test(perf): plant illegal milestoneName chars to guard #25 sanitization

### DIFF
--- a/scripts/gen-perf-fixtures.ts
+++ b/scripts/gen-perf-fixtures.ts
@@ -47,6 +47,14 @@ export interface SizeSpec {
   application: { actionOverrides: number; profileActionOverrides: number; tabs: number };
   globalValueSet: { customValues: number };
   bot: { dialogs: number; mlIntents: number };
+  // Round-trip regression target for path-segment sanitization (config-disassembler
+  // 0.5.0 / config-disassembler-node 1.3.0). A non-trivial subset of the generated
+  // milestoneName values contains characters that are illegal in a path segment
+  // (`/`, `:`, `*`, `?`, etc.). Sanitization is a no-op for safe identifiers, so
+  // existing perf coverage is unaffected; if sanitization ever regresses, those
+  // milestones either fail to write or land in phantom subdirectories and the
+  // recomposed bytes drop below the 0.99 retention threshold.
+  entitlementProcess: { milestones: number };
 }
 
 const PROFILES: Record<Profile, SizeSpec> = {
@@ -76,6 +84,7 @@ const PROFILES: Record<Profile, SizeSpec> = {
     application: { actionOverrides: 100, profileActionOverrides: 50, tabs: 20 },
     globalValueSet: { customValues: 100 },
     bot: { dialogs: 30, mlIntents: 20 },
+    entitlementProcess: { milestones: 30 },
   },
   medium: {
     permissionSet: {
@@ -103,6 +112,7 @@ const PROFILES: Record<Profile, SizeSpec> = {
     application: { actionOverrides: 500, profileActionOverrides: 250, tabs: 50 },
     globalValueSet: { customValues: 500 },
     bot: { dialogs: 150, mlIntents: 80 },
+    entitlementProcess: { milestones: 80 },
   },
   large: {
     // Calibrated against shapes seen in large 10+ year-old orgs:
@@ -133,6 +143,7 @@ const PROFILES: Record<Profile, SizeSpec> = {
     application: { actionOverrides: 2_500, profileActionOverrides: 1_500, tabs: 100 },
     globalValueSet: { customValues: 1_500 },
     bot: { dialogs: 600, mlIntents: 250 },
+    entitlementProcess: { milestones: 150 },
   },
   xlarge: {
     permissionSet: {
@@ -160,6 +171,7 @@ const PROFILES: Record<Profile, SizeSpec> = {
     application: { actionOverrides: 5_000, profileActionOverrides: 3_000, tabs: 200 },
     globalValueSet: { customValues: 3_000 },
     bot: { dialogs: 1_200, mlIntents: 500 },
+    entitlementProcess: { milestones: 300 },
   },
 };
 
@@ -751,6 +763,56 @@ function genBotVersion(spec: SizeSpec['bot']): string {
   return lines.join('\n') + '\n';
 }
 
+function genEntitlementProcess(spec: SizeSpec['entitlementProcess']): string {
+  // milestoneName is the unique-id key for this metadata type (see
+  // src/metadata/uniqueIdElements.ts). About 30% of the names below contain a
+  // `/` and one contains `:` so the disassembler exercises path-segment
+  // sanitization on every perf run. With sanitization in place the resulting
+  // shard filenames are safe and the file reassembles 1:1; if sanitization
+  // ever regresses the writes either fail (`/` makes the parent dir bogus on
+  // all platforms) or land in phantom subdirectories, dropping the recomposed
+  // bytes well below the 0.99 retention threshold and failing this suite.
+  const milestoneNameTemplates = [
+    'Initial Response',
+    'Sync/Import',
+    'First Engagement',
+    'Standard Resolution',
+    'Customer/Callback',
+    'Verify Action',
+    'Confirm:Step',
+    'Final Closure',
+    'Approval/Reject',
+    'Continue Path',
+  ] as const;
+
+  const lines: string[] = [];
+  lines.push(XML_HEADER + `<EntitlementProcess${NS}>`);
+  lines.push('    <SObjectType>Case</SObjectType>');
+  lines.push('    <active>true</active>');
+  lines.push('    <description>Synthetic entitlement process for performance testing.</description>');
+  lines.push('    <entryStartDateField>EntitlementStartDate</entryStartDateField>');
+  lines.push('    <isRecordTypeApplied>false</isRecordTypeApplied>');
+  lines.push('    <isVersionDefault>true</isVersionDefault>');
+
+  for (let i = 1; i <= spec.milestones; i++) {
+    const template = pick(milestoneNameTemplates, i);
+    lines.push('    <milestones>');
+    lines.push(`        <minutesToComplete>${(i % 240) + 15}</minutesToComplete>`);
+    lines.push('        <startDateField>CreatedDate</startDateField>');
+    // Counter suffix keeps every milestoneName unique so the disassembler is
+    // exercising sanitization (not the SHA-256 collision fallback).
+    lines.push(`        <milestoneName>${template} ${pad(i, 4)}</milestoneName>`);
+    lines.push('    </milestones>');
+  }
+
+  lines.push('    <name>Mega Entitlement Process</name>');
+  lines.push('    <versionMaster>Mega_EntitlementProcess</versionMaster>');
+  lines.push('    <versionNotes>Synthetic v1</versionNotes>');
+  lines.push('    <versionNumber>1</versionNumber>');
+  lines.push('</EntitlementProcess>');
+  return lines.join('\n') + '\n';
+}
+
 // ---------------------------------------------------------------------------
 // Layout / driver
 // ---------------------------------------------------------------------------
@@ -830,6 +892,12 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   );
   await writeOut(outDir, `${base}/bots/Mega_Bot/Mega_Bot.bot-meta.xml`, genBot(), files);
   await writeOut(outDir, `${base}/bots/Mega_Bot/v1.botVersion-meta.xml`, genBotVersion(spec.bot), files);
+  await writeOut(
+    outDir,
+    `${base}/entitlementProcesses/Mega_EntitlementProcess.entitlementProcess-meta.xml`,
+    genEntitlementProcess(spec.entitlementProcess),
+    files,
+  );
 
   const totalBytes = files.reduce((s, f) => s + f.bytes, 0);
   return { outDir, profile, files, totalBytes };

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -56,6 +56,11 @@ const DEFAULT_METADATA_TYPES = [
   'bot',
   'app',
   'globalValueSet',
+  // entitlementProcess intentionally exercises path-segment sanitization: the
+  // generator plants `/` and `:` in milestoneName values so a regression of
+  // the config-disassembler 0.5.0 sanitization fix would shrink the
+  // recomposed file below the RETENTION_THRESHOLD guard below.
+  'entitlementProcess',
 ];
 const METADATA_TYPES = envList('PERF_TYPES', DEFAULT_METADATA_TYPES);
 


### PR DESCRIPTION
## Summary

- Adds an `EntitlementProcess` fixture (`Mega_EntitlementProcess.entitlementProcess-meta.xml`) to `gen-perf-fixtures.ts`. Roughly 30% of generated `milestoneName` values intentionally contain `/`, plus one template uses `:`, so path-segment sanitization is exercised on every perf run.
- Registers `entitlementProcess` in `DEFAULT_METADATA_TYPES` for `decompose.perf.ts` so the existing 0.99 byte-retention guard now covers the sanitization codepath in addition to the collision-detection codepath already covered by `Mega.app`.
- No new CI job, infra, or fixture-tree shape change. The pre-existing `perf.yml` workflow now catches regressions of `config-disassembler#25` (path-segment sanitization, fixed in Rust 0.5.0 / Node 1.3.0) for free.

## Why this catches a regression

If sanitization is ever stripped or weakened, milestone shards whose names contain `/` either:

- fail to write outright (parent dir does not exist on Linux, macOS, or Windows), or
- land in phantom subdirectories that the recompose walk does not pick up correctly.

Either way, the recomposed `entitlementProcess-meta.xml` ends up smaller than the generator-emitted bytes, the existing per-file ratio check trips below the `RETENTION_THRESHOLD = 0.99`, and the perf job fails with a pointed `data loss on round-trip for ...` message.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc -p . --noEmit` clean
- [x] `PERF_PROFILE=small PERF_FORMATS=xml npm run test:perf` passes locally (round-trip stable, idempotent on the new fixture)
- [ ] CI `perf.yml` runs green on this branch
