### PR TITLE
chore(perf,docs): log per-file retention; tighten README/HANDBOOK/CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,26 +96,26 @@ The default `npm test` runs the full pipeline (compile, lint, unit tests). Use i
 
 ### Metadata and SDR
 
-Metadata attributes (except unique-ID elements) come from this plugin’s version of **@salesforce/source-deploy-retrieve** (SDR). The `-m` / `--metadata-type` flag uses the metadata **suffix** from SDR’s registry.
+Metadata attributes (except unique-ID elements) come from this plugin's pinned version of **@salesforce/source-deploy-retrieve** (SDR). The `-m` / `--metadata-type` flag uses the metadata **suffix** from SDR's registry.
 
-Dependabot will check for SDR updates once a week and open a PR for new versions. If the PR version includes an update to the metadata registry file, a GitHub action will automatically merge the PR assuming all build checks pass. If the PR version of SDR contains no changes to the metadata registry file, the GitHub action will automatically close the PR.
+Dependabot opens a weekly PR for new SDR versions. A GitHub action auto-merges the PR if it bumps the registry file (after build checks pass) and auto-closes it otherwise.
 
 ### Unique ID elements
 
-Unique ID elements are used to name decomposed files for nested elements. The file that holds leaf elements keeps the original metadata file name.
+Unique ID elements name the decomposed files emitted by the `unique-id` strategy. The file that holds leaf elements keeps the original metadata file name.
 
