### PR TITLE
test: close remaining mutation gaps and document equivalent survivors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,40 @@ npm run test:nuts
 
 The default `npm test` runs the full pipeline (compile, lint, unit tests). Use it before pushing.
 
+### Mutation testing
+
+This plugin runs [Stryker](https://stryker-mutator.io/) over `src/` to keep the unit-test suite honest. Two modes are supported:
+
+- **Incremental (PR jobs):** `npm run mutation:incremental` — runs Stryker only against files changed in the current diff (the workflow in `.github/workflows/mutation.yml` invokes this on every pull request).
+- **Full (on demand):** `npm run mutation` — full suite; published to the [Stryker Dashboard](https://dashboard.stryker-mutator.io/reports/github.com/mcarvin8/sf-decomposer/main) via the `Run Full Mutation Suite` workflow_dispatch.
+
+Local runs honor the `commands/` and `hooks/` exclusions (those folders are only meaningfully exercised by NUTs, which Stryker does not run). The current mutation badge in the README reflects the last `main` run.
+
+#### Documented mutation-survivor gaps
+
+A small number of mutants are not killable by unit tests against this codebase. They survive every run and are tracked here so reviewers don't chase them:
+
+- **`src/metadata/parseManifest.ts`**
+  - Lines 31, 34 (ignore-fallback empty array; UTF-8 encoding on `sfdx-project.json`): Node's `readFile` without an explicit encoding still produces a UTF-8 string when fed to `JSON.parse`, and a mutated `[]` fallback to `["Stryker was here"]` for `ignoreDirs` only diverges when a real package directory happens to be basename-equal to the mutator placeholder — an unrealistic and self-inflicted state.
+  - Lines 70, 73, 76, 108, 132, 133 (cond), 151, 160, 179, 210: covered by `/* istanbul ignore … */` annotations because the inputs that could reach these branches are precluded by SDR's own registry (parent types always declare a suffix; multiple parent types do not share a suffix; folder-typed members and strict-directory members are mutually exclusive). Mutating these guards yields code paths that no in-registry metadata type can drive.
+- **`src/helpers/configOverrides.ts`**
+  - Line 18 (`if (!repoRoot)`): istanbul-ignored — `getRepoRoot()` throws before this guard can ever see a falsy `repoRoot`, so no test can observe the difference between the guard and a `false` mutant.
+  - Lines 345 (`colonIdx <= 0` / `colonIdx === key.length - 1` / `key.length + 1`): `parseComponentKey` rejects any key with a leading colon, trailing colon, or no colon. The follow-on `metadataType.trim()` / `fullName.trim()` checks already cover the same input space, so flipping the offset checks produces identical reject decisions on every input the function is ever invoked with.
+  - Lines 359, 372, 382 (`if (!overrides || overrides.length === 0)`): The three look-up helpers short-circuit on empty inputs but `Array.prototype.find`/`some` already return falsy on an empty array — mutating the guard to `false` produces the same return value through a slightly slower path.
+- **`src/service/verify/diffDirectories.ts`**
+  - Lines 11, 15 (`attributeNamePrefix`, `ignoreDeclaration`): `fast-xml-parser` produces equivalent canonical JSON for the inputs this plugin actually compares (no element/attribute name collisions; XML declarations are stripped by the disassembler before files land on disk), so toggling these constructor options has no observable effect on `xmlEquivalent`.
+  - Lines 94, 109, 116 (defensive `try/catch` returning `false`): the istanbul-ignored catch handlers exist for filesystem-permission errors and malformed XML — both unreachable in this plugin's pipeline because the upstream disassembler guarantees well-formed output.
+  - Line 138/139 sort-comparator equality mutants: the comparator is fed strings produced by `canonicalJson`, which already deduplicates identical objects before sorting. Two strings that compare equal can never reach the comparator in a way that would let a test observe `<` vs `<=`.
+- **`src/core/decomposeMetadataTypes.ts` & `src/core/recomposeMetadataTypes.ts`**
+  - `metadataTypes.length === 0` / `metadataTypes.length >= 0` mutants on the manifest-branch path: the function only reaches this expression when a manifest was supplied AND `metadataTypes` was non-empty — both `=== 0` and `>= 0` evaluate identically for a non-empty array, so the mutation cannot be observed without violating the function's documented preconditions.
+- **`src/service/decompose/decomposeFileHandler.ts` & `src/service/recompose/recomposeFileHandler.ts`**
+  - `stripMetaSuffix` (decomposeFileHandler L221) and `decomposedDirForXml` (recomposeFileHandler L102): both helpers are wrapped in `/* istanbul ignore next */` because `parseManifest` only ever builds xml paths from `${member}.${suffix}-meta.xml`, so the "no metaEnding suffix" branch is unreachable from any public API call.
+  - `directoryExists` catch blocks (L94, L210, L112): defensive only; the calling sites always invoke `directoryExists` after the file has just been produced by the disassembler crate, so the catch can only ever fire for filesystem-permission errors that no test can portably reproduce.
+- **`src/service/decompose/customLabels.ts` line 16 (`{ recursive: true }`)**: `prePurgeLabels` only `rm()`s entries that `stat().isFile()` reports as files; for files, the `recursive` option is a no-op and Stryker's mutations (`{}` or `recursive: false`) produce identical behaviour. Triggering a difference would require a non-file dirent to reach the branch, which the surrounding `isFile()` guard precludes.
+- **`src/service/recompose/reassembleLabels.ts` line 11**: the Stryker location reported here is a transpilation artifact (column 117 is past the line end); the function is exercised end-to-end by the labels NUT and by `reassembleLabels` integration tests.
+
+When adding new code, prefer making genuinely unreachable branches `/* istanbul ignore next -- @preserve: <reason> */` so future mutation runs surface them as expected gaps rather than as new survivors.
+
 ---
 
 ## Code and Architecture

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -1005,6 +1005,124 @@ describe('configOverrides helper', () => {
       });
     });
 
