### PR TITLE
refactor: replace p-limit with in-house concurrency limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@salesforce/core": "^8.26.3",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/source-deploy-retrieve": "^12.35.9",
-        "config-disassembler": "^2.3.0",
-        "p-limit": "^7.3.0"
+        "config-disassembler": "^2.3.0"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^20.4.2",
@@ -11460,20 +11459,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/p-limit": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
-      "dependencies": {
-        "yocto-queue": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -15010,17 +14995,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "@salesforce/core": "^8.26.3",
     "@salesforce/sf-plugins-core": "^12.2.6",
     "@salesforce/source-deploy-retrieve": "^12.35.9",
-    "config-disassembler": "^2.3.0",
-    "p-limit": "^7.3.0"
+    "config-disassembler": "^2.3.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^20.4.2",

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -1,10 +1,10 @@
 'use strict';
 
-import pLimit from 'p-limit';
 import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
 import { parseManifest, ManifestFilter } from '../metadata/parseManifest.js';
 import { decomposeFileHandler } from '../service/decompose/decomposeFileHandler.js';
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
+import { pLimit } from '../helpers/pLimit.js';
 import { DecomposerResult, DecomposeOptions } from '../helpers/types.js';
 import { resolveDecomposeOptionsForType } from '../helpers/configOverrides.js';
 

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -1,10 +1,10 @@
 'use strict';
 
-import pLimit from 'p-limit';
 import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
 import { parseManifest, ManifestFilter } from '../metadata/parseManifest.js';
 import { recomposeFileHandler } from '../service/recompose/recomposeFileHandler.js';
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
+import { pLimit } from '../helpers/pLimit.js';
 import { DecomposerResult, RecomposeOptions } from '../helpers/types.js';
 
 export async function recomposeMetadataTypes(options: RecomposeOptions): Promise<DecomposerResult> {

--- a/src/helpers/pLimit.ts
+++ b/src/helpers/pLimit.ts
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Creates a concurrency limiter that ensures at most `concurrency` async tasks
+ * run simultaneously. Returns a scheduler function with the same call signature
+ * as the p-limit package: `limit(fn, ...args)` enqueues the task and returns a
+ * Promise that resolves/rejects with the task's result.
+ */
+export function pLimit(concurrency: number): <T>(fn: () => T | Promise<T>) => Promise<T> {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  function next(): void {
+    if (queue.length === 0 || active >= concurrency) return;
+    active++;
+    const run = queue.shift()!;
+    run();
+  }
+
+  return function limit<T>(fn: () => T | Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        Promise.resolve()
+          .then(() => fn())
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            next();
+          });
+      });
+      next();
+    });
+  };
+}

--- a/src/service/core/moveFiles.ts
+++ b/src/service/core/moveFiles.ts
@@ -2,8 +2,8 @@
 
 import { readdir, stat, rename, copyFile, unlink, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import pLimit from 'p-limit';
 import { CONCURRENCY_LIMITS } from '../../helpers/constants.js';
+import { pLimit } from '../../helpers/pLimit.js';
 
 async function moveFile(source: string, destination: string): Promise<void> {
   await mkdir(dirname(destination), { recursive: true });

--- a/src/service/decompose/customLabels.ts
+++ b/src/service/decompose/customLabels.ts
@@ -3,9 +3,9 @@
 
 import { join } from 'node:path';
 import { readdir, stat, rm, rename } from 'node:fs/promises';
-import pLimit from 'p-limit';
 
 import { CUSTOM_LABELS_FILE, CONCURRENCY_LIMITS } from '../../helpers/constants.js';
+import { pLimit } from '../../helpers/pLimit.js';
 import { moveFiles } from '../core/moveFiles.js';
 
 export async function prePurgeLabels(metadataPath: string): Promise<void> {

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -3,10 +3,10 @@
 import { resolve, relative, join, dirname, basename } from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
 import { DisassembleXMLFileHandler } from 'config-disassembler';
-import pLimit from 'p-limit';
 
 import { CUSTOM_LABELS_FILE, CONCURRENCY_LIMITS } from '../../helpers/constants.js';
 import { DecomposerOverride } from '../../helpers/types.js';
+import { pLimit } from '../../helpers/pLimit.js';
 import {
   ResolvedDecomposeTypeOptions,
   hasComponentOverridesForType,

--- a/src/service/decompose/renameWorkflows.ts
+++ b/src/service/decompose/renameWorkflows.ts
@@ -3,9 +3,9 @@
 
 import { join } from 'node:path';
 import { readdir, rename } from 'node:fs/promises';
-import pLimit from 'p-limit';
 
 import { WORKFLOW_SUFFIX_MAPPING, CONCURRENCY_LIMITS } from '../../helpers/constants.js';
+import { pLimit } from '../../helpers/pLimit.js';
 
 export async function renameWorkflows(directory: string): Promise<void> {
   const files = await readdir(directory, { recursive: true });

--- a/src/service/recompose/recomposeFileHandler.ts
+++ b/src/service/recompose/recomposeFileHandler.ts
@@ -3,9 +3,9 @@
 import { readdir, stat } from 'node:fs/promises';
 import { join, dirname, basename } from 'node:path';
 import { ReassembleXMLFileHandler } from 'config-disassembler';
-import pLimit from 'p-limit';
 
 import { CONCURRENCY_LIMITS } from '../../helpers/constants.js';
+import { pLimit } from '../../helpers/pLimit.js';
 import { reassembleLabels } from './reassembleLabels.js';
 import { renameBotVersionFile } from './renameBotVersionFiles.js';
 


### PR DESCRIPTION
## Remove p-limit dependency

Replaces the `p-limit` package with a small in-house concurrency limiter
(`src/helpers/pLimit.ts`) that covers the exact API surface this codebase uses.

### Why
`p-limit` is a pure-ESM package that requires extra toolchain accommodation
(bundler config, Jest transform exemptions, etc.). Since we only use the
basic `limit(fn)` scheduling pattern — never `.activeCount`, `.pendingCount`,
or `.clearQueue()` — carrying the full package is unnecessary.

### What changed
- Added `src/helpers/pLimit.ts` with a ~25-line drop-in scheduler
- Updated all six import sites to point at the local module
- Removed `p-limit` from `package.json`

### Implementation notes
The scheduler accepts `() => T | Promise<T>` so both the async task
functions and the synchronous `disassembleHandler` call sites type-check
without modification. Internally, `Promise.resolve().then(() => fn())`
normalises sync and async return values uniformly.

Concurrency constants in `src/helpers/constants.ts` are unchanged.