### PR TITLE
test(verify): cover verifyMetadataTypes orchestration and diffDirectories edge cases

### DIFF
--- a/test/units/diffDirectories.test.ts
+++ b/test/units/diffDirectories.test.ts
@@ -158,4 +158,106 @@ describe('canonicalJson', () => {
     expect(canonicalJson('foo')).toBe('"foo"');
     expect(canonicalJson(42)).toBe('42');
   });
+
+  it('preserves nested object key ordering recursively', () => {
+    // Verifies the recursion through canonicalize() actually sorts deep keys, not just the top level.
+    const a = { outer: { b: 1, a: 2 }, top: 3 };
+    const b = { top: 3, outer: { a: 2, b: 1 } };
+    expect(canonicalJson(a)).toBe(canonicalJson(b));
+  });
+
+  it('produces stable output regardless of array element order containing objects', () => {
+    const left = [
+      { name: 'A', val: 1 },
+      { name: 'B', val: 2 },
+    ];
+    const right = [
+      { val: 2, name: 'B' },
+      { val: 1, name: 'A' },
+    ];
+    expect(canonicalJson(left)).toBe(canonicalJson(right));
+  });
+
+  it('uses a strict less-than/greater-than/equal comparator (no ambiguous mid-states)', () => {
+    // Two arrays with strictly different elements must canonicalise stably -- ensures the
+    // sort comparator returns -1 / +1 (not e.g. 0 for everything, which would leave the
+    // sort order indeterminate). We rely on the fact that sort with all-zero comparator
+    // would leave the original order in place, so reverse-order would NOT match forward.
+    const fwd = canonicalJson([1, 2, 3, 4, 5]);
+    const bwd = canonicalJson([5, 4, 3, 2, 1]);
+    expect(fwd).toBe(bwd);
+    // And both should equal the canonical of the sorted form.
+    expect(fwd).toBe(JSON.stringify([1, 2, 3, 4, 5]));
+  });
+
+  it('returns 0 from the comparator for two elements with identical canonical form', () => {
+    // Pure stability/identity check: two identical objects in an array preserve length.
+    const out = JSON.parse(canonicalJson([{ k: 1 }, { k: 1 }])) as unknown[];
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ k: 1 });
+    expect(out[1]).toEqual({ k: 1 });
+  });
+});
+
+describe('XMLParser configuration coverage', () => {
+  // These tests pin the constructor options for the module-scoped XMLParser. Each option
+  // affects how `xmlEquivalent` interprets two strings, so flipping any option should change
+  // observable behaviour for at least one input.
+
+  it('parses attributes (ignoreAttributes=false)', () => {
+    // If ignoreAttributes were true, both inputs would parse identically (no attrs), so the
+    // strings would compare equal. Different attribute values must therefore produce !=.
+    expect(xmlEquivalent('<r a="1"/>', '<r a="2"/>')).toBe(false);
+  });
+
+  it('exposes attributes with the configured @_ prefix (attributeNamePrefix)', () => {
+    // If the prefix were anything other than the configured "@_", the parsed shapes would
+    // still be equal -- this test only requires that attribute parsing is non-trivial.
+    // The parse-attributes path is exercised indirectly via the equality check above.
+    expect(xmlEquivalent('<r a="1" b="2"/>', '<r b="2" a="1"/>')).toBe(true);
+  });
+
+  it('keeps tag values as strings (parseTagValue=false)', () => {
+    // With parseTagValue=true, "1" would parse as the number 1 and "01" as the number 1 too,
+    // which would make these equal. With parseTagValue=false they stay as distinct strings.
+    expect(xmlEquivalent('<r><n>1</n></r>', '<r><n>01</n></r>')).toBe(false);
+  });
+
+  it('keeps attribute values as strings (parseAttributeValue=false)', () => {
+    // Same reasoning as above, applied to attributes.
+    expect(xmlEquivalent('<r a="1"/>', '<r a="01"/>')).toBe(false);
+  });
+
+  it('trims surrounding whitespace from tag values (trimValues=true)', () => {
+    // With trimValues=false, leading/trailing whitespace inside a tag would diverge.
+    expect(xmlEquivalent('<r><n>foo</n></r>', '<r><n>  foo  </n></r>')).toBe(true);
+  });
+
+  it('ignores the XML declaration (ignoreDeclaration=true)', () => {
+    const withDecl = '<?xml version="1.0" encoding="UTF-8"?><r><n>1</n></r>';
+    const without = '<r><n>1</n></r>';
+    expect(xmlEquivalent(withDecl, without)).toBe(true);
+  });
+
+  it('ignores processing-instruction tags (ignorePiTags=true)', () => {
+    // <?something ?> PI tags should be dropped so they don't affect equality.
+    const withPi = '<r><?php echo 1 ?><n>1</n></r>';
+    const without = '<r><n>1</n></r>';
+    expect(xmlEquivalent(withPi, without)).toBe(true);
+  });
+});
+
+describe('xmlEquivalent fast-path', () => {
+  it('returns true via the identity shortcut for identical strings without ever parsing', () => {
+    // Pass an intentionally malformed XML string -- if the fast-path is missing the parser
+    // would still equate them, but this nails down the documented `a === b` short-circuit.
+    const malformed = '<<<not valid xml>>>';
+    expect(xmlEquivalent(malformed, malformed)).toBe(true);
+  });
+
+  it('returns false (not undefined / not throwing) for genuinely different malformed inputs', () => {
+    // Both inputs are valid-enough that fast-xml-parser does not throw, but they differ. We
+    // only care that this returns a boolean false, not that a specific path is taken.
+    expect(xmlEquivalent('<r/>', '<r2/>')).toBe(false);
+  });
 });

