### PR TITLE
test(metadata): cover parseManifest, getPackageDirectories, getRegistryValuesBySuffix

### DIFF
--- a/test/units/getPackageDirectories.test.ts
+++ b/test/units/getPackageDirectories.test.ts
@@ -1,0 +1,170 @@
+'use strict';
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getPackageDirectories } from '../../src/metadata/getPackageDirectories.js';
+import { SFDX_CONFIG_FILE } from '../utils/constants.js';
+
+// `getPackageDirectories` resolves `<metaDirectory>` under each package dir declared
+// in sfdx-project.json, with optional `ignoreDirs` basename filtering. It walks up from
+// `process.cwd()` to find sfdx-project.json and then chdirs into the discovered repo
+// root, so each test builds an isolated SFDX project, chdir's into it, and asserts the
+// shape and contents of the returned `metadataPaths`.
+
+type Project = {
+  root: string;
+  forceAppDir: string;
+  altDir: string;
+};
+
+async function makeProject(): Promise<Project> {
+  const root = await mkdtemp(join(tmpdir(), 'get-pkg-dirs-'));
+  const forceAppDir = join(root, 'force-app');
+  const altDir = join(root, 'package');
+  await mkdir(forceAppDir, { recursive: true });
+  await mkdir(altDir, { recursive: true });
+
+  const sfdxProject = {
+    packageDirectories: [{ path: 'force-app', default: true }, { path: 'package' }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+  await writeFile(join(root, SFDX_CONFIG_FILE), JSON.stringify(sfdxProject, null, 2));
+  return { root, forceAppDir, altDir };
+}
+
+describe('getPackageDirectories', () => {
+  const originalCwd = process.cwd();
+  let project: Project;
+
+  beforeEach(async () => {
+    project = await makeProject();
+    process.chdir(project.root);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(project.root, { recursive: true, force: true });
+  });
+
+  it('returns a metadataPaths entry per matching package dir (direct match)', async () => {
+    const a = join(project.forceAppDir, 'permissionsets');
+    const b = join(project.altDir, 'permissionsets');
+    await mkdir(a, { recursive: true });
+    await mkdir(b, { recursive: true });
+
+    const { metadataPaths, ignorePath } = await getPackageDirectories('permissionsets', undefined);
+
+    expect(new Set(metadataPaths)).toEqual(new Set([resolve(a), resolve(b)]));
+    // The IGNORE_FILE constant resolves under the discovered repo root.
+    expect(ignorePath).toBe(resolve(project.root, '.sfdecomposerignore'));
+  });
+
+  it('finds the target directory at nested depths via recursion', async () => {
+    const deep = join(project.forceAppDir, 'main', 'default', 'permissionsets');
+    await mkdir(deep, { recursive: true });
+
+    const { metadataPaths } = await getPackageDirectories('permissionsets', undefined);
+
+    expect(metadataPaths).toEqual([resolve(deep)]);
+  });
+
+  it('returns the first hit per package directory rather than all matches', async () => {
+    // Both a shallow and deep `permissionsets` exist in force-app. The function uses
+    // `find` so only one is returned per package dir.
+    const shallow = join(project.forceAppDir, 'permissionsets');
+    const deep = join(project.forceAppDir, 'main', 'default', 'permissionsets');
+    await mkdir(shallow, { recursive: true });
+    await mkdir(deep, { recursive: true });
+
+    const { metadataPaths } = await getPackageDirectories('permissionsets', undefined);
+
+    // Exactly one path per package directory.
+    expect(metadataPaths).toHaveLength(1);
+    expect(metadataPaths[0]).toBe(resolve(shallow));
+  });
+
+  it('returns an empty list when no package directory contains the target', async () => {
+    const { metadataPaths } = await getPackageDirectories('missingDir', undefined);
+    expect(metadataPaths).toEqual([]);
+  });
+
+  it('honours ignoreDirs by basename and skips matching package directories entirely', async () => {
+    const inForceApp = join(project.forceAppDir, 'permissionsets');
+    const inAlt = join(project.altDir, 'permissionsets');
+    await mkdir(inForceApp, { recursive: true });
+    await mkdir(inAlt, { recursive: true });
+
+    // ignoreDirs is normalised through `basename`, so passing a deep path still matches.
+    const { metadataPaths } = await getPackageDirectories('permissionsets', ['nested/path/package']);
+
+    expect(metadataPaths).toEqual([resolve(inForceApp)]);
+  });
+
+  it('treats undefined and empty-array ignoreDirs identically', async () => {
+    const inForceApp = join(project.forceAppDir, 'permissionsets');
+    const inAlt = join(project.altDir, 'permissionsets');
+    await mkdir(inForceApp, { recursive: true });
+    await mkdir(inAlt, { recursive: true });
+
+    const u = await getPackageDirectories('permissionsets', undefined);
+    const e = await getPackageDirectories('permissionsets', []);
+
+    expect(new Set(u.metadataPaths)).toEqual(new Set([resolve(inForceApp), resolve(inAlt)]));
+    expect(new Set(e.metadataPaths)).toEqual(
+      u.metadataPaths.length === e.metadataPaths.length ? new Set(u.metadataPaths) : new Set(e.metadataPaths),
+    );
+    // Stronger pointwise equivalence:
+    expect(new Set(e.metadataPaths)).toEqual(new Set(u.metadataPaths));
+  });
+
+  it('chdir-s into the discovered repo root', async () => {
+    // Start a level above the project, but pointing cwd at the project root. The
+    // function should chdir to the project root.
+    process.chdir(project.root);
+    await getPackageDirectories('permissionsets', undefined);
+    expect(process.cwd()).toBe(resolve(project.root));
+  });
+
+  it('does not return undefined entries when one package dir matches and another does not', async () => {
+    const inForceApp = join(project.forceAppDir, 'permissionsets');
+    await mkdir(inForceApp, { recursive: true });
+    // No `permissionsets` under project.altDir.
+
+    const { metadataPaths } = await getPackageDirectories('permissionsets', undefined);
+
+    expect(metadataPaths).toEqual([resolve(inForceApp)]);
+    expect(metadataPaths.every((p) => typeof p === 'string')).toBe(true);
+  });
+
+  it('descends through unrelated sibling directories during recursion', async () => {
+    // The recursion must walk into every directory at every level until it finds the match.
+    const buried = join(project.forceAppDir, 'a', 'b', 'c', 'workflows');
+    // Sibling that should be visited but never matched.
+    const sibling = join(project.forceAppDir, 'a', 'b', 'lwc');
+    await mkdir(buried, { recursive: true });
+    await mkdir(sibling, { recursive: true });
+
+    const { metadataPaths } = await getPackageDirectories('workflows', undefined);
+
+    expect(metadataPaths).toEqual([resolve(buried)]);
+  });
+
+  it('returns the same path twice when both package dirs have the target at the same depth', async () => {
+    // Distinct absolute paths (one per package dir) — sanity check that both entries
+    // appear when neither is filtered.
+    const a = join(project.forceAppDir, 'workflows');
+    const b = join(project.altDir, 'workflows');
+    await mkdir(a, { recursive: true });
+    await mkdir(b, { recursive: true });
+
+    const { metadataPaths } = await getPackageDirectories('workflows', undefined);
+
+    expect(metadataPaths).toHaveLength(2);
+    expect(new Set(metadataPaths)).toEqual(new Set([resolve(a), resolve(b)]));
+  });
+});

--- a/test/units/getPackageDirectories.test.ts
+++ b/test/units/getPackageDirectories.test.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -21,7 +21,11 @@ type Project = {
 };
 
 async function makeProject(): Promise<Project> {
-  const root = await mkdtemp(join(tmpdir(), 'get-pkg-dirs-'));
+  // mkdtemp on macOS returns a path under `/var/folders/...`, but `process.cwd()` resolves
+  // it through the `/var -> /private/var` symlink to `/private/var/folders/...`. The SUT
+  // builds its return values off the cwd-derived repo root, so we realpath here to make
+  // tests compare against the same root-form the function uses internally.
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'get-pkg-dirs-')));
   const forceAppDir = join(root, 'force-app');
   const altDir = join(root, 'package');
   await mkdir(forceAppDir, { recursive: true });

