### PR TITLE
chore: annotate equivalent mutants with Stryker disable comments

### DIFF
--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -27,6 +27,10 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
 
   if (manifest) {
     manifestFilter = await parseManifest(manifest, ignoreDirs);
+    // Stryker disable next-line ConditionalExpression, EqualityOperator: the `--metadata-type`
+    // flag rejects empty arrays at parse time, so this branch only ever sees a non-empty
+    // metadataTypes array; `length === 0`, `length >= 0`, and the always-true mutant are
+    // indistinguishable for the inputs this code path is actually reached with.
     if (metadataTypes && metadataTypes.length > 0) {
       const manifestTypes = new Set(manifestFilter.suffixes);
       effectiveTypes = metadataTypes.filter((type) => manifestTypes.has(type));

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -15,6 +15,9 @@ export async function recomposeMetadataTypes(options: RecomposeOptions): Promise
 
   if (manifest) {
     manifestFilter = await parseManifest(manifest, ignoreDirs);
+    // Stryker disable next-line ConditionalExpression, EqualityOperator: see the matching
+    // comment in decomposeMetadataTypes.ts -- the `--metadata-type` flag rejects empty arrays
+    // at parse time, so this branch only ever sees a non-empty metadataTypes array.
     if (metadataTypes && metadataTypes.length > 0) {
       const manifestTypes = new Set(manifestFilter.suffixes);
       effectiveTypes = metadataTypes.filter((type) => manifestTypes.has(type));

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -15,6 +15,8 @@ import { ConfigFile, DecomposerOverride } from './types.js';
 export async function resolveDefaultConfigPath(): Promise<string> {
   const { repoRoot } = await getRepoRoot();
   /* istanbul ignore if -- @preserve: getRepoRoot throws when no sfdx-project.json ancestor exists, so repoRoot is always defined here. */
+  // Stryker disable next-line all: paired with the istanbul-ignore above; this branch is
+  // unreachable from any caller because getRepoRoot() throws before returning a falsy repoRoot.
   if (!repoRoot) {
     throw new Error(`Cannot locate ${HOOK_CONFIG_JSON}: repo root not found.`);
   }
@@ -60,6 +62,9 @@ const SPLIT_TAGS_MODES = new Set<string>(['split', 'group']);
 export async function loadOverridesFromConfig(configPath: string): Promise<DecomposerOverride[]> {
   let raw: string;
   try {
+    // Stryker disable next-line StringLiteral: JSON.parse(Buffer) defaults to UTF-8 decoding,
+    // so the encoding argument is observably equivalent for the ASCII configs this plugin
+    // accepts; round-tripping is asserted in test/units/configOverrides.test.ts.
     raw = await readFile(configPath, 'utf-8');
   } catch {
     return [];
@@ -342,6 +347,10 @@ function validateComponentEntries(components: string[], i: number, seenComponent
  */
 export function parseComponentKey(key: string): { metadataType: string; fullName: string } | undefined {
   const colonIdx = key.indexOf(':');
+  // Stryker disable next-line EqualityOperator, ConditionalExpression, ArithmeticOperator: the
+  // follow-on `!metadataType || !fullName` guard catches every input these mutations could
+  // diverge on (leading/trailing colon, no colon), so each mutation produces an identical
+  // reject decision for every reachable input.
   if (colonIdx <= 0 || colonIdx === key.length - 1) return undefined;
   const metadataType = key.slice(0, colonIdx).trim();
   const fullName = key.slice(colonIdx + 1).trim();
@@ -356,6 +365,9 @@ export function getOverrideForType(
   metadataType: string,
   overrides?: DecomposerOverride[],
 ): DecomposerOverride | undefined {
+  // Stryker disable next-line ConditionalExpression: Array.prototype.find already returns
+  // undefined for an empty array, so guarding with `overrides.length === 0` is redundant from
+  // an observable-behavior perspective; the explicit guard is a micro-optimization only.
   if (!overrides || overrides.length === 0) return undefined;
   return overrides.find((override) => override.metadataTypes?.includes(metadataType));
 }
@@ -369,6 +381,8 @@ export function getOverrideForComponent(
   fullName: string,
   overrides?: DecomposerOverride[],
 ): DecomposerOverride | undefined {
+  // Stryker disable next-line ConditionalExpression: see getOverrideForType comment; Array.find
+  // already returns undefined for empty input.
   if (!overrides || overrides.length === 0) return undefined;
   const key = `${metadataType}:${fullName}`;
   return overrides.find((override) => override.components?.includes(key));
@@ -379,6 +393,8 @@ export function getOverrideForComponent(
  * Used by the decompose handler to decide whether per-component enumeration is required.
  */
 export function hasComponentOverridesForType(metadataType: string, overrides?: DecomposerOverride[]): boolean {
+  // Stryker disable next-line ConditionalExpression: see getOverrideForType comment; Array.some
+  // already returns false for empty input.
   if (!overrides || overrides.length === 0) return false;
   const prefix = `${metadataType}:`;
   return overrides.some((override) => override.components?.some((component) => component.startsWith(prefix)));

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -28,9 +28,15 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
   };
   const absManifestPath = resolve(repoRoot, manifestPath);
 
+  // Stryker disable next-line StringLiteral: JSON.parse(Buffer) defaults to UTF-8 decoding,
+  // so the encoding argument is observably equivalent for the ASCII sfdx-project.json contents
+  // this plugin is ever invoked against.
   const sfdxProjectRaw: string = await readFile(dxConfigFilePath, 'utf-8');
   const sfdxProject: SfdxProject = JSON.parse(sfdxProjectRaw) as SfdxProject;
 
+  // Stryker disable next-line ArrayDeclaration: the empty-array fallback only diverges from the
+  // mutator's placeholder array when a real package directory's basename happens to equal
+  // "Stryker was here", which no real SFDX project produces.
   const normalizedIgnoreDirs = (ignoreDirs ?? []).map((dir) => basename(dir));
   const packageDirs = sfdxProject.packageDirectories
     .map((directory) => resolve(repoRoot, directory.path))
@@ -67,12 +73,19 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
     groupedEntries.map(async ({ parentType, parentMembers, wildcard }) => {
       const suffix = parentType.suffix;
       /* istanbul ignore next -- @preserve: parent metadata types always declare a suffix in SDR's registry */
+      // Stryker disable next-line all: paired with the istanbul-ignore; SDR's registry never
+      // produces a parent type without a suffix, so this guard is unreachable from any caller.
       if (!suffix) return undefined;
 
       const typeDirs = await findTypeDirectories(packageDirs, parentType.directoryName);
+      // Stryker disable next-line ConditionalExpression: when typeDirs is empty the downstream
+      // Promise.all([]) resolves immediately and xmlPaths.size === 0 returns undefined anyway,
+      // so the early-return mutation is a micro-optimization with no observable difference.
       if (typeDirs.length === 0) return undefined;
 
       const xmlPaths = new Set<string>();
+      // Stryker disable next-line ArrayDeclaration: resolveTasks is awaited via Promise.all; a
+      // string placeholder added by the mutator resolves to itself and is harmlessly discarded.
       const resolveTasks: Array<Promise<void>> = [];
 
       if (wildcard) {
@@ -105,6 +118,9 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
     const { suffix, xmlPaths } = entry;
 
     /* istanbul ignore else -- @preserve: multiple parent types sharing a suffix is not produced by SDR's registry */
+    // Stryker disable next-line ConditionalExpression: SDR never assigns the same suffix to two
+    // different parent types, so the `has(suffix) === true` branch is unreachable from any
+    // real metadata input; the always-true mutant is observably equivalent.
     if (!parentXmlsBySuffix.has(suffix)) {
       parentXmlsBySuffix.set(suffix, xmlPaths);
       orderedSuffixes.push(suffix);
@@ -137,6 +153,8 @@ async function searchRecursively(dir: string, targetName: string): Promise<strin
     return [...directMatches, ...nested.flat()];
   } catch {
     /* istanbul ignore next -- @preserve: Filesystem permission errors are platform-specific */
+    // Stryker disable next-line BlockStatement: defensive only; readdir() only throws for
+    // permission-denied or missing-dir errors, which the caller cannot reach.
     return [];
   }
 }
@@ -148,6 +166,7 @@ async function resolveMemberXml(
 ): Promise<string | undefined> {
   const { suffix, strictDirectoryName, folderType } = parentType;
   /* istanbul ignore next -- @preserve: types reaching this point always have a suffix */
+  // Stryker disable next-line all: paired with the istanbul-ignore above.
   if (!suffix) return undefined;
 
   // Labels type has a single file regardless of member name.
@@ -157,6 +176,10 @@ async function resolveMemberXml(
     return (await exists(labelsFile)) ? resolve(labelsFile) : undefined;
   }
 
+  // Stryker disable next-line ConditionalExpression, BlockStatement: when folderType is true,
+  // strictDirectoryName is always false (mutually exclusive in SDR's registry), so the
+  // mutated false-branch falls through to the identical non-strict `join(typeDir, ...)` path
+  // below and produces the same observable result.
   if (folderType) {
     // Folder-scoped types (e.g. Report, Dashboard, EmailTemplate, Document).
     // Member is of the form `<folder>/<name>`; file is `<typeDir>/<folder>/<name>.<suffix>-meta.xml`.
@@ -176,6 +199,7 @@ async function resolveMemberXml(
 async function listParentXmlPaths(typeDir: string, parentType: MetadataType): Promise<string[]> {
   const { suffix, strictDirectoryName } = parentType;
   /* istanbul ignore next -- @preserve: types reaching this point always have a suffix */
+  // Stryker disable next-line all: paired with the istanbul-ignore above.
   if (!suffix) return [];
 
   const metaEnding = `.${suffix}-meta.xml`;
@@ -208,6 +232,9 @@ async function exists(path: string): Promise<boolean> {
     await stat(path);
     return true;
   } catch {
+    // Stryker disable next-line BlockStatement: the catch is the contract for "path does not
+    // exist"; returning `undefined` (the empty-block mutant) is treated as falsy by every
+    // caller, so the mutation is observably equivalent.
     return false;
   }
 }

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -218,6 +218,8 @@ function stripMetaSuffix(fileName: string, metaSuffix: string): string {
   const metaEnding = `.${metaSuffix}-meta.xml`;
   /* istanbul ignore next -- @preserve: parseManifest always builds xml paths from `${member}.${suffix}-meta.xml`,
      so non-matching basenames cannot reach this helper through the public API. */
+  // Stryker disable next-line all: paired with the istanbul-ignore above; non-matching
+  // basenames are unreachable from any caller because parseManifest builds these xml paths.
   return fileName.endsWith(metaEnding) ? fileName.slice(0, -metaEnding.length) : fileName;
 }
 

--- a/src/service/recompose/recomposeFileHandler.ts
+++ b/src/service/recompose/recomposeFileHandler.ts
@@ -75,6 +75,9 @@ async function recomposeFromManifest(
     await Promise.all(tasks);
 
     /* istanbul ignore else -- @preserve: bot is the only strict-directory type that needs post-processing in tests */
+    // Stryker disable next-line ConditionalExpression: paired with the istanbul-ignore above;
+    // bot is the only strict-directory type the post-rename step applies to, and no other
+    // strict type ever reaches this branch from the public API.
     if (metaSuffix === 'bot') {
       // renameBotVersionFile expects the parent metadata directory (e.g. .../bots),
       // not the individual bot directory. Walk up one level and dedupe.
@@ -110,6 +113,8 @@ async function directoryExists(path: string): Promise<boolean> {
     const stats = await stat(path);
     return stats.isDirectory();
   } catch {
+    // Stryker disable next-line BlockStatement: the catch is the contract for "directory does
+    // not exist"; the empty-block mutant returns undefined which every caller treats as falsy.
     return false;
   }
 }

--- a/src/service/verify/diffDirectories.ts
+++ b/src/service/verify/diffDirectories.ts
@@ -8,10 +8,17 @@ import { VerifyDrift } from '../../helpers/types.js';
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
+  // Stryker disable next-line StringLiteral: fast-xml-parser produces equivalent canonical JSON
+  // for the XML this plugin compares (no element/attribute name collisions are possible because
+  // both sides come from the same SDR-driven disassembler output), so any non-empty prefix
+  // yields the same xmlEquivalent() result.
   attributeNamePrefix: '@_',
   parseTagValue: false,
   parseAttributeValue: false,
   trimValues: true,
+  // Stryker disable next-line BooleanLiteral: the disassembler strips XML declarations before
+  // files land on disk, so toggling ignoreDeclaration has no observable effect on inputs to
+  // xmlEquivalent().
   ignoreDeclaration: true,
   ignorePiTags: true,
 });
@@ -92,6 +99,9 @@ async function fileExists(path: string): Promise<boolean> {
     await stat(path);
     return true;
   } catch {
+    // Stryker disable next-line BlockStatement: defensive only; the caller already filters to
+    // entries that readdir() produced, so this catch is unreachable from the public API and
+    // cannot be observed by tests in a portable way.
     return false;
   }
 }
@@ -135,7 +145,11 @@ function canonicalize(value: unknown): unknown {
     normalized.sort((left, right) => {
       const ls = JSON.stringify(left);
       const rs = JSON.stringify(right);
+      // Stryker disable next-line EqualityOperator: canonicalJson dedupes upstream and the
+      // comparator is fed already-stringified values; two strings that compare equal cannot
+      // reach this branch in a way that would let a test observe `<` vs `<=`.
       if (ls < rs) return -1;
+      // Stryker disable next-line EqualityOperator: see comment above; symmetric case.
       if (ls > rs) return 1;
       return 0;
     });


### PR DESCRIPTION
## Summary

Annotates the documented equivalent-mutant survivors with inline `// Stryker disable next-line <Mutator>` comments so they no longer count against the score (or drown out real survivors in future reports). Follow-up to PR #450, which added the same content as prose-only entries in `CONTRIBUTING.md`.

Every disable is scoped to specific mutator names (not `all`, unless paired with an existing `/* istanbul ignore */`) so the covered branches still receive every other mutation Stryker can generate on the same line.

## What changes

- `src/service/verify/diffDirectories.ts` — XMLParser `attributeNamePrefix` and `ignoreDeclaration` constructor options; `fileExists` catch; the two sort-comparator equality branches in `canonicalize`.
- `src/helpers/configOverrides.ts` — `resolveDefaultConfigPath` `!repoRoot` guard (paired with existing istanbul-ignore); `loadOverridesFromConfig` `readFile` encoding; `parseComponentKey` offset checks; the three empty-overrides short-circuits in `getOverrideForType` / `getOverrideForComponent` / `hasComponentOverridesForType`.
- `src/core/decomposeMetadataTypes.ts` and `src/core/recomposeMetadataTypes.ts` — the manifest-branch `metadataTypes.length > 0` guard (CLI rejects empty arrays upstream, so the `=== 0` mutant is unobservable).
- `src/metadata/parseManifest.ts` — `sfdx-project.json` `readFile` encoding; `ignoreDirs` fallback array; the four istanbul-ignored guards (suffix, empty-typeDirs, parentXmlsBySuffix.has, suffix-in-listParentXmlPaths); `resolveTasks` array initialiser; `folderType` branch; `searchRecursively` catch; `exists()` catch.
- `src/service/decompose/decomposeFileHandler.ts` — `stripMetaSuffix` istanbul-only branch.
- `src/service/recompose/recomposeFileHandler.ts` — `directoryExists` catch; the `bot`-only post-processing branch (paired with existing istanbul-ignore).

Each disable comment includes a one-sentence rationale at the call site so future readers (human or LLM) don't have to cross-reference `CONTRIBUTING.md` to understand why a line is excluded.

## What this does NOT touch

Survivors that were NOT annotated and remain as "documented gaps" in CONTRIBUTING.md:

- `customLabels.ts` L16 (`{ recursive: true }`) — kept honest by the surrounding `isFile()` guard; annotating risks masking a real review signal if that guard ever moves.
- `*FileHandler.ts` `decomposedDirForXml` stem-slicing and similar helpers whose unreachable branches depend on `parseManifest`'s output shape — kept as doc-only so a future shape change shows up as a new survivor instead of staying silently disabled.
- `reassembleLabels.ts` L11 transpile-artifact position — Stryker is reporting a column that doesn't map to any real expression; nothing to disable.

## Test plan

- [x] `npx vitest run` — full suite, 377 / 377 pass.
- [x] `npx eslint src` — clean.
- [ ] After merge, trigger a full mutation run. Expect: covered-mutation score moves out of the low 90s and the residual survivors are exactly the doc-only entries above.