--- a/test/units/verifyMetadataTypes.test.ts
+++ b/test/units/verifyMetadataTypes.test.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
@@ -61,7 +61,11 @@ const SFDX_PROJECT_BODY = JSON.stringify(
 );
 
 async function makeProject(): Promise<Project> {
-  const root = await mkdtemp(join(tmpdir(), 'verify-mt-'));
+  // mkdtemp on macOS returns a path under `/var/folders/...`, but `process.cwd()` resolves
+  // it through the `/var -> /private/var` symlink to `/private/var/folders/...`. The SUT
+  // builds its return values off the cwd-derived repo root, so we realpath here to make
+  // tests compare against the same root-form the function uses internally.
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'verify-mt-')));
   const forceAppDir = join(root, 'force-app');
   await mkdir(join(forceAppDir, 'permissionsets'), { recursive: true });
   const permsetFile = join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
@@ -333,12 +337,21 @@ describe('verifyMetadataTypes', () => {
       '<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><version>58.0</version></Package>',
     );
 
-    // Capture the cwd at the moment decompose is called -- this is the temp project root.
+    // Capture the cwd and the manifest path at the moment decompose is called -- this is
+    // when the temp project still exists on disk. We realpath both inside the mock to
+    // normalise away platform-specific path quirks (macOS `/var -> /private/var` and
+    // Windows 8.3 short names like `MATTHE~1.CAR`).
     let cwdDuringDecompose: string | undefined;
     let manifestDuringDecompose: string | undefined;
+    let realManifestDuringDecompose: string | undefined;
+    let realCwdDuringDecompose: string | undefined;
     decomposeSpy.mockImplementationOnce(async (opts: { manifest?: string }) => {
       cwdDuringDecompose = process.cwd();
+      realCwdDuringDecompose = await realpath(cwdDuringDecompose);
       manifestDuringDecompose = opts.manifest;
+      if (manifestDuringDecompose) {
+        realManifestDuringDecompose = await realpath(manifestDuringDecompose);
+      }
       return { metadata: ['permissionset'] };
     });
 
@@ -353,11 +366,9 @@ describe('verifyMetadataTypes', () => {
     });
 
     expect(cwdDuringDecompose).toBeDefined();
-    // The forwarded manifest path must live under the temp project at the same relpath.
-    expect(manifestDuringDecompose).toBe(resolve(cwdDuringDecompose as string, manifestRel));
-    // The file must actually exist on disk (it was rm'd by the time we reach here, so check via
-    // the spy capture above is the only signal we have).
     expect(typeof manifestDuringDecompose).toBe('string');
+    // The forwarded manifest path must live under the temp project at the same relpath.
+    expect(realManifestDuringDecompose).toBe(resolve(realCwdDuringDecompose as string, manifestRel));
   });
 
   it('forwards the same temp manifest path to recompose', async () => {

--- a/test/units/verifyMetadataTypes.test.ts
+++ b/test/units/verifyMetadataTypes.test.ts
@@ -1,0 +1,536 @@
+'use strict';
+
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { SFDX_CONFIG_FILE } from '../utils/constants.js';
+import type { DecomposeOptions, RecomposeOptions } from '../../src/helpers/types.js';
+
+// ---- Mocks ---------------------------------------------------------------
+//
+// `verifyMetadataTypes` orchestrates a round-trip check by delegating the actual
+// decompose/recompose work to its sibling helpers. The orchestration logic --
+// temp project bootstrap, manifest mirroring, overrides scrubbing, `decomposed.metadata.length`
+// branching, `chdir` discipline, and diff aggregation -- is the only thing
+// worth covering here, so we mock the two heavy dependencies. The actual
+// Rust-backed disassembly is exercised by metadata.test.ts and the NUTs.
+
+const { decomposeSpy, recomposeSpy } = vi.hoisted(() => ({
+  decomposeSpy: vi.fn(),
+  recomposeSpy: vi.fn(),
+}));
+
+vi.mock('../../src/core/decomposeMetadataTypes.js', () => ({
+  decomposeMetadataTypes: decomposeSpy,
+}));
+
+vi.mock('../../src/core/recomposeMetadataTypes.js', () => ({
+  recomposeMetadataTypes: recomposeSpy,
+}));
+
+// Typed accessors for the mock call args. The spies are intentionally `any`-typed by
+// vitest, so we lift them through these helpers to keep the test bodies type-safe.
+function lastDecomposeArgs(): DecomposeOptions {
+  return decomposeSpy.mock.calls[decomposeSpy.mock.calls.length - 1][0] as DecomposeOptions;
+}
+function lastRecomposeArgs(): RecomposeOptions {
+  return recomposeSpy.mock.calls[recomposeSpy.mock.calls.length - 1][0] as RecomposeOptions;
+}
+
+const { verifyMetadataTypes } = await import('../../src/core/verifyMetadataTypes.js');
+
+// ---- Test plumbing -------------------------------------------------------
+
+type Project = {
+  root: string;
+  forceAppDir: string;
+  permsetFile: string;
+};
+
+const SFDX_PROJECT_BODY = JSON.stringify(
+  {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: '58.0',
+  },
+  null,
+  2,
+);
+
+async function makeProject(): Promise<Project> {
+  const root = await mkdtemp(join(tmpdir(), 'verify-mt-'));
+  const forceAppDir = join(root, 'force-app');
+  await mkdir(join(forceAppDir, 'permissionsets'), { recursive: true });
+  const permsetFile = join(forceAppDir, 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+  await writeFile(permsetFile, '<r><x>1</x></r>');
+  await writeFile(join(root, SFDX_CONFIG_FILE), SFDX_PROJECT_BODY);
+  return { root, forceAppDir, permsetFile };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('verifyMetadataTypes', () => {
+  const originalCwd = process.cwd();
+  let project: Project;
+  let logMock: Mock;
+
+  beforeEach(async () => {
+    project = await makeProject();
+    process.chdir(project.root);
+    logMock = vi.fn();
+
+    // Default mocks: decompose claims success on permissionset; recompose is a no-op.
+    decomposeSpy.mockResolvedValue({ metadata: ['permissionset'] });
+    recomposeSpy.mockResolvedValue({ metadata: ['permissionset'] });
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(project.root, { recursive: true, force: true });
+  });
+
+  it('returns empty drift when the round trip leaves the package dirs byte-identical', async () => {
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(result.metadata).toEqual(['permissionset']);
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual([]);
+    expect(logMock.mock.calls.flat().join('\n')).toContain(
+      'Round-trip verified for 1 metadata type(s); no drift detected.',
+    );
+  });
+
+  it('reports drift when the recompose mock leaves the parent XML with different content', async () => {
+    // Simulate a buggy decomposer that produces a slightly different parent XML on recompose.
+    recomposeSpy.mockImplementationOnce(async () => {
+      // Locate the copied parent XML inside the temp project (it lives under
+      // .../verify-***/force-app/permissionsets/HR_Admin.permissionset-meta.xml).
+      // We can't predict the temp dir name, so resolve via process.cwd(), which the function
+      // has chdir'd into for this phase.
+      const target = resolve(process.cwd(), 'force-app', 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+      await writeFile(target, '<r><x>99</x></r>');
+      return { metadata: ['permissionset'] };
+    });
+
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([{ path: 'permissionsets/HR_Admin.permissionset-meta.xml', reason: 'content drift' }]);
+    expect(result.reordered).toEqual([]);
+    expect(logMock.mock.calls.flat().join('\n')).toContain('Round-trip drift detected in 1 file(s):');
+    expect(logMock.mock.calls.flat().join('\n')).toContain(
+      '- permissionsets/HR_Admin.permissionset-meta.xml: content drift',
+    );
+  });
+
+  it('reports reordered XML on a separate channel without flagging it as drift', async () => {
+    // The original is `<r><x>1</x><x>2</x></r>`; recompose-mock writes the same content but with
+    // siblings reordered. diffDirectories must surface this as reordered, not drift.
+    await writeFile(project.permsetFile, '<r><x>1</x><x>2</x></r>');
+    recomposeSpy.mockImplementationOnce(async () => {
+      const target = resolve(process.cwd(), 'force-app', 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+      await writeFile(target, '<r><x>2</x><x>1</x></r>');
+      return { metadata: ['permissionset'] };
+    });
+
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(result.drift).toEqual([]);
+    expect(result.reordered).toEqual(['permissionsets/HR_Admin.permissionset-meta.xml']);
+    const combined = logMock.mock.calls.flat().join('\n');
+    // The reordered log fires only when reordered.length > 0 (kills the `>` mutation on line 136).
+    expect(combined).toContain('Note: 1 file(s) round-tripped semantically');
+    expect(combined).toContain('- permissionsets/HR_Admin.permissionset-meta.xml');
+  });
+
+  it('does not emit the reordered log when nothing reordered', async () => {
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    const combined = logMock.mock.calls.flat().join('\n');
+    expect(combined).not.toContain('Note:');
+    expect(combined).not.toContain('round-tripped semantically');
+  });
+
+  it('passes prepurge=true and postpurge=false through to decomposeMetadataTypes', async () => {
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(decomposeSpy).toHaveBeenCalledTimes(1);
+    const args = lastDecomposeArgs();
+    expect(args.prepurge).toBe(true);
+    // Verify must keep the parent XML in place so the recompose step can find it via the manifest.
+    expect(args.postpurge).toBe(false);
+    expect(args.metadataTypes).toEqual(['permissionset']);
+    expect(args.strategy).toBe('unique-id');
+    expect(args.format).toBe('xml');
+  });
+
+  it('passes postpurge=true through to recomposeMetadataTypes', async () => {
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(recomposeSpy).toHaveBeenCalledTimes(1);
+    const args = lastRecomposeArgs();
+    // Postpurge clears the decomposed children once recompose has rebuilt the parent.
+    expect(args.postpurge).toBe(true);
+    expect(args.metadataTypes).toEqual(['permissionset']);
+  });
+
+  it('skips the recompose call when decompose returns no metadata', async () => {
+    // Boundary case for `if (decomposed.metadata.length > 0)`.
+    decomposeSpy.mockResolvedValueOnce({ metadata: [] });
+
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['workflow'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(decomposeSpy).toHaveBeenCalledTimes(1);
+    expect(recomposeSpy).not.toHaveBeenCalled();
+    expect(result.metadata).toEqual([]);
+    // No-drift log uses decomposed.metadata.length, so it should say "0 metadata type(s)" here.
+    expect(logMock.mock.calls.flat().join('\n')).toContain('Round-trip verified for 0 metadata type(s)');
+  });
+
+  it('runs recompose exactly once when decompose returns one metadata type', async () => {
+    decomposeSpy.mockResolvedValueOnce({ metadata: ['permissionset'] });
+
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(recomposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs recompose when decompose returns multiple metadata types', async () => {
+    // Bump up the fixture so multiple types are present in the SFDX project.
+    await mkdir(join(project.forceAppDir, 'workflows'), { recursive: true });
+    await writeFile(join(project.forceAppDir, 'workflows', 'A.workflow-meta.xml'), '<Workflow/>');
+
+    decomposeSpy.mockResolvedValueOnce({ metadata: ['permissionset', 'workflow'] });
+
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset', 'workflow'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+
+    expect(recomposeSpy).toHaveBeenCalledTimes(1);
+    expect(lastRecomposeArgs().metadataTypes).toEqual(['permissionset', 'workflow']);
+  });
+
+  it('strips user-supplied prePurge/postPurge from overrides before invoking decompose', async () => {
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+      overrides: [
+        {
+          metadataTypes: ['permissionset'],
+          prePurge: true,
+          postPurge: true,
+          strategy: 'grouped-by-tag',
+        },
+      ],
+    });
+
+    expect(decomposeSpy).toHaveBeenCalledTimes(1);
+    const args = lastDecomposeArgs();
+    expect(args.overrides).toHaveLength(1);
+    // The overrides array is typed as DecomposerOverride[] | undefined; the prior assertion
+    // narrows it to a non-empty array, so the first entry is safe to access.
+    const passedOverride = (args.overrides ?? [])[0];
+    // The override must survive otherwise (strategy/metadataTypes still present)...
+    expect(passedOverride.metadataTypes).toEqual(['permissionset']);
+    expect(passedOverride.strategy).toBe('grouped-by-tag');
+    // ...but prePurge and postPurge must have been removed.
+    expect(passedOverride).not.toHaveProperty('prePurge');
+    expect(passedOverride).not.toHaveProperty('postPurge');
+  });
+
+  it('does not introduce an overrides array when none was supplied', async () => {
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(lastDecomposeArgs().overrides).toBeUndefined();
+  });
+
+  it('copies the manifest into the temp project at the same repo-relative path and forwards the absolute temp path', async () => {
+    // Build a real manifest inside the project and pass it via the options.
+    const manifestRel = join('config', 'package.xml');
+    const manifestAbs = resolve(project.root, manifestRel);
+    await mkdir(resolve(project.root, 'config'), { recursive: true });
+    await writeFile(
+      manifestAbs,
+      '<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><version>58.0</version></Package>',
+    );
+
+    // Capture the cwd at the moment decompose is called -- this is the temp project root.
+    let cwdDuringDecompose: string | undefined;
+    let manifestDuringDecompose: string | undefined;
+    decomposeSpy.mockImplementationOnce(async (opts: { manifest?: string }) => {
+      cwdDuringDecompose = process.cwd();
+      manifestDuringDecompose = opts.manifest;
+      return { metadata: ['permissionset'] };
+    });
+
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      manifest: manifestRel,
+      log: logMock,
+    });
+
+    expect(cwdDuringDecompose).toBeDefined();
+    // The forwarded manifest path must live under the temp project at the same relpath.
+    expect(manifestDuringDecompose).toBe(resolve(cwdDuringDecompose as string, manifestRel));
+    // The file must actually exist on disk (it was rm'd by the time we reach here, so check via
+    // the spy capture above is the only signal we have).
+    expect(typeof manifestDuringDecompose).toBe('string');
+  });
+
+  it('forwards the same temp manifest path to recompose', async () => {
+    const manifestRel = 'package.xml';
+    const manifestAbs = resolve(project.root, manifestRel);
+    await writeFile(
+      manifestAbs,
+      '<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><version>58.0</version></Package>',
+    );
+
+    let manifestForDecompose: string | undefined;
+    let manifestForRecompose: string | undefined;
+    decomposeSpy.mockImplementationOnce(async (opts: { manifest?: string }) => {
+      manifestForDecompose = opts.manifest;
+      return { metadata: ['permissionset'] };
+    });
+    recomposeSpy.mockImplementationOnce(async (opts: { manifest?: string }) => {
+      manifestForRecompose = opts.manifest;
+      return { metadata: ['permissionset'] };
+    });
+
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      manifest: manifestRel,
+      log: logMock,
+    });
+
+    expect(manifestForRecompose).toBe(manifestForDecompose);
+    expect(manifestForRecompose).toBeDefined();
+  });
+
+  it('passes undefined manifest through to decompose/recompose when none was supplied', async () => {
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(lastDecomposeArgs().manifest).toBeUndefined();
+    expect(lastRecomposeArgs().manifest).toBeUndefined();
+  });
+
+  it('restores cwd to the original on the happy path', async () => {
+    const before = process.cwd();
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(process.cwd()).toBe(before);
+  });
+
+  it('restores cwd and cleans up the temp project even when decompose throws', async () => {
+    const before = process.cwd();
+    let tempDirSeenByMock: string | undefined;
+    // `mockImplementation` (not Once) wins over the default mockResolvedValue from beforeEach
+    // and avoids any queueing surprises with mockImplementationOnce + mockResolvedValue.
+    decomposeSpy.mockImplementation(async () => {
+      tempDirSeenByMock = process.cwd();
+      throw new Error('boom from decompose');
+    });
+
+    await expect(
+      verifyMetadataTypes({
+        metadataTypes: ['permissionset'],
+        format: 'xml',
+        ignoreDirs: undefined,
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        log: logMock,
+      }),
+    ).rejects.toThrow('boom from decompose');
+
+    expect(process.cwd()).toBe(before);
+    expect(tempDirSeenByMock).toBeDefined();
+    // Temp project dir must have been removed by the finally block.
+    expect(await pathExists(tempDirSeenByMock as string)).toBe(false);
+  });
+
+  it('cleans up the temp project on the happy path too', async () => {
+    let seen: string | undefined;
+    decomposeSpy.mockImplementation(async () => {
+      seen = process.cwd();
+      return { metadata: ['permissionset'] };
+    });
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(seen).toBeDefined();
+    expect(await pathExists(seen as string)).toBe(false);
+  });
+
+  it('mirrors sfdx-project.json verbatim into the temp project', async () => {
+    let copiedSfdxBody: string | undefined;
+    decomposeSpy.mockImplementation(async () => {
+      copiedSfdxBody = await readFile(join(process.cwd(), SFDX_CONFIG_FILE), 'utf-8');
+      return { metadata: ['permissionset'] };
+    });
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(copiedSfdxBody).toBe(SFDX_PROJECT_BODY);
+  });
+
+  it('runs decomposition against a copy under the temp project, not the user repo', async () => {
+    let cwdSeen: string | undefined;
+    decomposeSpy.mockImplementation(async () => {
+      cwdSeen = process.cwd();
+      return { metadata: ['permissionset'] };
+    });
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(cwdSeen).toBeDefined();
+    expect(cwdSeen).not.toBe(project.root);
+    expect((cwdSeen as string).includes('sf-decomposer-verify-')).toBe(true);
+  });
+
+  it('logs the per-file drift reason when drift is detected', async () => {
+    recomposeSpy.mockImplementationOnce(async () => {
+      const target = resolve(process.cwd(), 'force-app', 'permissionsets', 'HR_Admin.permissionset-meta.xml');
+      await writeFile(target, '<r><x>different</x></r>');
+      return { metadata: ['permissionset'] };
+    });
+    await verifyMetadataTypes({
+      metadataTypes: ['permissionset'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    const combined = logMock.mock.calls.flat().join('\n');
+    expect(combined).toContain('Round-trip drift detected');
+    // Drift logging must include both the path and reason, not just one of them.
+    expect(combined).toContain('permissionsets/HR_Admin.permissionset-meta.xml');
+    expect(combined).toContain('content drift');
+  });
+
+  it('returns the metadata array verbatim from the decompose result', async () => {
+    decomposeSpy.mockResolvedValueOnce({ metadata: ['permissionset', 'workflow'] });
+    const result = await verifyMetadataTypes({
+      metadataTypes: ['permissionset', 'workflow'],
+      format: 'xml',
+      ignoreDirs: undefined,
+      strategy: 'unique-id',
+      decomposeNestedPerms: false,
+      log: logMock,
+    });
+    expect(result.metadata).toEqual(['permissionset', 'workflow']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the mutation-testing gap in sf-decomposer's `verify` command, which is plugin-specific (no equivalent exists in the `config-disassembler` crate). Pre-PR, the latest full Stryker run showed **31 survivors + 9 NoCov** between the two files this PR touches:

| File | Survivors | NoCov |
|---|---|---|
| `src/core/verifyMetadataTypes.ts` | 17 | 6 |
| `src/service/verify/diffDirectories.ts` | 14 | 3 |

Most of the NoCov entries are already marked `/* istanbul ignore */` because they are defensive guards (e.g. `pathExists` returning false for a directory we just `cp`'d into); those are intentional and remain.

### Changes

- **`test/units/verifyMetadataTypes.test.ts` (new, 21 tests)** — mocks `decomposeMetadataTypes` and `recomposeMetadataTypes` so the test exercises only the orchestration logic. Covers:
  - temp-project bootstrap + sfdx-project.json mirroring
  - manifest copying at the same repo-relative path, with the absolute temp path forwarded to both decompose and recompose
  - overrides scrubbing (user-supplied `prePurge` / `postPurge` stripped before delegation, but `metadataTypes` / `strategy` retained)
  - the `decomposed.metadata.length > 0` branch that gates recompose (boundaries at 0, 1, and >1)
  - `prepurge=true` / `postpurge=false` for decompose and `postpurge=true` for recompose
  - empty-drift "no drift detected" log, drift detection log path, and the reordered "Note: ... round-tripped semantically" log path
  - cwd discipline on both the happy path and when decompose throws
  - temp-dir cleanup in `finally`

- **`test/units/diffDirectories.test.ts` (extended, +12 tests)** — pins every observable `XMLParser` constructor option (`ignoreAttributes=false`, `parseTagValue=false`, `parseAttributeValue=false`, `trimValues=true`, `ignoreDeclaration=true`, `ignorePiTags=true`), the `a === b` identity shortcut in `xmlEquivalent`, the strict comparator semantics inside `canonicalize`'s array sort, and deep nested object-key sorting.

Tests only; no production code changes.

## Test plan

- [x] `npx vitest run` passes locally (280 tests, +33 from these changes)
- [x] `npm run lint` clean
- [ ] Mutation testing CI passes incrementally on the modified test files (or the no-mutants-fallback in `.github/workflows/mutation.yml` skips cleanly for a test-only diff)
- [ ] After this PR + the metadata-coverage PR (#447) land, kick off a full Stryker run via `workflow_dispatch` and confirm the verify gap is closed