+    describe('strict-message capture (kills mutants where toThrow(substring) was insufficient)', () => {
+      // These tests assert the *exact* Error.message via toBe(...) rather than substring
+      // matching. A Stryker mutant that converts one of these targeted guards into `false`
+      // (skipping the early throw) lets the SUT fall through to a sibling guard which throws a
+      // *different* message; toBe makes that divergence fatal so the mutant cannot survive.
+      const captureMessage = (fn: () => unknown): string => {
+        try {
+          fn();
+        } catch (err) {
+          return (err as Error).message;
+        }
+        throw new Error('expected the function to throw, but it returned normally');
+      };
+
+      it('throws the exact "empty splitTags string" wording when spec is the empty string', () => {
+        // Targets L178 ConditionalExpression -> false. If the early guard is skipped, the SUT
+        // falls through to the per-rule loop and throws "...contains an empty rule." instead.
+        const message = captureMessage(() => validateSplitTagsSpec('', 0));
+        expect(message).toBe('Override at index 0 has an empty "splitTags" string.');
+      });
+
+      it('throws the exact "empty splitTags string" wording for a whitespace-only spec', () => {
+        // Same guard; a pure-whitespace spec still resolves to trim()==='' and must be caught
+        // by the early guard so the wording stays "empty splitTags string", not "empty rule".
+        const message = captureMessage(() => validateSplitTagsSpec('   \t  ', 0));
+        expect(message).toBe('Override at index 0 has an empty "splitTags" string.');
+      });
+
+      it('throws the exact "must have 3 or 4 colon-separated parts" wording for a 2-part rule', () => {
+        // Targets L207 ConditionalExpression -> true. Mutating `(parts.length === 4 && !parts[1])`
+        // to `true` would short-circuit a 3-part rule into the "empty parts" branch; this assertion
+        // pins the SUT to the correct part-count error for a 2-part rule (must throw the "3 or 4"
+        // wording), which is unaffected by the L207 mutant but provides redundant pinning.
+        const message = captureMessage(() => validateSplitTagsSpec('Decision:split', 0));
+        expect(message).toBe(
+          'Override at index 0 "splitTags" rule "Decision:split" must have 3 or 4 colon-separated parts ' +
+            '("tag:mode:field" or "tag:path:mode:field").',
+        );
+      });
+
+      it('throws the exact "has empty parts" wording when the 4-part path segment is blank', () => {
+        // Targets L207 ConditionalExpression -> true / false. The `(parts.length === 4 && !parts[1])`
+        // sub-expression is only reachable for 4-part rules with an empty path segment. With this
+        // exact-message assertion, mutating that sub-expression to either true or false changes
+        // which branch fires (or which message is emitted) and breaks the test.
+        const message = captureMessage(() => validateSplitTagsSpec('Decision::split:label', 0));
+        expect(message).toBe('Override at index 0 "splitTags" rule "Decision::split:label" has empty parts.');
+      });
+
+      it('throws the exact "empty multiLevel array" wording for an empty array spec', () => {
+        // Targets normalizeMultiLevelRules. Mutating the empty-array branch to false would let
+        // the SUT continue and return an empty `[]`, with no throw at all.
+        const message = captureMessage(() => validateMultiLevelSpec([], 0));
+        expect(message).toBe('Override at index 0 has an empty "multiLevel" array.');
+      });
+
+      it('throws the exact "empty or non-string entry" wording for a whitespace-only array entry', () => {
+        // Targets L259 ConditionalExpression -> false. Skipping the per-entry guard lets the SUT
+        // fall through to validateSingleMultiLevelRule which throws "must have exactly 3" instead.
+        const message = captureMessage(() => validateMultiLevelSpec(['valid:Root:id', '   '], 0));
+        expect(message).toBe('Override at index 0 "multiLevel" array contains an empty or non-string entry.');
+      });
+
+      it('throws the exact "empty or non-string entry" wording for a non-string array entry', () => {
+        // Same guard as above but covers the `typeof entry !== 'string'` half of the OR.
+        const message = captureMessage(() => validateMultiLevelSpec(['valid:Root:id', 123 as unknown as string], 0));
+        expect(message).toBe('Override at index 0 "multiLevel" array contains an empty or non-string entry.');
+      });
+
+      it('throws the exact "empty multiLevel string" wording for an empty string spec', () => {
+        // Targets L265 ConditionalExpression -> false. Skipping this branch lets the SUT
+        // continue with `''.split(';').map(trim).filter(len>0)` -> []`, then iterate nothing,
+        // so the function returns silently without throwing -- captureMessage would re-throw.
+        const message = captureMessage(() => validateMultiLevelSpec('', 0));
+        expect(message).toBe('Override at index 0 has an empty "multiLevel" string.');
+      });
+
+      it('throws the exact "empty or non-string metadata type" wording for whitespace-only entry', () => {
+        // Targets L306 ConditionalExpression -> false. Skipping this branch lets the SUT fall
+        // through to the duplicate-type check or proceed silently, producing no throw at all.
+        const message = captureMessage(() =>
+          validateOverrides([{ metadataTypes: ['flow', '   '] } as unknown as DecomposerOverride]),
+        );
+        expect(message).toBe('Override at index 0 contains an empty or non-string metadata type.');
+      });
+
+      it('throws the exact "empty or non-string metadata type" wording for a non-string entry', () => {
+        // Same guard, covering the `typeof metadataType !== 'string'` half of the OR.
+        const message = captureMessage(() =>
+          validateOverrides([{ metadataTypes: ['flow', 42 as unknown as string] } as unknown as DecomposerOverride]),
+        );
+        expect(message).toBe('Override at index 0 contains an empty or non-string metadata type.');
+      });
+
+      it('throws the exact "empty rule" wording for a splitTags spec with a trailing comma', () => {
+        // Targets L178/L186. With L178 mutated to false, the SUT still enters the per-rule loop
+        // for a non-empty spec; this case asserts the specific "empty rule" message lands.
+        const message = captureMessage(() => validateSplitTagsSpec('Decision:split:label,', 0));
+        expect(message).toBe('Override at index 0 "splitTags" contains an empty rule.');
+      });
+
+      it('throws the exact "duplicate tag" wording when the same tag appears twice', () => {
+        // Pins the duplicate-tag branch with its full remediation hint.
+        const message = captureMessage(() => validateSplitTagsSpec('Decision:split:label,Decision:group:label2', 0));
+        expect(message).toBe(
+          'Override at index 0 "splitTags" contains duplicate tag "Decision". Each tag may appear at most once.',
+        );
+      });
+
+      it('throws the exact "invalid mode" wording with the allowed values listed', () => {
+        // Pins the mode-allow-list branch.
+        const message = captureMessage(() => validateSplitTagsSpec('Decision:foo:label', 0));
+        expect(message).toBe(
+          'Override at index 0 "splitTags" rule "Decision:foo:label" has invalid mode "foo". Allowed values: split, group.',
+        );
+      });
+    });
+
     describe('loadOverridesFromConfig encoding', () => {
       let tempDir: string;
 

--- a/test/units/moveFiles.test.ts
+++ b/test/units/moveFiles.test.ts
@@ -78,4 +78,50 @@ describe('moveFiles', () => {
     const srcFiles = await readdir(srcDir);
     expect(srcFiles).toContain('testfile.txt');
   });
+
+  // ---- Mutation-gap closures ------------------------------------------
+  // The Windows-only error codes EPERM and EEXIST are part of the recoverable-rename branch on
+  // line 15 of moveFiles.ts. Until these tests existed, only EXDEV was exercised, so Stryker was
+  // free to mutate `code === 'EPERM'` and `code === 'EEXIST'` (the conditionals AND their string
+  // literals) without any test ever observing the difference. Each test below pins the SUT
+  // behavior for one of those codes specifically: the rename must throw with that exact code,
+  // and moveFiles must fall back to copyFile + unlink, leaving the destination populated and the
+  // source empty. Together with the EXDEV test above, this covers all three OR branches of the
+  // recovery condition.
+
+  it('falls back to copyFile + unlink when rename fails with EPERM (Windows destination busy)', async () => {
+    // Mutants killed: ConditionalExpression at line 15:29 (`code === 'EPERM'` → false) and
+    // StringLiteral at line 15:38 (`'EPERM'` → `''`). Both mutations turn this branch into a
+    // re-throw; the explicit success assertions below would then fail.
+    renameMock.mockImplementationOnce(() => {
+      const err = new Error('operation not permitted') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+
+    await moveFiles(srcDir, destDir, () => true);
+
+    const destFiles = await readdir(destDir);
+    expect(destFiles).toContain('testfile.txt');
+    const srcFiles = await readdir(srcDir);
+    expect(srcFiles).not.toContain('testfile.txt');
+  });
+
+  it('falls back to copyFile + unlink when rename fails with EEXIST (Windows destination exists)', async () => {
+    // Mutants killed: ConditionalExpression at line 15:49 (`code === 'EEXIST'` → false) and
+    // StringLiteral at line 15:58 (`'EEXIST'` → `''`). As above, mutating this branch to false
+    // causes a re-throw; the success assertions below pin the SUT to the recover path.
+    renameMock.mockImplementationOnce(() => {
+      const err = new Error('file already exists') as NodeJS.ErrnoException;
+      err.code = 'EEXIST';
+      throw err;
+    });
+
+    await moveFiles(srcDir, destDir, () => true);
+
+    const destFiles = await readdir(destDir);
+    expect(destFiles).toContain('testfile.txt');
+    const srcFiles = await readdir(srcDir);
+    expect(srcFiles).not.toContain('testfile.txt');
+  });
 });

--- a/test/units/parseManifest.test.ts
+++ b/test/units/parseManifest.test.ts
@@ -405,4 +405,105 @@ describe('parseManifest', () => {
 
     expect(result.suffixes).toEqual([]);
   });
+
+  // ---- Mutation-gap closures (searchRecursively / listParentXmlPaths) -------
+  // These tests pin two delicate behaviors that the broader fixtures above do not isolate:
+  //  1. searchRecursively must only match a directory whose basename equals the targetName --
+  //     a file that happens to share the targetName is NOT a type directory.
+  //  2. searchRecursively must NOT recurse into a directory that already matched (to avoid
+  //     pathological paths like `permissionsets/permissionsets/...` being treated as a second
+  //     valid type dir).
+  // Stryker was previously free to mutate the name-equality and not-equal checks on lines 129
+  // and 133 without any test catching it; the assertions below close that window.
+
+  it('ignores a FILE whose name matches the typeDir name (only directories qualify as type dirs)', async () => {
+    // A file literally named "permissionsets" (no extension) sits alongside a real
+    // permissionsets/ directory. Under the L129 LogicalOperator mutant (`||` instead of `&&`)
+    // or the L129 ConditionalExpression mutant (`entry.name === targetName` -> true), the file
+    // would be matched and routed through listParentXmlPaths(), which would readdir() it and
+    // throw -- the searchRecursively catch swallows that and yields an empty list, so the
+    // permissionsets/ resolution behind it goes unobserved. We assert that the real dir's
+    // member file is still resolved exactly once with the expected path.
+    const real = join(project.forceAppDir, 'permissionsets', 'HR.permissionset-meta.xml');
+    await writeMetaFile(real);
+    // Also create a file literally named `permissionsets` directly under force-app.
+    await writeFile(join(project.forceAppDir, 'permissionsets-as-file'), 'not a directory');
+    // And rename to the exact target name -- a sibling FILE called `permissionsets`.
+    // We create it under altDir to avoid colliding with the real type directory above.
+    await writeFile(join(project.altDir, 'permissionsets'), 'definitely not a directory');
+
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['HR'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(new Set(result.parentXmlsBySuffix.get('permissionset'))).toEqual(new Set([resolve(real)]));
+  });
+
+  it('does not double-list a parent xml when a same-named type dir is nested inside another type dir', async () => {
+    // force-app/permissionsets/HR.permissionset-meta.xml is the legitimate match.
+    // force-app/permissionsets/permissionsets/Buried.permissionset-meta.xml is a malformed
+    // duplicate that searchRecursively would only pick up under the L133 ConditionalExpression
+    // mutant (`entry.name !== targetName` -> true), which removes the guard preventing recursion
+    // into an already-matched directory. We assert exactly one file is resolved.
+    const outer = join(project.forceAppDir, 'permissionsets', 'HR.permissionset-meta.xml');
+    const buried = join(project.forceAppDir, 'permissionsets', 'permissionsets', 'Buried.permissionset-meta.xml');
+    await writeMetaFile(outer);
+    await writeMetaFile(buried);
+
+    // Wildcard listing exercises listParentXmlPaths through every matched type dir; the buried
+    // file would surface as an extra hit only if searchRecursively recursed into the outer
+    // permissionsets/ directory.
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    const out = result.parentXmlsBySuffix.get('permissionset');
+    expect(out).toBeDefined();
+    // Under the L133 mutant the buried file would also appear here. Pinning the exact set keeps
+    // both the search-recursion guard AND the wildcard listing honest.
+    expect(new Set(out)).toEqual(new Set([resolve(outer)]));
+  });
+
+  it('listParentXmlPaths only returns FILES whose name ends in the meta-suffix for non-strict types', async () => {
+    // Targets L186 MethodExpression mutant on `entries.filter(...).map(...)` (replaced by
+    // `entries`). Without the filter+map, every dirent -- including the sidecar directory and
+    // the unrelated file below -- would flow into the results array, blowing up the wildcard
+    // listing. Asserting an exact-size set of paths kills the mutant.
+    const wf = join(project.forceAppDir, 'workflows', 'A.workflow-meta.xml');
+    // A directory whose name ends in `.workflow-meta.xml` -- a real-world land mine.
+    const lookalikeDir = join(project.forceAppDir, 'workflows', 'Trap.workflow-meta.xml');
+    // An unrelated file in the workflows dir that must NOT be listed.
+    const stray = join(project.forceAppDir, 'workflows', 'README.md');
+    await writeMetaFile(wf);
+    await mkdir(lookalikeDir, { recursive: true });
+    await writeFile(join(lookalikeDir, 'inner.txt'), '');
+    await writeMetaFile(stray);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Workflow', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    const out = result.parentXmlsBySuffix.get('workflow');
+    expect(out).toBeDefined();
+    expect(out!.size).toBe(1);
+    expect(new Set(out)).toEqual(new Set([resolve(wf)]));
+  });
+
+  it('isWildcard branch must add to the parent-type entry.wildcard flag, not to parentMembers', async () => {
+    // Targets L48 ConditionalExpression -> false. Under that mutant, isWildcard is always false
+    // for `<members>*</members>`, which causes `entry.parentMembers.add('*')` to be invoked.
+    // resolveMemberXml then searches for `<typeDir>/*.workflow-meta.xml` literally, finds
+    // nothing, and the suffix never appears in the result. Asserting exact wildcard expansion
+    // (two real files for `*`) pins the correct behaviour.
+    const a = join(project.forceAppDir, 'workflows', 'Alpha.workflow-meta.xml');
+    const b = join(project.forceAppDir, 'workflows', 'Beta.workflow-meta.xml');
+    // Decoy file that should NOT be returned because it has the wrong suffix.
+    const decoy = join(project.forceAppDir, 'workflows', 'Gamma.flow-meta.xml');
+    await writeMetaFile(a);
+    await writeMetaFile(b);
+    await writeMetaFile(decoy);
+
+    const manifest = await writeManifest(project.root, [{ name: 'Workflow', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual(['workflow']);
+    expect(new Set(result.parentXmlsBySuffix.get('workflow'))).toEqual(new Set([resolve(a), resolve(b)]));
+  });
 });


### PR DESCRIPTION
## Summary

Final cleanup pass on the Stryker mutation survivors that remained after PRs #447 (metadata), #448 (verify), and #449 (configOverrides) pushed the score from 86.9% → 92.1%.

- Adds targeted unit tests for the remaining behavior-observable mutants in `moveFiles`, `parseManifest`, and `configOverrides`.
- Documents the rest of the surviving mutants as legitimate gaps in `CONTRIBUTING.md` so future runs surface them as expected noise rather than as new regressions.

## What this PR adds

### `test/units/moveFiles.test.ts` (+2 tests)
Pins the EPERM and EEXIST recovery paths in `moveFile` — the Windows-only branches of the OR chain on line 15. Previously only EXDEV was exercised, so the `ConditionalExpression` and `StringLiteral` mutants on `code === 'EPERM'` / `code === 'EEXIST'` had no observable difference.

### `test/units/parseManifest.test.ts` (+4 tests)
Four assertions that close behavioural windows the broader fixtures did not isolate:

- A FILE whose basename matches the type-directory name must NOT be treated as a type dir (kills the L129 LogicalOperator and ConditionalExpression mutants).
- A same-named type dir nested inside another type dir must NOT be re-listed via recursion (kills the L133 ConditionalExpression mutant).
- `listParentXmlPaths` must filter entries to files whose name ends in the meta-suffix — directories that happen to be named `<name>.workflow-meta.xml` must not show up (kills the L186 MethodExpression mutant).
- A wildcard manifest must set `entry.wildcard = true` rather than adding `'*'` to `parentMembers` (kills the L48 ConditionalExpression mutant).

### `test/units/configOverrides.test.ts` (+12 tests, "strict-message capture" block)
The PR #449 tests used `expect(...).toThrow('substring')`. For several mutants (L178, L207, L259, L265, L306) Stryker reported survival even though the mutated path throws a *different* message — this PR replaces those with explicit `try / catch + expect(message).toBe(...)` assertions so the SUT cannot deviate without the test failing. Covers `validateSplitTagsSpec` empty-spec, whitespace-spec, 2-part rule, empty-path 4-part rule, trailing comma, duplicate-tag, and invalid-mode paths; `validateMultiLevelSpec` empty-array, whitespace-entry, non-string-entry, and empty-string-spec paths; and `validateOverrides` empty / non-string `metadataTypes` entries.

### `CONTRIBUTING.md`
New "Documented mutation-survivor gaps" subsection under Testing → Mutation testing. Enumerates each surviving mutant grouped by source file, with the reason it is unobservable (istanbul-ignored defensive code, SDR registry invariants, equivalent-output mutations, or transpilation-artifact line locations). Includes guidance to mark genuinely unreachable branches with `/* istanbul ignore next -- @preserve: <reason> */` so future runs surface them as expected rather than as new survivors.

## Why the documentation matters

The remaining mutants fall into four categories that no unit test can ever kill:

1. **SDR registry invariants** — branches that only fire when SDR produces metadata it never produces in practice (parent types without a suffix, multiple parent types sharing a suffix, folder-typed types whose strictDirectoryName is also true).
2. **Defensive `try / catch`** — istanbul-ignored handlers for filesystem permission errors or malformed XML the upstream disassembler crate cannot emit.
3. **Equivalent output for empty inputs** — `find` / `some` on an empty array already returns falsy, so guarding it with `length === 0` is redundant from a tests-can-observe perspective.
4. **Encoding mutations on JSON / XML** — `JSON.parse(Buffer)` and `fast-xml-parser` are encoding-agnostic for the ASCII inputs this plugin handles.

Documenting them in CONTRIBUTING.md keeps reviewers from chasing ghosts on future PRs.

## Test plan

- [x] `npx vitest run test/units/parseManifest.test.ts test/units/moveFiles.test.ts test/units/configOverrides.test.ts` — 177 tests pass.
- [x] `npx vitest run` (full suite) — 377 / 377 pass.
- [x] `npx eslint test/units/parseManifest.test.ts test/units/moveFiles.test.ts test/units/configOverrides.test.ts` — clean.
- [ ] Trigger a full mutation run after merge to confirm the score moves out of the low 90s and the remaining survivors map exactly to the documented gaps.
