### PR TITLE
chore(stryker): upload mutation score to dashboard.stryker-mutator.io

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -89,7 +89,16 @@ jobs:
         # GitHub-hosted ubuntu-latest runners have 4 cores (as of 2026). Stryker
         # defaults concurrency to cores-1; pinning explicitly avoids surprises
         # if GitHub changes runner sizing later.
-        run: npm run test:mutation -- --concurrency 3
+        #
+        # The dashboard reporter (configured in stryker.config.json) uploads the
+        # mutation score to https://dashboard.stryker-mutator.io. The API key is
+        # injected from the STRYKER_DASHBOARD_API_KEY secret; --dashboard.version
+        # overrides the hardcoded `main` so that the dashboard partitions runs
+        # per ref (e.g. release branches, tags) when this job is dispatched from
+        # somewhere other than main.
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        run: npm run test:mutation -- --concurrency 3 --dashboard.version "${{ github.ref_name }}"
 
       - name: Upload mutation report
         if: always()

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/LICENSE.md)
 [![Maintainability](https://qlty.sh/badges/8492c1c6-0f93-4d37-bfad-32fd3b788a2d/maintainability.svg)](https://qlty.sh/gh/mcarvin8/projects/sf-decomposer)
 [![codecov](https://codecov.io/gh/mcarvin8/sf-decomposer/graph/badge.svg?token=YFU52L4XM5)](https://codecov.io/gh/mcarvin8/sf-decomposer)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fmcarvin8%2Fsf-decomposer%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/mcarvin8/sf-decomposer/main)
 [![Performance](https://img.shields.io/badge/Performance-Dashboard-58a6ff)](https://mcarvin8.github.io/sf-decomposer/dev/bench/runtime/)
 
 A Salesforce CLI plugin that **decomposes** large metadata XML files into smaller, version-control–friendly files (XML, JSON, YAML, JSON5), and **recomposes** them back into deployment-ready metadata.

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -14,9 +14,14 @@
     "!src/helpers/types.ts",
     "!src/helpers/constants.ts"
   ],
-  "reporters": ["html", "clear-text", "progress"],
+  "reporters": ["html", "clear-text", "progress", "dashboard"],
   "htmlReporter": {
     "fileName": "reports/mutation/index.html"
+  },
+  "dashboard": {
+    "project": "github.com/mcarvin8/sf-decomposer",
+    "version": "main",
+    "reportType": "mutationScore"
   },
   "timeoutMS": 600000,
   "timeoutFactor": 2,


### PR DESCRIPTION
Wire the official Stryker dashboard reporter so each full-suite run publishes its mutation score (no exclusions; the score reflects the real coverage picture, SfCommand shells included).

- `stryker.config.json`: add `dashboard` to `reporters` and configure `project`, a default `version`, and `reportType: mutationScore` so only the headline number is uploaded (not the full HTML report).
- `.github/workflows/mutation.yml`: inject the `STRYKER_DASHBOARD_API_KEY` secret into the `full` job and override `--dashboard.version` with `github.ref_name` so the dashboard partitions results by branch / tag rather than always reporting under `main`.
- `README.md`: add the canonical Stryker badge so the live score is visible alongside the other quality badges.

Local runs continue to work unchanged; if the API key is absent, Stryker logs a warning and skips the dashboard upload without failing the build.