### PR TITLE
feat: bump config-disassembler to v2 (per-platform optional deps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
 
 ### Supported Platforms
 
-sf-decomposer depends on [config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node), which includes prebuilt native binaries for:
+sf-decomposer depends on [config-disassembler-node](https://github.com/mcarvin8/config-disassembler-node), which ships prebuilt native binaries as platform-specific optional npm packages — your package manager installs only the one matching your `os` / `cpu` / `libc`:
 
 | Platform    | Architectures                      |
 | ----------- | ---------------------------------- |
 | **macOS**   | x64 (Intel), arm64 (Apple Silicon) |
-| **Linux**   | x64, arm64, ia32                   |
-| **Windows** | x64, arm64                         |
+| **Linux**   | x64 (gnu), arm64 (gnu)             |
+| **Windows** | x64, arm64, ia32                   |
 
 If your platform or architecture is not listed, please open an [issue](https://github.com/mcarvin8/sf-decomposer/issues).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "^8.26.3",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.0",
-        "config-disassembler": "^1.5.0",
+        "config-disassembler": "^2.0.3",
         "fast-xml-parser": "^5.7.2",
         "p-limit": "^7.3.0"
       },
@@ -6432,13 +6432,123 @@
       "dev": true
     },
     "node_modules/config-disassembler": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-1.5.0.tgz",
-      "integrity": "sha512-fujCo/IkmOYJewbQcuR/XioAOi1tNY9SRCvpGL5fWFfvSly1PiPcH1UscaOOq6AabSCLUIHB8h1gTO3IrA788g==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.6.2"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-2.0.3.tgz",
+      "integrity": "sha512-NnLPTNUhiUchTT7SRCKMxnhj/kzeYdNrDpUwiqNnWOw9E5hmWIvQAcnuFsgE6LVfn0ehWzONKgdrl3nUzPzw8Q==",
+      "engines": {
+        "node": ">=20"
       },
+      "optionalDependencies": {
+        "config-disassembler-darwin-arm64": "2.0.3",
+        "config-disassembler-darwin-x64": "2.0.3",
+        "config-disassembler-linux-arm64-gnu": "2.0.3",
+        "config-disassembler-linux-x64-gnu": "2.0.3",
+        "config-disassembler-win32-arm64-msvc": "2.0.3",
+        "config-disassembler-win32-ia32-msvc": "2.0.3",
+        "config-disassembler-win32-x64-msvc": "2.0.3"
+      }
+    },
+    "node_modules/config-disassembler-darwin-arm64": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-2.0.3.tgz",
+      "integrity": "sha512-C5RIIl1YGys6YK/HG06PZ/yYaU6TDVgtL3ry0mIU7y8vZ6tp+/FD2ZP/eOpE62WNRYimhds7NN7yA+3LuyfKew==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-disassembler-darwin-x64": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-2.0.3.tgz",
+      "integrity": "sha512-FA18IVfWWDs1Uh71oinOw2nVOZvCISoP7ABWFjMgIjO7MuxuFRQh+lWCmY92t0nSYdx5oGnU4ezrnsRvpHrqVA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-disassembler-linux-arm64-gnu": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-2.0.3.tgz",
+      "integrity": "sha512-rOQTAe5OdqzYSk9PFB5ljVtaiwrMfSxMNviFp79VJeyqdTcbMhS8FWmwaorO5uT9yVbdxqjQM6Bnzacv63MfLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-disassembler-linux-x64-gnu": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-2.0.3.tgz",
+      "integrity": "sha512-MMQlpHOmrucsEaX7AL1ElIycPcvUir+2SO2JW5YuC+XxujIwIMAQxOEHI9+25ee9d+UKhNWpkYCOTjNCY3HQcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-disassembler-win32-arm64-msvc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-2.0.3.tgz",
+      "integrity": "sha512-90eAoHdDRYusXtVo7VJJcitooo3vW1sW1odtvPNfZFfBKkmeZrm1BlO/bdIhngLYlZOEUiEV6yMZiGyqRSSiUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-disassembler-win32-ia32-msvc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-2.0.3.tgz",
+      "integrity": "sha512-y53d7ylehXA4CFQD274yJQz0tQxYvJWC6vMLZEGt0m5a5njB3gx4Rs297XeC8l1TdE0OrwfvKepg7ihCPv0k5A==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/config-disassembler-win32-x64-msvc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-2.0.3.tgz",
+      "integrity": "sha512-zE+JmMiQFl5H+DUDshyl0HUXp4skHQGRaTWIHZUn9u3HseZUtCpwJaRIAhPqJdAbpxUPzeozss4aqg61VsZHFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=20"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "^8.26.3",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.0",
-    "config-disassembler": "^1.5.0",
+    "config-disassembler": "^2.0.3",
     "fast-xml-parser": "^5.7.2",
     "p-limit": "^7.3.0"
   },


### PR DESCRIPTION
## Summary

- Bumps `config-disassembler` from `^1.5.0` → `^2.0.3`
- Updates the README "Supported Platforms" table to reflect v2's platform matrix
- No source-level code changes — the public API (`DisassembleXMLFileHandler`, `ReassembleXMLFileHandler`, `DisassembleConfigFileHandler`, `ReassembleConfigFileHandler` + their option keys) is preserved by v2

## What changes for sf-decomposer users

- **Smaller install footprint** — config-disassembler 2.x ships native binaries as per-platform optional npm packages (`config-disassembler-darwin-x64`, `config-disassembler-linux-x64-gnu`, `config-disassembler-win32-x64-msvc`, …). npm/yarn/pnpm install only the one matching the user's `os` / `cpu` / `libc` instead of bundling all binaries into the main tarball.
- **Same behavior** — same underlying Rust crate (`config-disassembler 0.5.1`), so disassemble / reassemble output is byte-identical.

## Platform matrix delta

| Platform    | v1.x                           | v2.x                            |
| ----------- | ------------------------------ | ------------------------------- |
| **macOS**   | x64, arm64                     | x64, arm64 (unchanged)          |
| **Linux**   | x64, arm64, **ia32**           | x64 (gnu), arm64 (gnu)          |
| **Windows** | x64, arm64                     | x64, arm64, **ia32**            |

- 32-bit Linux dropped (napi-rs does not support `i686-unknown-linux-gnu`)
- 32-bit Windows added

## Test plan

- [x] `npm install config-disassembler@^2.0.3` resolves and installs only the matching platform package locally (verified on win32-x64: only `config-disassembler-win32-x64-msvc` ended up in `node_modules/`)
- [x] Pre-commit `lint` + `build` (wireit) green
- [x] CI matrix green on Linux / macOS / Windows
- [ ] NUTs / functional tests green