--- a/test/units/getRegistryValuesBySuffix.test.ts
+++ b/test/units/getRegistryValuesBySuffix.test.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -25,7 +25,11 @@ type Project = {
 };
 
 async function makeProject(): Promise<Project> {
-  const root = await mkdtemp(join(tmpdir(), 'gvbs-'));
+  // mkdtemp on macOS returns a path under `/var/folders/...`, but `process.cwd()` resolves
+  // it through the `/var -> /private/var` symlink to `/private/var/folders/...`. The SUT
+  // builds its return values off the cwd-derived repo root, so we realpath here to make
+  // tests compare against the same root-form the function uses internally.
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'gvbs-')));
   const forceAppDir = join(root, 'force-app');
   await mkdir(forceAppDir, { recursive: true });
 

--- a/test/units/getRegistryValuesBySuffix.test.ts
+++ b/test/units/getRegistryValuesBySuffix.test.ts
@@ -1,0 +1,173 @@
+'use strict';
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getRegistryValuesBySuffix } from '../../src/metadata/getRegistryValuesBySuffix.js';
+import { DEFAULT_UNIQUE_ID_ELEMENTS } from '../../src/helpers/constants.js';
+import { SFDX_CONFIG_FILE } from '../utils/constants.js';
+
+// `getRegistryValuesBySuffix` is the gatekeeper for every decompose/recompose flow:
+// it validates the suffix, looks up the registry entry, rejects unsupported adapter
+// strategies, resolves the on-disk type directories, and finally builds the
+// `metaAttributes` payload (including unique-id wiring for the decompose path).
+//
+// The existing `metadata.test.ts` exercises the error branches (botVersion, object,
+// unsupported adapter) indirectly through `decomposeMetadataTypes`, but it never
+// inspects the returned `metaAttributes` itself, which leaves the unique-id and
+// directory-resolution branches uncovered. These direct-call tests close that gap.
+
+type Project = {
+  root: string;
+  forceAppDir: string;
+};
+
+async function makeProject(): Promise<Project> {
+  const root = await mkdtemp(join(tmpdir(), 'gvbs-'));
+  const forceAppDir = join(root, 'force-app');
+  await mkdir(forceAppDir, { recursive: true });
+
+  const sfdxProject = {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+  await writeFile(join(root, SFDX_CONFIG_FILE), JSON.stringify(sfdxProject, null, 2));
+  return { root, forceAppDir };
+}
+
+describe('getRegistryValuesBySuffix', () => {
+  const originalCwd = process.cwd();
+  let project: Project;
+
+  beforeEach(async () => {
+    project = await makeProject();
+    process.chdir(project.root);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(project.root, { recursive: true, force: true });
+  });
+
+  it('rejects the unsupported `object` suffix with a stable message', async () => {
+    await expect(getRegistryValuesBySuffix('object', 'decompose', undefined)).rejects.toThrow(
+      'Custom Objects are not supported by this plugin.',
+    );
+  });
+
+  it('rejects the `botVersion` suffix and directs the user to `bot`', async () => {
+    await expect(getRegistryValuesBySuffix('botVersion', 'decompose', undefined)).rejects.toThrow(
+      '`botVersion` suffix should not be used. Please use `bot` to decompose/recompose bot and bot version files.',
+    );
+  });
+
+  it('rejects unknown suffixes and surfaces the offending suffix in the message', async () => {
+    await expect(getRegistryValuesBySuffix('definitelyNotARealSuffix', 'decompose', undefined)).rejects.toThrow(
+      'Metadata type not found for the given suffix: definitelyNotARealSuffix.',
+    );
+  });
+
+  it('rejects suffixes whose registry entry uses an unsupported adapter strategy', async () => {
+    // `.cls` is a matchingContentFile type, which this plugin cannot decompose.
+    await expect(getRegistryValuesBySuffix('cls', 'decompose', undefined)).rejects.toThrow(
+      'Metadata types with matchingContentFile strategies are not supported by this plugin.',
+    );
+  });
+
+  it('throws when the type directory does not exist anywhere in the package dirs', async () => {
+    await expect(getRegistryValuesBySuffix('animationRule', 'decompose', undefined)).rejects.toThrow(
+      'No directories named animationRules were found in any package directory.',
+    );
+  });
+
+  it('returns the unique-id elements prefixed with DEFAULT_UNIQUE_ID_ELEMENTS for the decompose command', async () => {
+    // permissionsets has a registered unique-id element list; decompose should join it onto the defaults.
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix('permissionset', 'decompose', undefined);
+
+    expect(metaAttributes.metaSuffix).toBe('permissionset');
+    expect(metaAttributes.uniqueIdElements.startsWith(`${DEFAULT_UNIQUE_ID_ELEMENTS},`)).toBe(true);
+    // The unique-id suffix portion is non-empty (the registry seeds at least one element).
+    expect(metaAttributes.uniqueIdElements.length).toBeGreaterThan(DEFAULT_UNIQUE_ID_ELEMENTS.length + 1);
+  });
+
+  it('omits the unique-id suffix segment for the recompose command (no `,` appended)', async () => {
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix('permissionset', 'recompose', undefined);
+
+    expect(metaAttributes.uniqueIdElements).toBe(DEFAULT_UNIQUE_ID_ELEMENTS);
+  });
+
+  it('falls back to DEFAULT_UNIQUE_ID_ELEMENTS verbatim when the registry has no unique-id mapping', async () => {
+    // `workflow` has no entry in src/metadata/uniqueIdElements.ts → unique-id helper returns undefined.
+    await mkdir(join(project.forceAppDir, 'workflows'), { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix('workflow', 'decompose', undefined);
+
+    expect(metaAttributes.uniqueIdElements).toBe(DEFAULT_UNIQUE_ID_ELEMENTS);
+  });
+
+  it('returns the resolved metadataPaths and strictDirectoryName for strict types (Bot)', async () => {
+    const dir = join(project.forceAppDir, 'bots');
+    await mkdir(dir, { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix('bot', 'decompose', undefined);
+
+    expect(metaAttributes.metaSuffix).toBe('bot');
+    expect(metaAttributes.strictDirectoryName).toBe(true);
+    expect(metaAttributes.metadataPaths).toEqual([resolve(dir)]);
+  });
+
+  it('returns strictDirectoryName=false for non-strict types (PermissionSet)', async () => {
+    const dir = join(project.forceAppDir, 'permissionsets');
+    await mkdir(dir, { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix('permissionset', 'decompose', undefined);
+
+    expect(metaAttributes.strictDirectoryName).toBe(false);
+  });
+
+  it('reuses the cached RegistryAccess singleton across calls', async () => {
+    // The singleton caching is a private implementation detail, but two back-to-back
+    // calls must produce identical registry values regardless of cache state.
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+
+    const first = await getRegistryValuesBySuffix('permissionset', 'decompose', undefined);
+    const second = await getRegistryValuesBySuffix('permissionset', 'decompose', undefined);
+
+    expect(second.metaAttributes).toEqual(first.metaAttributes);
+    expect(second.ignorePath).toBe(first.ignorePath);
+  });
+
+  it('threads ignoreDirs through to getPackageDirectories so filtered packages drop out', async () => {
+    // Two package dirs; ignore the alt one. (Note: this test rewrites the sfdx-project.json
+    // for this run only — the per-test temp project is torn down in afterEach.)
+    const altDir = join(project.root, 'altpkg');
+    await mkdir(altDir, { recursive: true });
+    await writeFile(
+      join(project.root, SFDX_CONFIG_FILE),
+      JSON.stringify(
+        {
+          packageDirectories: [{ path: 'force-app', default: true }, { path: 'altpkg' }],
+          namespace: '',
+          sfdcLoginUrl: 'https://login.salesforce.com',
+          sourceApiVersion: '58.0',
+        },
+        null,
+        2,
+      ),
+    );
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+    await mkdir(join(altDir, 'permissionsets'), { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix('permissionset', 'decompose', ['altpkg']);
+
+    expect(metaAttributes.metadataPaths).toEqual([resolve(project.forceAppDir, 'permissionsets')]);
+  });
+});

--- a/test/units/parseManifest.test.ts
+++ b/test/units/parseManifest.test.ts
@@ -1,0 +1,404 @@
+'use strict';
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { parseManifest } from '../../src/metadata/parseManifest.js';
+import { SFDX_CONFIG_FILE } from '../utils/constants.js';
+
+// ---- Test workspace plumbing --------------------------------------------
+//
+// `parseManifest` walks up from `process.cwd()` to find sfdx-project.json,
+// resolves the manifest against that repo root, and then crawls the package
+// directories listed in sfdx-project.json for parent metadata XML files. To
+// exercise it directly we build a real (but tiny) SFDX project in a temp
+// directory, chdir into it, and assert the returned map.
+
+type Project = {
+  root: string;
+  forceAppDir: string;
+  altDir: string;
+};
+
+async function makeProject(): Promise<Project> {
+  const root = await mkdtemp(join(tmpdir(), 'parse-manifest-'));
+  const forceAppDir = join(root, 'force-app');
+  const altDir = join(root, 'package');
+  await mkdir(forceAppDir, { recursive: true });
+  await mkdir(altDir, { recursive: true });
+
+  const sfdxProject = {
+    packageDirectories: [{ path: 'force-app', default: true }, { path: 'package' }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  };
+  await writeFile(join(root, SFDX_CONFIG_FILE), JSON.stringify(sfdxProject, null, 2));
+  return { root, forceAppDir, altDir };
+}
+
+async function writeMetaFile(path: string, body = '<r/>'): Promise<void> {
+  await mkdir(join(path, '..'), { recursive: true });
+  await writeFile(path, body);
+}
+
+async function writeManifest(rootDir: string, types: Array<{ name: string; members: string[] }>): Promise<string> {
+  const typeBlocks = types
+    .map(
+      (t) =>
+        `    <types>\n${t.members.map((m) => `        <members>${m}</members>`).join('\n')}\n        <name>${t.name}</name>\n    </types>`,
+    )
+    .join('\n');
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+${typeBlocks}
+    <version>58.0</version>
+</Package>`;
+  const manifestPath = join(rootDir, 'manifest.xml');
+  await writeFile(manifestPath, xml);
+  return 'manifest.xml';
+}
+
+describe('parseManifest', () => {
+  const originalCwd = process.cwd();
+  let project: Project;
+
+  beforeEach(async () => {
+    project = await makeProject();
+    process.chdir(project.root);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(project.root, { recursive: true, force: true });
+  });
+
+  it('resolves non-strict members against the on-disk parent XML', async () => {
+    const hrAdmin = join(project.forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+    const employee = join(project.forceAppDir, 'permissionsets', 'Employee.permissionset-meta.xml');
+    await writeMetaFile(hrAdmin);
+    await writeMetaFile(employee);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['HR_Admin', 'Employee'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual(['permissionset']);
+    const paths = result.parentXmlsBySuffix.get('permissionset');
+    expect(paths).toBeDefined();
+    expect(new Set(paths)).toEqual(new Set([resolve(hrAdmin), resolve(employee)]));
+  });
+
+  it('resolves strict-directory members under <member>/<member>.<suffix>-meta.xml', async () => {
+    // Bot is strictDirectoryName: true.
+    const myBot = join(project.forceAppDir, 'bots', 'MyBot', 'MyBot.bot-meta.xml');
+    const otherBot = join(project.forceAppDir, 'bots', 'OtherBot', 'OtherBot.bot-meta.xml');
+    await writeMetaFile(myBot);
+    await writeMetaFile(otherBot);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Bot', members: ['MyBot'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual(['bot']);
+    expect(new Set(result.parentXmlsBySuffix.get('bot'))).toEqual(new Set([resolve(myBot)]));
+  });
+
+  it('resolves folder-typed members against the in-folder file (Report)', async () => {
+    // Report carries folderType="ReportFolder"; member is `<folder>/<name>`.
+    const reportInFolder = join(project.forceAppDir, 'reports', 'FolderX', 'Report1.report-meta.xml');
+    await writeMetaFile(reportInFolder);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Report', members: ['FolderX/Report1'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual(['report']);
+    expect(new Set(result.parentXmlsBySuffix.get('report'))).toEqual(new Set([resolve(reportInFolder)]));
+  });
+
+  it('handles wildcard members for non-strict types by listing every matching parent XML', async () => {
+    const a = join(project.forceAppDir, 'workflows', 'A.workflow-meta.xml');
+    const b = join(project.forceAppDir, 'workflows', 'B.workflow-meta.xml');
+    // Not a workflow file: must not be collected.
+    const noise = join(project.forceAppDir, 'workflows', 'README.md');
+    await writeMetaFile(a);
+    await writeMetaFile(b);
+    await writeMetaFile(noise);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Workflow', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('workflow'))).toEqual(new Set([resolve(a), resolve(b)]));
+  });
+
+  it('handles wildcard members for strict types by listing <child>/<child>.<suffix>-meta.xml', async () => {
+    const myBot = join(project.forceAppDir, 'bots', 'MyBot', 'MyBot.bot-meta.xml');
+    const otherBot = join(project.forceAppDir, 'bots', 'OtherBot', 'OtherBot.bot-meta.xml');
+    // Stray file directly under bots/ — must not be picked up for strict dir.
+    const stray = join(project.forceAppDir, 'bots', 'stray.bot-meta.xml');
+    // Subdirectory that does not contain a matching .<suffix>-meta.xml — must not appear.
+    const orphan = join(project.forceAppDir, 'bots', 'EmptyBot', 'placeholder.txt');
+    await writeMetaFile(myBot);
+    await writeMetaFile(otherBot);
+    await writeMetaFile(stray);
+    await writeMetaFile(orphan);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Bot', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('bot'))).toEqual(new Set([resolve(myBot), resolve(otherBot)]));
+  });
+
+  it('resolves CustomLabels to a single labels file regardless of the declared member', async () => {
+    const labelsFile = join(project.forceAppDir, 'labels', 'CustomLabels.labels-meta.xml');
+    await writeMetaFile(labelsFile);
+
+    const manifest = await writeManifest(project.root, [{ name: 'CustomLabel', members: ['Greeting', 'Farewell'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    // CustomLabel rolls up to the CustomLabels parent type (single suffix `labels`).
+    expect(result.suffixes).toEqual(['labels']);
+    expect(new Set(result.parentXmlsBySuffix.get('labels'))).toEqual(new Set([resolve(labelsFile)]));
+  });
+
+  it('combines wildcard and explicit members under the same parent type without double-listing', async () => {
+    const a = join(project.forceAppDir, 'workflows', 'A.workflow-meta.xml');
+    const b = join(project.forceAppDir, 'workflows', 'B.workflow-meta.xml');
+    await writeMetaFile(a);
+    await writeMetaFile(b);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Workflow', members: ['*', 'A'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    // Members are deduped through a Set; wildcard should already include `A`.
+    expect(new Set(result.parentXmlsBySuffix.get('workflow'))).toEqual(new Set([resolve(a), resolve(b)]));
+  });
+
+  it('finds parent XMLs nested deep inside a package directory', async () => {
+    // Sales orgs commonly nest under force-app/main/default/...; verifies the recursive search.
+    const deepDir = join(project.forceAppDir, 'main', 'default', 'permissionsets');
+    const file = join(deepDir, 'Deep.permissionset-meta.xml');
+    await writeMetaFile(file);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['Deep'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(new Set([resolve(file)]));
+  });
+
+  it('aggregates resolutions from multiple package directories', async () => {
+    const fromForceApp = join(project.forceAppDir, 'permissionsets', 'HR.permissionset-meta.xml');
+    const fromAlt = join(project.altDir, 'permissionsets', 'Other.permissionset-meta.xml');
+    await writeMetaFile(fromForceApp);
+    await writeMetaFile(fromAlt);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['HR', 'Other'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(
+      new Set([resolve(fromForceApp), resolve(fromAlt)]),
+    );
+  });
+
+  it('honours ignoreDirs by basename match, skipping the filtered package directory', async () => {
+    const kept = join(project.forceAppDir, 'permissionsets', 'Keep.permissionset-meta.xml');
+    const skipped = join(project.altDir, 'permissionsets', 'Skip.permissionset-meta.xml');
+    await writeMetaFile(kept);
+    await writeMetaFile(skipped);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['Keep', 'Skip'] }]);
+    // Pass the directory with a trailing path segment to verify basename normalization.
+    const result = await parseManifest(manifest, ['some/parent/package']);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(new Set([resolve(kept)]));
+  });
+
+  it('treats undefined ignoreDirs the same as no filtering', async () => {
+    const fromForceApp = join(project.forceAppDir, 'permissionsets', 'HR.permissionset-meta.xml');
+    const fromAlt = join(project.altDir, 'permissionsets', 'Other.permissionset-meta.xml');
+    await writeMetaFile(fromForceApp);
+    await writeMetaFile(fromAlt);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['HR', 'Other'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(
+      new Set([resolve(fromForceApp), resolve(fromAlt)]),
+    );
+  });
+
+  it('omits a type entirely when no package directory contains its type dir', async () => {
+    // Manifest references a type whose directoryName (permissionsets) does not exist on disk.
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['HR_Admin'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+    expect(result.parentXmlsBySuffix.size).toBe(0);
+  });
+
+  it('omits a type when its type dir exists but no declared member resolves to an XML on disk', async () => {
+    // Type dir exists, but member file does not.
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['DoesNotExist'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+    expect(result.parentXmlsBySuffix.size).toBe(0);
+  });
+
+  it('returns the same Set for one parent type irrespective of member declaration order', async () => {
+    const a = join(project.forceAppDir, 'permissionsets', 'A.permissionset-meta.xml');
+    const b = join(project.forceAppDir, 'permissionsets', 'B.permissionset-meta.xml');
+    await writeMetaFile(a);
+    await writeMetaFile(b);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['B', 'A'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(new Set([resolve(a), resolve(b)]));
+  });
+
+  it('returns an empty result when the manifest declares no types', async () => {
+    const manifest = await writeManifest(project.root, []);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+    expect(result.parentXmlsBySuffix.size).toBe(0);
+  });
+
+  it('skips wildcard listings for strict types whose subdirectories lack the matching meta file', async () => {
+    // bots/EmptyBot/ exists but has no MyBot-meta file. Only a different .txt file.
+    const orphan = join(project.forceAppDir, 'bots', 'EmptyBot', 'notes.txt');
+    await writeMetaFile(orphan);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Bot', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+  });
+
+  it('orders suffixes in the order their parent types are first encountered', async () => {
+    const ps = join(project.forceAppDir, 'permissionsets', 'P.permissionset-meta.xml');
+    const wf = join(project.forceAppDir, 'workflows', 'W.workflow-meta.xml');
+    await writeMetaFile(ps);
+    await writeMetaFile(wf);
+
+    const manifest = await writeManifest(project.root, [
+      { name: 'PermissionSet', members: ['P'] },
+      { name: 'Workflow', members: ['W'] },
+    ]);
+    const result = await parseManifest(manifest, undefined);
+
+    // Both should be present; both suffixes must appear exactly once.
+    expect(result.suffixes.sort()).toEqual(['permissionset', 'workflow']);
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(new Set([resolve(ps)]));
+    expect(new Set(result.parentXmlsBySuffix.get('workflow'))).toEqual(new Set([resolve(wf)]));
+  });
+
+  it('does not include non-XML files in non-strict wildcard listings', async () => {
+    const wf = join(project.forceAppDir, 'workflows', 'A.workflow-meta.xml');
+    const sidecar = join(project.forceAppDir, 'workflows', 'A.config-disassembler.json');
+    const childMeta = join(project.forceAppDir, 'workflows', 'A', 'something.xml');
+    await writeMetaFile(wf);
+    await writeMetaFile(sidecar);
+    await writeMetaFile(childMeta);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Workflow', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('workflow'))).toEqual(new Set([resolve(wf)]));
+  });
+
+  it('does not pick up directory entries when listing parent XMLs for non-strict types', async () => {
+    const wf = join(project.forceAppDir, 'workflows', 'A.workflow-meta.xml');
+    // A directory named like a meta file should never be confused for one.
+    const dirLookalike = join(project.forceAppDir, 'workflows', 'Trap.workflow-meta.xml', 'inner.txt');
+    await writeMetaFile(wf);
+    await writeMetaFile(dirLookalike);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Workflow', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('workflow'))).toEqual(new Set([resolve(wf)]));
+  });
+
+  it('uses the searchRecursively traversal to descend past unrelated sibling directories', async () => {
+    // Sibling dirs that are NOT the target name must be descended into, not matched.
+    const target = join(project.forceAppDir, 'classes', 'permissionsets', 'Buried.permissionset-meta.xml');
+    const otherSibling = join(project.forceAppDir, 'objects', 'Account.object-meta.xml');
+    await writeMetaFile(target);
+    await writeMetaFile(otherSibling);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['Buried'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(new Set([resolve(target)]));
+  });
+
+  it('returns the resolved absolute path (not the typeDir-relative path) for non-strict resolution', async () => {
+    const file = join(project.forceAppDir, 'permissionsets', 'HR.permissionset-meta.xml');
+    await writeMetaFile(file);
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['HR'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    const out = Array.from(result.parentXmlsBySuffix.get('permissionset') ?? []);
+    expect(out).toHaveLength(1);
+    // resolve() of the same path returns the canonical absolute path; the function applies it.
+    expect(out[0]).toBe(resolve(file));
+  });
+
+  it('returns the resolved absolute path for strict-directory resolution', async () => {
+    const file = join(project.forceAppDir, 'bots', 'MyBot', 'MyBot.bot-meta.xml');
+    await writeMetaFile(file);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Bot', members: ['MyBot'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    const out = Array.from(result.parentXmlsBySuffix.get('bot') ?? []);
+    expect(out).toEqual([resolve(file)]);
+  });
+
+  it('returns the resolved absolute path for folder-typed resolution', async () => {
+    const file = join(project.forceAppDir, 'reports', 'F', 'R.report-meta.xml');
+    await writeMetaFile(file);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Report', members: ['F/R'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    const out = Array.from(result.parentXmlsBySuffix.get('report') ?? []);
+    expect(out).toEqual([resolve(file)]);
+  });
+
+  it('returns the resolved absolute path for CustomLabels', async () => {
+    const file = join(project.forceAppDir, 'labels', 'CustomLabels.labels-meta.xml');
+    await writeMetaFile(file);
+
+    const manifest = await writeManifest(project.root, [{ name: 'CustomLabel', members: ['Foo'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    const out = Array.from(result.parentXmlsBySuffix.get('labels') ?? []);
+    expect(out).toEqual([resolve(file)]);
+  });
+
+  it('does not include a strict member whose folder is missing the meta xml', async () => {
+    // bots/MyBot/ exists but only with an unrelated file inside.
+    await writeMetaFile(join(project.forceAppDir, 'bots', 'MyBot', 'something-else.txt'));
+
+    const manifest = await writeManifest(project.root, [{ name: 'Bot', members: ['MyBot'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+  });
+
+  it('does not include a folder-typed member whose target file is missing', async () => {
+    // reports/F/ exists but Missing.report-meta.xml does not.
+    await mkdir(join(project.forceAppDir, 'reports', 'F'), { recursive: true });
+
+    const manifest = await writeManifest(project.root, [{ name: 'Report', members: ['F/Missing'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+  });
+});

--- a/test/units/parseManifest.test.ts
+++ b/test/units/parseManifest.test.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -23,7 +23,11 @@ type Project = {
 };
 
 async function makeProject(): Promise<Project> {
-  const root = await mkdtemp(join(tmpdir(), 'parse-manifest-'));
+  // mkdtemp on macOS returns a path under `/var/folders/...`, but `process.cwd()` resolves
+  // it through the `/var -> /private/var` symlink to `/private/var/folders/...`. The SUT
+  // builds its return values off the cwd-derived repo root, so we realpath here to make
+  // tests compare against the same root-form the function uses internally.
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'parse-manifest-')));
   const forceAppDir = join(root, 'force-app');
   const altDir = join(root, 'package');
   await mkdir(forceAppDir, { recursive: true });


### PR DESCRIPTION
## Summary

Closes the largest mutation-testing gap in `src/metadata/` by adding three new direct-call unit-test files. Pre-PR, the latest full Stryker run showed **48 survivors** between these three helpers:

| File | Survivors | NoCov |
|---|---|---|
| `src/metadata/parseManifest.ts` | 31 | 4 |
| `src/metadata/getPackageDirectories.ts` | 12 | 0 |
| `src/metadata/getRegistryValuesBySuffix.ts` | 5 | 0 |

The existing `metadata.test.ts` only exercises these indirectly through `decomposeMetadataTypes`, so it hits the error throws but never inspects the returned attribute map nor the on-disk path-resolution branches.

This PR adds:

- `test/units/parseManifest.test.ts` (26 tests): non-strict, strict-directory, folder-typed, CustomLabels, wildcard for strict and non-strict types, combined wildcard+member, nested-package recursion, `ignoreDirs` basename normalization, and the negative paths where members or type directories are missing.
- `test/units/getPackageDirectories.test.ts` (10 tests): direct matches, nested matches, the "first-hit per package dir" semantics, `ignoreDirs` filtering, and the `chdir`-to-repo-root side effect.
- `test/units/getRegistryValuesBySuffix.test.ts` (12 tests): unsupported-suffix errors, unknown suffixes, adapter rejections, missing type dirs, unique-id wiring for `decompose` vs `recompose` (this is the path that builds the `DEFAULT_UNIQUE_ID_ELEMENTS,...` string the Rust crate consumes), strict vs non-strict attribute mapping, the `RegistryAccess` singleton, and `ignoreDirs` threading.

Tests only; no production code changes.

## Test plan

- [x] `npx vitest run` passes locally (294 tests, +48 from these files)
- [x] `npm run lint` passes
- [ ] Mutation testing CI passes incrementally on changed files
- [ ] After this PR + the follow-up verify PR land, run the full mutation suite and confirm the metadata/ gap is closed
