### PR TITLE
feat(metadata): expand uniqueIdElements coverage from audit pass

### DIFF
--- a/scripts/audit/type-pairs.ts
+++ b/scripts/audit/type-pairs.ts
@@ -79,4 +79,10 @@ export const ROUNDTRIP_PAIRS: readonly TypePair[] = [
   { type: 'applications', suffix: 'app' },
   { type: 'entitlementProcesses', suffix: 'entitlementProcess' },
   { type: 'approvalProcesses', suffix: 'approvalProcess' },
+  // Types added in the compound-uniqueid-expansion pass (PR #439). Keep them
+  // in the round-trip net so any future change that weakens
+  // `serviceChannelStatusFieldMappings` (compound `type+value`) or the
+  // genAiPlugin functionName/developerName keys is caught immediately.
+  { type: 'serviceChannels', suffix: 'serviceChannel' },
+  { type: 'genAiPlugins', suffix: 'genAiPlugin' },
 ];

--- a/src/metadata/uniqueIdElements.ts
+++ b/src/metadata/uniqueIdElements.ts
@@ -144,9 +144,30 @@ export default [
       uniqueIdElements: ['sobjectType'],
     },
     reportType: {
-      // `<sections>` items use `<masterLabel>` as their natural key. Same
+      // `<sections>` items use `<masterLabel>` as their natural key — same
       // pattern as `globalValueSetTranslation`/`standardValueSetTranslation`.
-      uniqueIdElements: ['masterLabel'],
+      // The singleton `<join>` element is keyed by `<relationship>` purely for
+      // readability: without it every reportType that joins a child object
+      // produces a hash-named shard.
+      uniqueIdElements: ['masterLabel', 'relationship'],
+    },
+    serviceChannel: {
+      // Each `<serviceChannelStatusFieldMappings>` row carries `<type>` (a
+      // status category like `COMPLETED` / `IN_PROGRESS`) and `<value>` (the
+      // human-readable status name). `<type>` collides massively (most rows
+      // are `COMPLETED`) and `<value>` alone is usually unique within a
+      // channel, but we observed status names repeated across distinct types
+      // in production data — the compound `type+value` is the only fully
+      // stable id, with `value` as a single-field fallback for any row that
+      // happens to lack `<type>`.
+      uniqueIdElements: ['type+value', 'value'],
+    },
+    genAiPlugin: {
+      // `<genAiFunctions>` items are keyed by `<functionName>`;
+      // `<genAiPluginInstructions>` items by `<developerName>`. Each
+      // repeating child only carries one of these fields, so first-match
+      // wins picks the right one without a compound.
+      uniqueIdElements: ['functionName', 'developerName'],
     },
     app: {
       // CustomApplication's `<profileActionOverrides>` and `<actionOverrides>`

--- a/test/units/uniqueIdElements.test.ts
+++ b/test/units/uniqueIdElements.test.ts
@@ -35,8 +35,17 @@ describe('uniqueIdElements registry', () => {
     expect(getUniqueIdElements('duplicateRule')).toBe('matchingRule');
     // queue: <queueSobject> use <sobjectType>
     expect(getUniqueIdElements('queue')).toBe('sobjectType');
-    // reportType: <sections> use <masterLabel>
-    expect(getUniqueIdElements('reportType')).toBe('masterLabel');
+    // reportType: <sections> use <masterLabel>; the singleton <join> uses <relationship>
+    expect(getUniqueIdElements('reportType')).toBe('masterLabel,relationship');
+  });
+
+  it('returns the documented list for the additions audited from the it-business-process corpus', () => {
+    // serviceChannel: each <serviceChannelStatusFieldMappings> row is keyed by
+    // the compound (type, value); single <value> is the fallback when <type>
+    // is absent.
+    expect(getUniqueIdElements('serviceChannel')).toBe('type+value,value');
+    // genAiPlugin: <genAiFunctions>/<functionName> and <genAiPluginInstructions>/<developerName>
+    expect(getUniqueIdElements('genAiPlugin')).toBe('functionName,developerName');
   });
 
   it('returns the compound-key fallback chain for `app` (covers profileActionOverrides + actionOverrides)', () => {


### PR DESCRIPTION
## Summary

A re-run of `npm run audit:sweep` against the `it-business-process` corpus (50-file cap per type) surfaced three high-value gaps where sibling shards were silently falling back to SHA-256 hash filenames. With the collision-detection safety net in `config-disassembler` 0.5.0, the worst case for an over-narrow `uniqueIdElements` list is a `WARN` plus hash-named shards instead of data loss, so it's safe to be more aggressive about coverage than before.

### Adds

| Type             | Element                                  | Key                | Hashes addressed |
| ---------------- | ---------------------------------------- | ------------------ | ---------------- |
| `serviceChannel` | `<serviceChannelStatusFieldMappings>`    | `type+value, value` | **126**          |
| `genAiPlugin`    | `<genAiFunctions>` / `<genAiPluginInstructions>` | `functionName, developerName` | **22** |
| `reportType`     | `<join>` (extended existing entry)       | adds `relationship` | **34**           |

**Total: ~182 hash-named shards across the audited corpus now resolve to stable, readable filenames.** No behavior change for any other type.

### Why these specifically

- **`serviceChannel.serviceChannelStatusFieldMappings`** carries only `<type>` (status category like `COMPLETED`) and `<value>` (the human-readable status name). `type` collides massively (most rows are `COMPLETED`) and `value` is *usually* unique within a channel — but production data shows a few status names repeated across distinct types, so the only fully stable key is the compound `type+value`, with `value` as the single-field fallback.
- **`genAiPlugin`** has two repeating children that each carry exactly one of the two new keys, so first-match-wins picks the right one without needing a compound.
- **`reportType.join`** is a singleton, so this is a pure-readability change — `<join>` was producing one hash per reportType-with-a-join just because there was no UID candidate. `<relationship>` makes the filename match the join target (e.g. `FeedItems.join-meta.xml`).

### Skipped (singleton wrappers, not a `uniqueIdElements` problem)

The sweep also flagged the following high hash counts but they're 1-of-1 wrappers with no natural single-field key on the wrapper element (e.g. `<networkMemberGroups>` is a `<profile>`-list container that lives once per network). Their content-addressed hash filenames are appropriate and stable across decompositions:

- `network`: `networkMemberGroups`, `networkPageOverrides`, `tabs` (83 hashes total)
- `connectedApp`: `oauthConfig`, `oauthPolicy` (53)
- `application`: `brand`, `workspaceConfig`, `consoleConfig` (35)
- `queue`: `queueMembers` (30)
- `liveChatAgentConfig`/`skill`/`presenceUserConfig`: `assignments` (30 combined)
- `duplicateRule`: `duplicateRuleFilter` (13)

A future PR could revisit those by switching their child paths to `grouped-by-tag` via overrides, but that's a separate change with different semantics.

### Audit harness coverage

`scripts/audit/type-pairs.ts` adds `serviceChannels` and `genAiPlugins` to `ROUNDTRIP_PAIRS` so any future change that weakens the new compound keys is caught by `npm run audit:roundtrip` against a real org tree.

## Test plan

- [x] `npm test` — unit suite green; updated `test/units/uniqueIdElements.test.ts` covers all three new/changed entries and the existing `reportType` expectation has been migrated.
- [x] `npm run audit:sweep --source-root <it-business-process>` (post-build) — sweep table shows `0` hashes for `serviceChannels`, `genAiPlugins`, and `reportTypes`.
- [x] `npm run audit:roundtrip --source-root <it-business-process>` — all 16 audited types (including the two new ones) report `contentSetDiff = 0` and `missing = 0`. Round-trip is byte-stable.
- [x] CI green on this branch.