-- **Defaults:** `fullName` and `name` for all metadata types.
-- **Overrides:** Edit `src/metadata/uniqueIdElements.ts`; use the metadata type’s **suffix** as the key.
-- **Fallback:** If no unique ID is found, the plugin uses a SHA-256 hash of the element content for the file name.
+- **Defaults:** `fullName` and `name`, for every metadata type.
+- **Overrides:** Edit `src/metadata/uniqueIdElements.ts`, keyed by the metadata type's **suffix**. Compound keys (e.g. `field1+field2`) join values with `__`.
+- **Fallback:** When no unique ID resolves, the plugin uses an 8-character SHA-256 hash of the element content. When two siblings would collide on the same id after sanitization, every member of the colliding group falls back to a hash and emits a `WARN` line (see [Filename safety](./README.md#filename-safety-unique-id) in the README).
 
 ### Config disassembler
 
-Core decompose/recompose logic lives in **[config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node)**, which uses a Rust crate to handle decomposing and recomposing files on the local disk. This plugin focuses on Salesforce metadata wiring (e.g. package dirs, SDR, strategies).
+The actual decompose/recompose work lives in **[config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node)** (a Rust crate behind a Node binding). This plugin focuses on Salesforce metadata wiring — package dirs, SDR, strategies, override resolution.
 
-- **In this plugin:** `src/service/decompose/decomposeFileHandler.ts` and `src/service/recompose/recomposeFileHandler.ts` call config-disassembler. Per-type / per-component override resolution happens in `src/helpers/configOverrides.ts` and is applied per file inside the decompose handler so different components of the same metadata type can be decomposed with different strategies/formats in one run.
-- **Changes to XML decompose/recompose behavior:** Contribute in the [config-disassembler](https://github.com/mcarvin8/config-disassembler) (Rust crate) and/or [config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node) repo.
+- **Where it's called:** `src/service/decompose/decomposeFileHandler.ts` and `src/service/recompose/recomposeFileHandler.ts`. Override resolution happens per-file in `src/helpers/configOverrides.ts`, so different components of the same metadata type can be decomposed with different strategies/formats in one run.
+- **Changing XML decompose/recompose behavior:** contribute in [config-disassembler](https://github.com/mcarvin8/config-disassembler) (Rust) and/or [config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node).
 
-Dependabot will check for config-disassembler updates once a week.
+Dependabot bumps both packages weekly.
 
 ---
 

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -126,9 +126,9 @@ Each dialog still gets its own folder, but steps live as flat `*.botSteps-meta.x
 >
 > The default still applies to every other bot.
 
-> **Agentforce vs Einstein.** Both share the `bot` suffix, so a single override entry covers both bot families. The structural difference (Agentforce uses richer `botFlowInvocation` and `genAi*` blocks where Einstein uses `botNavigation` and `mlIntents`) is invisible to this recipe — `multiLevel` rules only target the repeating sections that exist on each side. The plugin ships an `Internal_Copilot_Sample` fixture that exercises the Agentforce-style shape and an Einstein-style `Sample_Chat_Bot` fixture; both round-trip with the same recipe.
-
-> **Sibling order inside `botSteps`.** Recompose orders `<botSteps>` siblings alphabetically by their on-disk filename, not by their original document position. For bot deploys this is a no-op (Salesforce doesn't rely on step order at the XML level), but a freshly-recomposed file may show step entries shuffled compared to the source you originally pulled. The committed fixtures in this repo are baked from the recompose output for that reason — `sf decomposer verify` will treat the baked output as the source of truth.
+> **Agentforce vs Einstein.** Both share the `bot` suffix and are covered by a single override. Their structural differences (Agentforce: `botFlowInvocation`, `genAi*`; Einstein: `botNavigation`, `mlIntents`) are invisible to the recipe — `multiLevel` only targets the repeating sections that exist on each side.
+>
+> **Sibling order inside `botSteps`.** Recompose orders `<botSteps>` siblings alphabetically by on-disk filename, not by document position. Salesforce ignores step order at the XML level, so deploys are unaffected — but a freshly-recomposed file may show steps shuffled compared to the originally-retrieved source. The committed fixtures in this repo are baked from the recompose output for that reason; `sf decomposer verify` treats the baked output as the source of truth.
 
 ## Flexipages (Lightning App / Record / Home pages)
 
@@ -280,7 +280,7 @@ sf decomposer verify -t bot --config
 You probably ran two `decompose` invocations back-to-back, one rule each. Don't. The disassembler rewrites `.multi_level.json` on every run, so each call replaces the prior one. Pass every rule for a given component in **one** override entry, in array form.
 
 **2. "My `multiLevel` rule is correct but recompose produces a smaller file."**
-This used to be the silent-overwrite symptom of a unique-id collision and was the canonical reason to widen `unique_id_elements`. As of `config-disassembler` Rust 0.5.0 / Node 1.3.0, sibling collisions are detected and every colliding row is written to its own SHA-256-named shard, so a true collision no longer shrinks the recomposed file — it just produces hash-named shards (see pitfall #5 below) and a `WARN` log under `RUST_LOG=warn`. If you genuinely see a smaller recomposed file on a current build, treat it as a regression and capture the offending fixture; otherwise the right next step for hash-named shards is the same: add a tiebreaker to `unique_id_elements` (e.g. `developerName,id`) and re-decompose with `prePurge: true`.
+On `config-disassembler` Rust ≥ 0.5.0 / Node ≥ 1.3.0 this should not happen — sibling collisions are written to per-element SHA-256 shards and surfaced as a `WARN` (see pitfall #5), not silently overwritten. If you do see a shrunken recomposed file on a current build, treat it as a regression worth capturing as a fixture.
 
 **3. "Component-scope override fields look ignored."**
 Component-scope wins over type-scope, but only for fields **the component override explicitly sets**. Fields it leaves out fall through to the type-scope value, then to the run-wide default. If you set `decomposedFormat: "yaml"` on a type and `strategy: "grouped-by-tag"` on the component, the component still gets `decomposedFormat: "yaml"` from the type override.

--- a/README.md
+++ b/README.md
@@ -14,29 +14,17 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
   <summary>Table of Contents</summary>
 
 - [Quick Start](#quick-start)
+- [Requirements](#requirements)
 - [Why sf-decomposer?](#why-sf-decomposer)
 - [Commands](#commands)
-  - [sf decomposer decompose](#sf-decomposer-decompose)
-  - [sf decomposer recompose](#sf-decomposer-recompose)
-  - [sf decomposer verify](#sf-decomposer-verify)
 - [Manifest-scoped runs](#manifest-scoped-runs)
 - [Decompose Strategies](#decompose-strategies)
-  - [Custom Labels](#custom-labels-decomposition)
-  - [Permission Sets (grouped-by-tag)](#additional-permission-set-decomposition)
-  - [Loyalty Program Setup](#loyalty-program-setup-decomposition)
 - [Supported Metadata](#supported-metadata)
-  - [Exceptions](#exceptions)
 - [Troubleshooting](#troubleshooting)
 - [Hooks](#hooks)
 - [Per-Type & Per-Component Overrides](#per-type--per-component-overrides)
-  - [splitTags grammar](#splittags-grammar)
-  - [multiLevel grammar](#multilevel-grammar)
 - [Ignore Files](#ignore-files)
-  - [.forceignore](#forceignore)
-  - [.sfdecomposerignore](#sfdecomposerignore)
-  - [.gitignore](#gitignore)
 - [Issues](#issues)
-- [Requirements](#requirements)
 - [Built With](#built-with)
 - [Contributing](#contributing)
 - [License](#license)
@@ -74,14 +62,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
    sf project deploy start
    ```
 
-   Or scope the recompose to just the components in your deploy manifest:
-
-   ```bash
-   sf decomposer recompose -x "manifest/package.xml"
-   sf project deploy start -x "manifest/package.xml"
-   ```
-
-   Or run the deploy command directly after configuring the [hooks](#hooks) to run the recompose automatically before deploying.
+   Pass `-x manifest/package.xml` to both commands to scope the run to the components in a deploy manifest. Configuring the [hooks](#hooks) automates this step entirely.
 
 ---
 
@@ -101,21 +82,14 @@ If other platforms or architectures require support, please open an issue in [co
 
 ## Why sf-decomposer?
 
-Salesforce’s built-in decomposition is limited. sf-decomposer gives admins and developers more control, flexibility, and better versioning.
+Salesforce's built-in decomposition is limited. sf-decomposer gives admins and developers more control, flexibility, and better versioning.
 
-### Benefits
-
-- **Broader metadata support** – Works with most Metadata API types, not just the subset Salesforce decomposes.
-- **Selective decomposition** – Decompose only what you need; use [.sfdecomposerignore](#sfdecomposerignore) to skip specific files.
-- **Manifest-scoped runs** – Pass `-x package.xml` to decompose or recompose only the components listed in a Salesforce manifest, mirroring `sf project deploy start -x`. Ideal for CI/CD pipelines that only ship a subset of metadata per deployment.
-- **Two [strategies](#decompose-strategies)**:
-  - **unique-id** (default): one file per nested element, named by content or hash.
-  - **grouped-by-tag**: one file per tag (e.g. all `fieldPermissions` in a permission set in `fieldPermissions.xml`). Use `--decompose-nested-permissions` for deeper permission set and muting permission set decomposition.
-- **Full decomposition** – Fully decompose types that Salesforce only partially supports (e.g. permission sets).
-- **Stable ordering** – Elements are sorted consistently to reduce noisy diffs.
-- **Multiple formats** – Output as XML, JSON, JSON5, or YAML.
-- **CI/CD hooks** – Auto decompose after retrieve and recompose before deploy via [.sfdecomposer.config.json](#hooks).
-- **Better reviews** – Smaller, structured files mean clearer pull requests and fewer merge conflicts.
+- **Broader metadata support** — works with most Metadata API types, not just the subset Salesforce decomposes.
+- **Two [strategies](#decompose-strategies)** — `unique-id` (one file per nested element) or `grouped-by-tag` (one file per tag).
+- **Multiple formats** — XML, JSON, JSON5, or YAML.
+- **Manifest-scoped runs** — pass `-x package.xml` to scope a run to just the components in a deploy manifest, the same way `sf project deploy start -x` does.
+- **CI/CD hooks** — auto-decompose after retrieve and auto-recompose before deploy via [.sfdecomposer.config.json](#hooks).
+- **Stable ordering and smaller files** — clearer pull requests, fewer merge conflicts.
 
 ---
 
@@ -238,22 +212,18 @@ sf decomposer verify -m "permissionset" -s "grouped-by-tag" -p
 sf decomposer verify -x "manifest/package.xml" --config
 ```
 
-Files where the **only** delta is sibling or attribute ordering are surfaced separately as informational notices ("Note: N file(s) round-tripped semantically but with sibling/attribute reordering") rather than as drift. This is safe — Salesforce treats metadata as order-agnostic and `config-disassembler` does not preserve original sibling order — but it tells you up front that committing the post-recompose output will produce a diff in git even though the metadata is functionally identical.
+Files whose **only** delta is sibling or attribute ordering are reported as informational notices, not drift. Salesforce treats metadata as order-agnostic, so the deploy is safe — the notice just warns that committing the post-recompose output will show a git diff even though the metadata is functionally identical.
 
 ---
 
 ## Manifest-scoped runs
 
-The `-x` / `--manifest` flag is supported by every `sf decomposer` command (`decompose`, `recompose`, `verify`) and accepts any standard Salesforce `package.xml`, limiting the work to just the components it lists. This is especially useful for CI/CD pipelines that deploy a subset of metadata per change.
+`-x` / `--manifest` is supported by every `sf decomposer` command and accepts the same `package.xml` you pass to `sf project deploy start -x`. Only the listed components are decomposed/recomposed; everything else is left alone.
 
-How it works:
-
-- The manifest is parsed with `@salesforce/source-deploy-retrieve`'s `ManifestResolver`, so the same XML you pass to `sf project deploy start -x` is honored here.
-- For each entry, the plugin resolves the matching parent metadata files in your local package directories (using each metadata type's `directoryName`, `suffix`, `strictDirectoryName`, and `folderType` from the SDR registry).
-- Only those files are decomposed/recomposed; everything else on disk is left untouched.
-- Wildcards (`<members>*</members>`) expand against your local source. Folder-typed members (e.g. `MyFolder/MyReport`) are resolved by walking the folder.
-- Types in the manifest that the plugin does not support (e.g. `CustomObject`, `ApexClass`) are skipped with a warning instead of failing the run, so a single manifest can drive both deploys and decomposer runs.
-- If both `--metadata-type` and `--manifest` are provided, the run is scoped to the intersection (only types present in both).
+- Wildcards (`<members>*</members>`) expand against your local source.
+- Folder members (e.g. `MyFolder/MyReport`) resolve by walking the folder.
+- Types the plugin does not support (e.g. `CustomObject`, `ApexClass`) are skipped with a warning, so the same manifest can drive both deploys and decomposer runs.
+- If both `--metadata-type` and `--manifest` are supplied, the run is scoped to the intersection.
 
 Example manifest:
 
@@ -331,16 +301,16 @@ permissionsets/
 
 ### Filename safety (unique-id)
 
-Two safety nets are applied automatically to every shard filename emitted by the **unique-id** strategy. Neither requires configuration:
+Two safety nets apply automatically to every shard filename emitted by the **unique-id** strategy. Neither requires configuration:
 
-- **Path-segment sanitization.** When a unique-id value contains characters that are illegal or reserved on at least one supported filesystem — path separators (`/`, `\`), Windows-reserved chars (`:`, `*`, `?`, `"`, `<`, `>`, `|`), or ASCII control bytes — each is replaced with `_`, and trailing `.` and spaces are stripped. So an `EntitlementProcess` milestone named `TrustFile Transaction Sync/Import Complete` yields the shard `TrustFile Transaction Sync_Import Complete.milestones-meta.xml` on every platform, instead of `/` being interpreted as a directory separator.
-- **Sibling-collision fallback.** After sanitization, if two or more siblings of the same parent tag would still resolve to the same shard filename (because the configured unique-id elements are too narrow for that metadata type, or because sanitization happened to fold two distinct values into the same form), every sibling in the colliding group falls back to a per-element 8-character SHA-256 hash. No row is silently overwritten on disk.
+- **Path-segment sanitization (silent).** Characters illegal or reserved on at least one supported filesystem — path separators (`/`, `\`), Windows-reserved chars (`:`, `*`, `?`, `"`, `<`, `>`, `|`), and ASCII control bytes — are replaced with `_`; trailing `.` and spaces are stripped. Sanitized filenames are byte-stable across platforms.
+- **Sibling-collision fallback (emits `WARN`).** When two or more siblings of the same parent tag would resolve to the same filename (the configured unique-id elements are too narrow, or sanitization folded two distinct values together), every sibling in the colliding group is written to its own per-element SHA-256 shard instead. No row is silently overwritten.
 
-Path-segment sanitization is silent — sanitized filenames round-trip identically and are byte-stable across platforms, so there is nothing to warn about. Sibling-collision fallback, by contrast, emits one `WARN` line per colliding group (parent tag, collided id, sibling count) so you can decide whether to widen `uniqueIdElements` for that metadata type. By default these are filtered out — see [Rust crate logging](#xml-disassemble-output-rust-crate) below for how to surface them. If you see a hash-named shard in your output and want to know why, that's the first place to look.
+If you see a hash-named shard and want to know whether it came from a collision (vs. simply a missing UID), set `RUST_LOG=warn` and rerun — see [Rust crate logging](#xml-disassemble-output-rust-crate).
 
 ### Custom Labels Decomposition
 
-Custom labels use only the **unique-id** strategy. If you pass `grouped-by-tag`, the plugin overrides to `unique-id` and continues. Grouping labels by tag would produce no difference from the original file since all elements share the same tag. Each label is written to its own file.
+Custom labels are always decomposed with `unique-id` (grouped-by-tag would be a no-op since every element shares the same tag). Each label is written to its own file:
 
 ```
 labels/
@@ -382,12 +352,9 @@ permissionsets/
 
 ### Loyalty Program Setup Decomposition
 
-`loyaltyProgramSetup` supports only the **unique-id** strategy. If you pass `grouped-by-tag`, the plugin overrides to `unique-id` and continues. The metadata is automatically decomposed further under unique-id:
+`loyaltyProgramSetup` is always decomposed with `unique-id`, with a built-in `multiLevel` default that splits `<programProcesses>` into per-process folders containing per-`<parameters>` / per-`<rules>` files.
 
-- Each `<programProcesses>` element → its own file.
-- Each `<parameters>` and `<rules>` child → its own file.
-
-> Recomposition for loyalty program setup removes decomposed files even without `--postpurge`. Use version control or CI to keep them if needed.
+> Recompose for `loyaltyProgramSetup` always removes the decomposed tree, with or without `--postpurge`. Rely on version control if you need to inspect it after a deploy.
 
 ```
 loyaltyProgramSetups/
@@ -470,44 +437,31 @@ For example, if you attempt to decompose Custom Labels but none of your package 
 
 ### XML disassemble output (Rust crate)
 
-The config-disassembler Node plugin uses a **Rust crate** for XML decomposing and recomposing. Disassemble errors and messages are shown in the terminal.
+The underlying Rust crate logs through [env_logger](https://docs.rs/env_logger). Set `RUST_LOG` to opt into more verbosity:
 
-Control verbosity with the `RUST_LOG` environment variable. The crate uses [env_logger](https://docs.rs/env_logger), so the standard level filters apply: `error`, `warn`, `info`, `debug`, `trace`. By default only `error`-level lines are surfaced, which is why you would not see filename-safety warnings (sibling-collision fallback, path-segment sanitization) without opting in.
+| Level            | What it covers                                                                                                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RUST_LOG=error` | Default. Parse errors and skipped files (leaf-only XML — primitives only, nothing to decompose).                                                                                              |
+| `RUST_LOG=warn`  | Adds [sibling-collision fallback](#filename-safety-unique-id) signals — one line per colliding group (parent tag, collided id, sibling count). **Recommended in CI** when shipping overrides. |
 
-| Level                 | What it covers                                                                                                                                                                                                                                                       |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `RUST_LOG=error`      | Default. Skipped files (leaf-only XML), parse errors.                                                                                                                                                                                                                |
-| `RUST_LOG=warn`       | Adds [sibling-collision fallback](#filename-safety-unique-id) signals — one line per colliding group naming the parent tag, the collided id, and the sibling count, so you can decide whether to widen `uniqueIdElements` for that metadata type. Recommended in CI. |
-| `RUST_LOG=info,debug` | Per-element decomposition tracing. Verbose; useful for plugin development, not day-to-day use.                                                                                                                                                                       |
-
-Example terminal output at the default `error` level (a leaf-only file):
+Example `WARN` (CustomApplication where four `actionOverrides` siblings shared the action name `View`):
 
 ```
-[2026-04-30T12:34:38Z ERROR config_disassembler::xml::builders::build_disassembled_files] The XML file C:\Users\matthew.carvin\Documents\sf-decomposer\fixtures\package-dir-1\permissionsets\only_leafs.permissionset-meta.xml only has leaf elements. This file will not be disassembled.
+[2026-05-04T15:21:09Z WARN config_disassembler::xml::builders::build_disassembled_files]
+  uniqueIdElements collision: <actionOverrides> id "View" matched 4 sibling elements;
+  falling back to SHA-256 content hashes for the colliding group.
+  Consider adding more discriminating fields to uniqueIdElements for this metadata type.
 ```
-
-Example with `RUST_LOG=warn` set, for a `CustomApplication` whose configured unique-id was too narrow for one group of `actionOverrides` siblings:
-
-```
-[2026-05-04T15:21:09Z WARN config_disassembler::xml::builders::build_disassembled_files] uniqueIdElements collision: <actionOverrides> id "View" matched 4 sibling elements; falling back to SHA-256 content hashes for the colliding group. Consider adding more discriminating fields to uniqueIdElements for this metadata type.
-```
-
-### Files with only leaf elements
-
-If a metadata file has only leaf elements (primitives, no nested structure), there is nothing to decompose. The Rust crate skips the file and logs an ERROR like the example above.
 
 ---
 
 ## Hooks
 
-> Configure [.forceignore](#forceignore) so the Salesforce CLI ignores decomposed files; otherwise `sf` commands can fail.
+Put **.sfdecomposer.config.json** in the project root to auto-decompose after `sf project retrieve start` and auto-recompose before `sf project deploy start` / `validate`.
 
-Put **.sfdecomposer.config.json** in the project root to run:
+> Configure [.forceignore](#forceignore) first — the Salesforce CLI must ignore decomposed files or `sf` commands can fail.
 
-- **After** `sf project retrieve start`: decompose.
-- **Before** `sf project deploy start` / `sf project deploy validate`: recompose.
-
-Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json), or the [sample config with overrides](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.overrides.json) to vary format/strategy/etc. by metadata type or by individual component.
+Copy and customize the [sample config](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.json), or the [sample with overrides](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.sfdecomposer.config.overrides.json) to vary format/strategy per metadata type or component.
 
 | Option                       | Required    | Description                                                                                                                                                                                                                   |
 | ---------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -605,7 +559,7 @@ For each component, each option is resolved independently in this order (highest
 
 Each `<tag>` may appear at most once in a spec. The plugin validates the grammar at config-load time. Deeper checks (e.g. unknown tag names for the metadata type) are surfaced by the underlying disassembler crate at runtime.
 
-#### splitTags cookbook
+**Examples:**
 
 ```json
 "overrides": [
@@ -618,21 +572,13 @@ Each `<tag>` may appear at most once in a spec. The plugin validates the grammar
     "metadataTypes": ["profile"],
     "strategy": "grouped-by-tag",
     "splitTags": "objectPermissions:split:object,fieldPermissions:group:field,layoutAssignments:group:layout"
-  },
-  {
-    "metadataTypes": ["flow"],
-    "strategy": "grouped-by-tag",
-    "splitTags": "actionCalls:split:name,decisions:split:name,assignments:split:name"
-  },
-  {
-    "metadataTypes": ["workflow"],
-    "strategy": "grouped-by-tag",
-    "splitTags": "rules:split:fullName,alerts:split:fullName,fieldUpdates:split:fullName,tasks:split:fullName"
   }
 ]
 ```
 
-> **Caveat:** When using `mode: split`, the chosen `<field>` must produce a unique value for every array item — otherwise two items would map to the same filename. If two items share a field value, prefer `mode: group` instead, which is designed for that case.
+> **Caveat:** With `mode: split`, the chosen `<field>` must produce a unique value across every array item — otherwise two items map to the same filename. If items can share a field value, use `mode: group` instead.
+
+See the [admin handbook](https://github.com/mcarvin8/sf-decomposer/blob/main/HANDBOOK.md) for additional `splitTags` and `multiLevel` recipes (flows, workflows, layouts, flexipages, bots).
 
 ### multiLevel grammar
 
@@ -672,13 +618,9 @@ Within one scope, the `(file_pattern, root_to_strip)` pair must be unique across
 ]
 ```
 
-> **`bot` and `loyaltyProgramSetup` ship with built-in `multiLevel` defaults**, so you don't need to add an override for either type to get the canonical decomposed layout — supply your own only if you want to replace the default. The full registry lives in [`src/metadata/multiLevelDefaults.ts`](https://github.com/mcarvin8/sf-decomposer/blob/main/src/metadata/multiLevelDefaults.ts).
-
-> **Why one call:** Pass every rule for a given component in a single override. Sequential single-rule decompositions rewrite the on-disk `.multi_level.json` and only the last rule survives — so multi-rule scenarios must travel together.
-
-> **Tip:** Use [`sf decomposer verify`](#sf-decomposer-verify) to non-destructively confirm a new override config still round-trips before committing it.
-
-> **Tip:** See the [admin handbook](https://github.com/mcarvin8/sf-decomposer/blob/main/HANDBOOK.md) for end-to-end recipes for Bots, Flexipages, Layouts, and other deeply-nested metadata.
+> **Built-in defaults.** `bot` and `loyaltyProgramSetup` ship with built-in `multiLevel` rules, so you do not need an override to get the canonical layout — supply your own only to replace the default. Full registry: [`src/metadata/multiLevelDefaults.ts`](https://github.com/mcarvin8/sf-decomposer/blob/main/src/metadata/multiLevelDefaults.ts).
+>
+> **Pass all rules at once.** Sequential single-rule decomposes rewrite `.multi_level.json` and only the last rule survives — bundle every rule for a given component into one override. Use [`sf decomposer verify`](#sf-decomposer-verify) to confirm a new config round-trips before committing it.
 
 ### Opting in from the CLI
 

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -159,11 +159,19 @@ describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
         // collision bug fixed in config-disassembler 0.4.3) that would still
         // pass the pass1 == pass2 idempotence check below since both passes
         // would produce the same shrunken output.
+        //
+        // We also collect every (path, original, recomposed, ratio) tuple so
+        // the per-format summary can print the full distribution. The
+        // RETENTION_THRESHOLD guard only fires below 0.99, but a regression
+        // that nibbles a file from 100.00% down to 99.50% should still be
+        // visible in PR logs before it crosses the floor.
+        const retention: Array<{ path: string; original: number; recomposed: number; ratio: number }> = [];
         for (const [path, content] of firstRoundtrip) {
           const original = fixtureFileBytes.get(path);
           if (original === undefined) continue; // sfdx-project.json, generated files
           const recomposed = Buffer.byteLength(content, 'utf8');
           const ratio = recomposed / original;
+          retention.push({ path, original, recomposed, ratio });
           expect(
             ratio,
             `data loss on round-trip for ${path}: ${recomposed}/${original} bytes (${(ratio * 100).toFixed(2)}%)`,
@@ -218,7 +226,7 @@ describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
           samples,
         });
 
-        printSummary(format, fixtureBytes, samples, decomposedSnapshot, reportFile);
+        printSummary(format, fixtureBytes, samples, decomposedSnapshot, retention, reportFile);
       });
     });
   }
@@ -274,6 +282,7 @@ function printSummary(
   inputBytes: number,
   samples: MeasureResult[],
   decomposedSnapshot: { files: number; bytes: number },
+  retention: ReadonlyArray<{ path: string; original: number; recomposed: number; ratio: number }>,
   reportFile: string,
 ): void {
   const totalElapsed = samples.reduce((s, x) => s + x.elapsedMs, 0);
@@ -290,6 +299,36 @@ function printSummary(
     );
   }
   lines.push(`[perf]   total=${formatMs(totalElapsed)}  peak rssΔ=${formatBytes(peakRssDelta)}  report=${reportFile}`);
+
+  // Per-file retention breakdown. Sorted ascending so any file that's eaten
+  // bytes shows at the top - that's where you look first when investigating
+  // a regression that's still above the 0.99 floor but trending downward.
+  if (retention.length > 0) {
+    const sorted = [...retention].sort((a, b) => a.ratio - b.ratio);
+    const minRatio = sorted[0].ratio;
+    const maxRatio = sorted[sorted.length - 1].ratio;
+    const meanRatio = sorted.reduce((s, x) => s + x.ratio, 0) / sorted.length;
+    const pathPad = Math.min(
+      60,
+      sorted.reduce((m, r) => Math.max(m, r.path.length), 0),
+    );
+    lines.push(
+      `[perf] retention (${format}): min=${formatPercent(minRatio)} ` +
+        `mean=${formatPercent(meanRatio)} max=${formatPercent(maxRatio)} ` +
+        `(threshold=${formatPercent(0.99)})`,
+    );
+    for (const r of sorted) {
+      lines.push(
+        `[perf]   ${r.path.padEnd(pathPad)}  ${formatPercent(r.ratio).padStart(7)}  ` +
+          `(${r.recomposed.toLocaleString()} / ${r.original.toLocaleString()} bytes)`,
+      );
+    }
+  }
+
   // eslint-disable-next-line no-console
   console.log(lines.join('\n'));
+}
+
+function formatPercent(ratio: number): string {
+  return `${(ratio * 100).toFixed(2)}%`;
 }


### PR DESCRIPTION
* test/perf: print a sorted per-file retention block (min/mean/max plus every recomposed -meta.xml ratio) at the end of each round-trip run. Drift from 100% is now visible in PR logs even when it stays above the 0.99 floor, so creeping regressions become a graph rather than a hard-fail surprise.
* README: trim duplicated bullets in "Why sf-decomposer", strip SDR internals from "Manifest-scoped runs", compress "Filename safety" and the RUST_LOG table to the levels users actually need, drop the redundant `splitTags` cookbook entries (workflow/flow live in the HANDBOOK already), and slim the TOC to top-level sections only.
* CONTRIBUTING: tighten "Unique ID elements" with the compound-key syntax and current collision-fallback behavior, and trim "Config disassembler" duplication.
* HANDBOOK: simplify pitfall #2 now that 0.5.0 detects collisions, and collapse the Bot section's two trailing tip blocks.