### PR TITLE
docs: document filename safety, RUST_LOG=warn, and refreshed pitfalls

### DIFF
--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -280,7 +280,7 @@ sf decomposer verify -t bot --config
 You probably ran two `decompose` invocations back-to-back, one rule each. Don't. The disassembler rewrites `.multi_level.json` on every run, so each call replaces the prior one. Pass every rule for a given component in **one** override entry, in array form.
 
 **2. "My `multiLevel` rule is correct but recompose produces a smaller file."**
-Almost always a unique-id collision. Two array items resolved to the same filename and one overwrote the other on disk. Add a tiebreaker to `unique_id_elements` (e.g. `developerName,id`) and re-decompose with `prePurge: true`.
+This used to be the silent-overwrite symptom of a unique-id collision and was the canonical reason to widen `unique_id_elements`. As of `config-disassembler` Rust 0.5.0 / Node 1.3.0, sibling collisions are detected and every colliding row is written to its own SHA-256-named shard, so a true collision no longer shrinks the recomposed file — it just produces hash-named shards (see pitfall #5 below) and a `WARN` log under `RUST_LOG=warn`. If you genuinely see a smaller recomposed file on a current build, treat it as a regression and capture the offending fixture; otherwise the right next step for hash-named shards is the same: add a tiebreaker to `unique_id_elements` (e.g. `developerName,id`) and re-decompose with `prePurge: true`.
 
 **3. "Component-scope override fields look ignored."**
 Component-scope wins over type-scope, but only for fields **the component override explicitly sets**. Fields it leaves out fall through to the type-scope value, then to the run-wide default. If you set `decomposedFormat: "yaml"` on a type and `strategy: "grouped-by-tag"` on the component, the component still gets `decomposedFormat: "yaml"` from the type override.
@@ -289,7 +289,10 @@ Component-scope wins over type-scope, but only for fields **the component overri
 That's by design for `multiLevel` types only. Multi-level recompose has to clean up inner-level directories so the next level can merge their reassembled XML. If you want the decomposed tree preserved for inspection, copy it before running `recompose`.
 
 **5. "Decompose succeeded but my decomposed files all have hash names."**
-Your `unique_id_elements` (or the rule's third part) didn't resolve to a non-empty value on those items. Check the source XML for the elements you listed — names are case-sensitive and live at the immediate child level of each repeating item. The plugin only walks one level deep when picking a UID.
+There are two distinct causes; run the decompose under `RUST_LOG=warn` to tell them apart:
+
+- **No `WARN` line.** Your `unique_id_elements` (or the rule's third part) didn't resolve to a non-empty value on those items. Check the source XML for the elements you listed — names are case-sensitive and live at the immediate child level of each repeating item. The plugin only walks one level deep when picking a UID.
+- **A `WARN` line of the form `uniqueIdElements collision: <parentTag> id "X" matched N sibling elements`.** The configured key is too narrow — multiple siblings legitimately share the same value, so the collision detector falls back to per-element SHA-256 hashes for that group rather than overwrite. Add a tiebreaker to `unique_id_elements` (e.g. a compound like `name+recordType`) and re-decompose with `prePurge: true`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,15 @@ permissionsets/
     └── userPermissions.xml
 ```
 
+### Filename safety (unique-id)
+
+Two safety nets are applied automatically to every shard filename emitted by the **unique-id** strategy. Neither requires configuration:
+
+- **Path-segment sanitization.** When a unique-id value contains characters that are illegal or reserved on at least one supported filesystem — path separators (`/`, `\`), Windows-reserved chars (`:`, `*`, `?`, `"`, `<`, `>`, `|`), or ASCII control bytes — each is replaced with `_`, and trailing `.` and spaces are stripped. So an `EntitlementProcess` milestone named `TrustFile Transaction Sync/Import Complete` yields the shard `TrustFile Transaction Sync_Import Complete.milestones-meta.xml` on every platform, instead of `/` being interpreted as a directory separator.
+- **Sibling-collision fallback.** After sanitization, if two or more siblings of the same parent tag would still resolve to the same shard filename (because the configured unique-id elements are too narrow for that metadata type, or because sanitization happened to fold two distinct values into the same form), every sibling in the colliding group falls back to a per-element 8-character SHA-256 hash. No row is silently overwritten on disk.
+
+Path-segment sanitization is silent — sanitized filenames round-trip identically and are byte-stable across platforms, so there is nothing to warn about. Sibling-collision fallback, by contrast, emits one `WARN` line per colliding group (parent tag, collided id, sibling count) so you can decide whether to widen `uniqueIdElements` for that metadata type. By default these are filtered out — see [Rust crate logging](#xml-disassemble-output-rust-crate) below for how to surface them. If you see a hash-named shard in your output and want to know why, that's the first place to look.
+
 ### Custom Labels Decomposition
 
 Custom labels use only the **unique-id** strategy. If you pass `grouped-by-tag`, the plugin overrides to `unique-id` and continues. Grouping labels by tag would produce no difference from the original file since all elements share the same tag. Each label is written to its own file.
@@ -463,12 +472,24 @@ For example, if you attempt to decompose Custom Labels but none of your package 
 
 The config-disassembler Node plugin uses a **Rust crate** for XML decomposing and recomposing. Disassemble errors and messages are shown in the terminal.
 
-Control verbosity with the `RUST_LOG` environment variable (e.g. `RUST_LOG=debug` for detailed output).
+Control verbosity with the `RUST_LOG` environment variable. The crate uses [env_logger](https://docs.rs/env_logger), so the standard level filters apply: `error`, `warn`, `info`, `debug`, `trace`. By default only `error`-level lines are surfaced, which is why you would not see filename-safety warnings (sibling-collision fallback, path-segment sanitization) without opting in.
 
-Example output in the terminal (Rust log format):
+| Level                 | What it covers                                                                                                                                                                                                                                                       |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RUST_LOG=error`      | Default. Skipped files (leaf-only XML), parse errors.                                                                                                                                                                                                                |
+| `RUST_LOG=warn`       | Adds [sibling-collision fallback](#filename-safety-unique-id) signals — one line per colliding group naming the parent tag, the collided id, and the sibling count, so you can decide whether to widen `uniqueIdElements` for that metadata type. Recommended in CI. |
+| `RUST_LOG=info,debug` | Per-element decomposition tracing. Verbose; useful for plugin development, not day-to-day use.                                                                                                                                                                       |
+
+Example terminal output at the default `error` level (a leaf-only file):
 
 ```
 [2026-04-30T12:34:38Z ERROR config_disassembler::xml::builders::build_disassembled_files] The XML file C:\Users\matthew.carvin\Documents\sf-decomposer\fixtures\package-dir-1\permissionsets\only_leafs.permissionset-meta.xml only has leaf elements. This file will not be disassembled.
+```
+
+Example with `RUST_LOG=warn` set, for a `CustomApplication` whose configured unique-id was too narrow for one group of `actionOverrides` siblings:
+
+```
+[2026-05-04T15:21:09Z WARN config_disassembler::xml::builders::build_disassembled_files] uniqueIdElements collision: <actionOverrides> id "View" matched 4 sibling elements; falling back to SHA-256 content hashes for the colliding group. Consider adding more discriminating fields to uniqueIdElements for this metadata type.
 ```
 
 ### Files with only leaf elements


### PR DESCRIPTION
## Summary

Documents the two filename-safety nets that came in with `config-disassembler` 0.5.0 / `-node` 1.3.0 (path-segment sanitization and sibling-collision SHA-256 fallback) and explains how to surface the collision `WARN` line via `RUST_LOG=warn`. Also corrects two HANDBOOK pitfalls whose diagnoses described the pre-0.5.0 silent-overwrite world.

### README.md

- New `### Filename safety (unique-id)` subsection inside `## Decompose Strategies`. Names both behaviors, notes sanitization is silent (sanitized filenames round-trip identically and are byte-stable across platforms), and points at the Rust-crate logging section for the collision `WARN`.
- Expanded `### XML disassemble output (Rust crate)` with a level table (`error` / `warn` / `info,debug`), a refreshed leaf-only ERROR example, and a real `WARN` example using the actual `uniqueIdElements collision: <parentTag> id "X" matched N sibling elements; ...` line emitted by `build_disassembled_files.rs` so readers know exactly what to grep for.

### HANDBOOK.md

- **Pitfall #2** ("smaller recomposed file") is no longer the symptom of a unique-id collision on current builds — collision fallback writes hash-named shards instead of overwriting. Rewritten to call out hash-named shards + `WARN` as the modern symptom, and to flag a smaller recomposed file as a regression worth capturing.
- **Pitfall #5** ("all decomposed files have hash names") split by root cause: missing UID resolution (no `WARN`) vs collision fallback (a `WARN` line naming the parent tag). `RUST_LOG=warn` is the disambiguator.

## Why now

Without this, a user who hits a true collision (or runs against an org whose `EntitlementProcess` milestoneNames embed `/`) sees SHA-256-named shards in their tree and has no in-band signal explaining the safety net. The `log::warn!` is already there; it just defaults to filtered out. This PR makes that visible without changing any behavior.

## Test plan

- [x] `npm run lint` clean
- [x] WARN line text in the README mirrors `src/xml/builders/build_disassembled_files.rs::resolve_collision_safe_ids` verbatim (parent-key, id, count, fallback rationale).
- [x] No code changes; HANDBOOK + README only.
- [ ] CI green on this branch.
