### PR TITLE
fix: remove process.chdir from verify; warn on missing manifest components

### DIFF
--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -20,13 +20,17 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
     manifest,
     overrides,
     log,
+    repoRoot,
   } = options;
 
   let manifestFilter: ManifestFilter | undefined;
   let effectiveTypes: string[];
 
   if (manifest) {
-    manifestFilter = await parseManifest(manifest, ignoreDirs);
+    manifestFilter = await parseManifest(manifest, ignoreDirs, repoRoot);
+    for (const { type, member } of manifestFilter.unresolvedComponents) {
+      log(`Warning: manifest component ${type}:${member} not found in local source; skipping.`);
+    }
     // Stryker disable next-line ConditionalExpression, EqualityOperator
     if (metadataTypes && metadataTypes.length > 0) {
       const manifestTypes = new Set(manifestFilter.suffixes);
@@ -58,7 +62,12 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
       let metaAttributes;
       let ignorePath: string;
       try {
-        ({ metaAttributes, ignorePath } = await getRegistryValuesBySuffix(metadataType, 'decompose', ignoreDirs));
+        ({ metaAttributes, ignorePath } = await getRegistryValuesBySuffix(
+          metadataType,
+          'decompose',
+          ignoreDirs,
+          repoRoot,
+        ));
       } catch (err) {
         /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
         if (!manifestFilter) throw err;

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -8,13 +8,16 @@ import { pLimit } from '../helpers/pLimit.js';
 import { DecomposerResult, RecomposeOptions } from '../helpers/types.js';
 
 export async function recomposeMetadataTypes(options: RecomposeOptions): Promise<DecomposerResult> {
-  const { metadataTypes, postpurge, ignoreDirs, manifest, log } = options;
+  const { metadataTypes, postpurge, ignoreDirs, manifest, log, repoRoot } = options;
 
   let manifestFilter: ManifestFilter | undefined;
   let effectiveTypes: string[];
 
   if (manifest) {
-    manifestFilter = await parseManifest(manifest, ignoreDirs);
+    manifestFilter = await parseManifest(manifest, ignoreDirs, repoRoot);
+    for (const { type, member } of manifestFilter.unresolvedComponents) {
+      log(`Warning: manifest component ${type}:${member} not found in local source; skipping.`);
+    }
     // Stryker disable next-line ConditionalExpression, EqualityOperator
     if (metadataTypes && metadataTypes.length > 0) {
       const manifestTypes = new Set(manifestFilter.suffixes);
@@ -45,7 +48,7 @@ export async function recomposeMetadataTypes(options: RecomposeOptions): Promise
 
       let metaAttributes;
       try {
-        ({ metaAttributes } = await getRegistryValuesBySuffix(metadataType, 'recompose', ignoreDirs));
+        ({ metaAttributes } = await getRegistryValuesBySuffix(metadataType, 'recompose', ignoreDirs, repoRoot));
       } catch (err) {
         /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
         if (!manifestFilter) throw err;

--- a/src/core/verifyMetadataTypes.ts
+++ b/src/core/verifyMetadataTypes.ts
@@ -54,7 +54,7 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
 
     // Manifests are validated by oclif's `Flags.file({ exists: true })`, so when one is supplied
     // it always points to a real file under the user's repo. Mirror it into the temp project at
-    // the same relative path so parseManifest (which is repoRoot-relative once we chdir) finds it.
+    // the same relative path so parseManifest finds it via the tempProjectDir repoRoot.
     let tempManifest: string | undefined;
     if (manifest) {
       const absManifest = resolve(originalCwd, manifest);
@@ -64,8 +64,6 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
       await cp(absManifest, tempManifestAbs);
       tempManifest = tempManifestAbs;
     }
-
-    process.chdir(tempProjectDir);
 
     // Strip any user-supplied prePurge/postPurge from the overrides for verify only. Verify needs
     // the parent XML to survive the decompose phase so that manifest-driven recompose can
@@ -92,6 +90,7 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
       manifest: tempManifest,
       overrides: verifyOverrides,
       log,
+      repoRoot: tempProjectDir,
     });
 
     if (decomposed.metadata.length > 0) {
@@ -103,10 +102,9 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
         ignoreDirs,
         manifest: tempManifest,
         log,
+        repoRoot: tempProjectDir,
       });
     }
-
-    process.chdir(originalCwd);
 
     const drift: VerifyDrift[] = [];
     const reordered: string[] = [];
@@ -144,10 +142,6 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
 
     return { metadata: decomposed.metadata, drift, reordered };
   } finally {
-    /* istanbul ignore next -- @preserve: defensive guard; we already chdir back on the happy path */
-    if (process.cwd() !== originalCwd) {
-      process.chdir(originalCwd);
-    }
     await rm(tempProjectDir, { recursive: true, force: true });
   }
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -85,6 +85,7 @@ export type DecomposeOptions = {
   manifest?: string;
   overrides?: DecomposerOverride[];
   log: (msg: string) => void;
+  repoRoot?: string;
 };
 
 export type RecomposeOptions = {
@@ -93,6 +94,7 @@ export type RecomposeOptions = {
   ignoreDirs?: string[];
   manifest?: string;
   log: (msg: string) => void;
+  repoRoot?: string;
 };
 
 export type VerifyOptions = {

--- a/src/metadata/getPackageDirectories.ts
+++ b/src/metadata/getPackageDirectories.ts
@@ -5,17 +5,16 @@ import { readFile, readdir } from 'node:fs/promises';
 
 import { getRepoRoot } from '../service/core/getRepoRoot.js';
 import { SfdxProject } from '../helpers/types.js';
-import { IGNORE_FILE } from '../helpers/constants.js';
+import { IGNORE_FILE, SFDX_PROJECT_FILE_NAME } from '../helpers/constants.js';
 
 export async function getPackageDirectories(
   metaDirectory: string,
-  ignoreDirs: string[] | undefined
+  ignoreDirs: string[] | undefined,
+  repoRootOverride?: string,
 ): Promise<{ metadataPaths: string[]; ignorePath: string }> {
-  const { repoRoot, dxConfigFilePath } = (await getRepoRoot()) as {
-    repoRoot: string;
-    dxConfigFilePath: string;
-  };
-  process.chdir(repoRoot);
+  const { repoRoot, dxConfigFilePath } = repoRootOverride
+    ? { repoRoot: repoRootOverride, dxConfigFilePath: join(repoRootOverride, SFDX_PROJECT_FILE_NAME) }
+    : ((await getRepoRoot()) as { repoRoot: string; dxConfigFilePath: string });
   const ignorePath = resolve(repoRoot, IGNORE_FILE);
   const sfdxProjectRaw: string = await readFile(dxConfigFilePath, 'utf-8');
   const sfdxProject: SfdxProject = JSON.parse(sfdxProjectRaw) as SfdxProject;

--- a/src/metadata/getRegistryValuesBySuffix.ts
+++ b/src/metadata/getRegistryValuesBySuffix.ts
@@ -20,14 +20,15 @@ function getRegistryAccessInstance(): RegistryAccess {
 export async function getRegistryValuesBySuffix(
   metaSuffix: string,
   command: string,
-  ignoreDirs: string[] | undefined
+  ignoreDirs: string[] | undefined,
+  repoRootOverride?: string,
 ): Promise<{ metaAttributes: MetaAttributes; ignorePath: string }> {
   if (metaSuffix === 'object') {
     throw Error('Custom Objects are not supported by this plugin.');
   }
   if (metaSuffix === 'botVersion') {
     throw Error(
-      '`botVersion` suffix should not be used. Please use `bot` to decompose/recompose bot and bot version files.'
+      '`botVersion` suffix should not be used. Please use `bot` to decompose/recompose bot and bot version files.',
     );
   }
   const registryAccess = getRegistryAccessInstance();
@@ -37,17 +38,21 @@ export async function getRegistryValuesBySuffix(
   if (
     metadataTypeEntry.strategies?.adapter &&
     ['matchingContentFile', 'digitalExperience', 'mixedContent', 'bundle'].includes(
-      metadataTypeEntry.strategies.adapter
+      metadataTypeEntry.strategies.adapter,
     )
   ) {
     throw Error(
-      `Metadata types with ${metadataTypeEntry.strategies.adapter} strategies are not supported by this plugin.`
+      `Metadata types with ${metadataTypeEntry.strategies.adapter} strategies are not supported by this plugin.`,
     );
   }
 
   let uniqueIdElements: string | undefined;
   if (command === 'decompose') uniqueIdElements = getUniqueIdElements(metaSuffix);
-  const { metadataPaths, ignorePath } = await getPackageDirectories(`${metadataTypeEntry.directoryName}`, ignoreDirs);
+  const { metadataPaths, ignorePath } = await getPackageDirectories(
+    `${metadataTypeEntry.directoryName}`,
+    ignoreDirs,
+    repoRootOverride,
+  );
   if (metadataPaths.length === 0)
     throw Error(`No directories named ${metadataTypeEntry.directoryName} were found in any package directory.`);
 

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -6,6 +6,7 @@ import { ManifestResolver, RegistryAccess, MetadataType } from '@salesforce/sour
 
 import { getRepoRoot } from '../service/core/getRepoRoot.js';
 import { SfdxProject } from '../helpers/types.js';
+import { SFDX_PROJECT_FILE_NAME } from '../helpers/constants.js';
 
 export type ManifestFilter = {
   // Maps metadata suffix to the set of absolute parent metadata xml file paths
@@ -13,6 +14,8 @@ export type ManifestFilter = {
   parentXmlsBySuffix: Map<string, Set<string>>;
   // Ordered list of suffixes discovered in the manifest.
   suffixes: string[];
+  // Non-wildcard manifest members whose XML file was not found in local source.
+  unresolvedComponents: Array<{ type: string; member: string }>;
 };
 
 type GroupedMembers = {
@@ -21,11 +24,14 @@ type GroupedMembers = {
   wildcard: boolean;
 };
 
-export async function parseManifest(manifestPath: string, ignoreDirs: string[] | undefined): Promise<ManifestFilter> {
-  const { repoRoot, dxConfigFilePath } = (await getRepoRoot()) as {
-    repoRoot: string;
-    dxConfigFilePath: string;
-  };
+export async function parseManifest(
+  manifestPath: string,
+  ignoreDirs: string[] | undefined,
+  repoRootOverride?: string,
+): Promise<ManifestFilter> {
+  const { repoRoot, dxConfigFilePath } = repoRootOverride
+    ? { repoRoot: repoRootOverride, dxConfigFilePath: join(repoRootOverride, SFDX_PROJECT_FILE_NAME) }
+    : ((await getRepoRoot()) as { repoRoot: string; dxConfigFilePath: string });
   const absManifestPath = resolve(repoRoot, manifestPath);
 
   // Stryker disable next-line StringLiteral
@@ -73,9 +79,13 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
 
       const typeDirs = await findTypeDirectories(packageDirs, parentType.directoryName);
       // Stryker disable next-line ConditionalExpression
-      if (typeDirs.length === 0) return undefined;
+      if (typeDirs.length === 0) {
+        const unresolvedMembers = wildcard ? [] : [...parentMembers];
+        return { suffix, xmlPaths: new Set<string>(), unresolvedMembers };
+      }
 
       const xmlPaths = new Set<string>();
+      const resolvedMembers = new Set<string>();
       // Stryker disable next-line ArrayDeclaration
       const resolveTasks: Array<Promise<void>> = [];
 
@@ -92,21 +102,32 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
         resolveTasks.push(
           ...typeDirs.map(async (typeDir) => {
             const xmlPath = await resolveMemberXml(typeDir, parentType, member);
-            if (xmlPath) xmlPaths.add(xmlPath);
+            if (xmlPath) {
+              xmlPaths.add(xmlPath);
+              resolvedMembers.add(member);
+            }
           }),
         );
       }
 
       await Promise.all(resolveTasks);
 
-      if (xmlPaths.size === 0) return undefined;
-      return { suffix, xmlPaths };
+      const unresolvedMembers = [...parentMembers].filter((m) => !resolvedMembers.has(m));
+      return { suffix, xmlPaths, unresolvedMembers };
     }),
   );
 
+  const unresolvedComponents: Array<{ type: string; member: string }> = [];
+
   for (const entry of resolvedPerGroup) {
     if (!entry) continue;
-    const { suffix, xmlPaths } = entry;
+    const { suffix, xmlPaths, unresolvedMembers } = entry;
+
+    for (const member of unresolvedMembers) {
+      unresolvedComponents.push({ type: suffix, member });
+    }
+
+    if (xmlPaths.size === 0) continue;
 
     /* istanbul ignore else -- @preserve: multiple parent types sharing a suffix is not produced by SDR's registry. Stryker disable next-line ConditionalExpression: */
     if (!parentXmlsBySuffix.has(suffix)) {
@@ -118,7 +139,7 @@ export async function parseManifest(manifestPath: string, ignoreDirs: string[] |
     }
   }
 
-  return { parentXmlsBySuffix, suffixes: orderedSuffixes };
+  return { parentXmlsBySuffix, suffixes: orderedSuffixes, unresolvedComponents };
 }
 
 async function findTypeDirectories(packageDirs: string[], directoryName: string): Promise<string[]> {

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -120,6 +120,7 @@ export async function parseManifest(
   const unresolvedComponents: Array<{ type: string; member: string }> = [];
 
   for (const entry of resolvedPerGroup) {
+    /* istanbul ignore next -- @preserve: undefined only reachable via the suffix-less branch already ignored above. Stryker disable next-line ConditionalExpression */
     if (!entry) continue;
     const { suffix, xmlPaths, unresolvedMembers } = entry;
 

--- a/test/units/parseManifest.test.ts
+++ b/test/units/parseManifest.test.ts
@@ -238,6 +238,18 @@ describe('parseManifest', () => {
 
     expect(result.suffixes).toEqual([]);
     expect(result.parentXmlsBySuffix.size).toBe(0);
+    expect(result.unresolvedComponents).toEqual([{ type: 'permissionset', member: 'HR_Admin' }]);
+  });
+
+  it('omits a wildcard type when no package directory contains its type dir and produces no unresolved components', async () => {
+    // Wildcard manifests that find no type dir are silently dropped — not surfaced as
+    // unresolved components, because the user asked for "whatever exists", not a named component.
+    const manifest = await writeManifest(project.root, [{ name: 'PermissionSet', members: ['*'] }]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual([]);
+    expect(result.parentXmlsBySuffix.size).toBe(0);
+    expect(result.unresolvedComponents).toEqual([]);
   });
 
   it('omits a type when its type dir exists but no declared member resolves to an XML on disk', async () => {
@@ -249,6 +261,7 @@ describe('parseManifest', () => {
 
     expect(result.suffixes).toEqual([]);
     expect(result.parentXmlsBySuffix.size).toBe(0);
+    expect(result.unresolvedComponents).toEqual([{ type: 'permissionset', member: 'DoesNotExist' }]);
   });
 
   it('returns the same Set for one parent type irrespective of member declaration order', async () => {

--- a/test/units/verifyMetadataTypes.test.ts
+++ b/test/units/verifyMetadataTypes.test.ts
@@ -337,17 +337,19 @@ describe('verifyMetadataTypes', () => {
       '<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><version>58.0</version></Package>',
     );
 
-    // Capture the cwd and the manifest path at the moment decompose is called -- this is
+    // Capture the repoRoot and manifest path at the moment decompose is called -- this is
     // when the temp project still exists on disk. We realpath both inside the mock to
     // normalise away platform-specific path quirks (macOS `/var -> /private/var` and
     // Windows 8.3 short names like `MATTHE~1.CAR`).
-    let cwdDuringDecompose: string | undefined;
+    let repoRootDuringDecompose: string | undefined;
     let manifestDuringDecompose: string | undefined;
     let realManifestDuringDecompose: string | undefined;
-    let realCwdDuringDecompose: string | undefined;
-    decomposeSpy.mockImplementationOnce(async (opts: { manifest?: string }) => {
-      cwdDuringDecompose = process.cwd();
-      realCwdDuringDecompose = await realpath(cwdDuringDecompose);
+    let realRepoRootDuringDecompose: string | undefined;
+    decomposeSpy.mockImplementationOnce(async (opts: { manifest?: string; repoRoot?: string }) => {
+      repoRootDuringDecompose = opts.repoRoot;
+      if (repoRootDuringDecompose) {
+        realRepoRootDuringDecompose = await realpath(repoRootDuringDecompose);
+      }
       manifestDuringDecompose = opts.manifest;
       if (manifestDuringDecompose) {
         realManifestDuringDecompose = await realpath(manifestDuringDecompose);
@@ -365,10 +367,10 @@ describe('verifyMetadataTypes', () => {
       log: logMock,
     });
 
-    expect(cwdDuringDecompose).toBeDefined();
+    expect(repoRootDuringDecompose).toBeDefined();
     expect(typeof manifestDuringDecompose).toBe('string');
     // The forwarded manifest path must live under the temp project at the same relpath.
-    expect(realManifestDuringDecompose).toBe(resolve(realCwdDuringDecompose as string, manifestRel));
+    expect(realManifestDuringDecompose).toBe(resolve(realRepoRootDuringDecompose as string, manifestRel));
   });
 
   it('forwards the same temp manifest path to recompose', async () => {
@@ -435,8 +437,8 @@ describe('verifyMetadataTypes', () => {
     let tempDirSeenByMock: string | undefined;
     // `mockImplementation` (not Once) wins over the default mockResolvedValue from beforeEach
     // and avoids any queueing surprises with mockImplementationOnce + mockResolvedValue.
-    decomposeSpy.mockImplementation(async () => {
-      tempDirSeenByMock = process.cwd();
+    decomposeSpy.mockImplementation(async (opts: { repoRoot?: string }) => {
+      tempDirSeenByMock = opts.repoRoot;
       throw new Error('boom from decompose');
     });
 
@@ -459,8 +461,8 @@ describe('verifyMetadataTypes', () => {
 
   it('cleans up the temp project on the happy path too', async () => {
     let seen: string | undefined;
-    decomposeSpy.mockImplementation(async () => {
-      seen = process.cwd();
+    decomposeSpy.mockImplementation(async (opts: { repoRoot?: string }) => {
+      seen = opts.repoRoot;
       return { metadata: ['permissionset'] };
     });
     await verifyMetadataTypes({
@@ -477,8 +479,10 @@ describe('verifyMetadataTypes', () => {
 
   it('mirrors sfdx-project.json verbatim into the temp project', async () => {
     let copiedSfdxBody: string | undefined;
-    decomposeSpy.mockImplementation(async () => {
-      copiedSfdxBody = await readFile(join(process.cwd(), SFDX_CONFIG_FILE), 'utf-8');
+    decomposeSpy.mockImplementation(async (opts: { repoRoot?: string }) => {
+      if (opts.repoRoot) {
+        copiedSfdxBody = await readFile(join(opts.repoRoot, SFDX_CONFIG_FILE), 'utf-8');
+      }
       return { metadata: ['permissionset'] };
     });
     await verifyMetadataTypes({
@@ -494,8 +498,8 @@ describe('verifyMetadataTypes', () => {
 
   it('runs decomposition against a copy under the temp project, not the user repo', async () => {
     let cwdSeen: string | undefined;
-    decomposeSpy.mockImplementation(async () => {
-      cwdSeen = process.cwd();
+    decomposeSpy.mockImplementation(async (opts: { repoRoot?: string }) => {
+      cwdSeen = opts.repoRoot;
       return { metadata: ['permissionset'] };
     });
     await verifyMetadataTypes({


### PR DESCRIPTION
## Summary

- **Bug 2 — `process.chdir` concurrency hazard**: `verifyMetadataTypes` previously called `process.chdir(tempProjectDir)` so that inner calls to `getPackageDirectories` and `parseManifest` (which use `process.cwd()` to locate the repo root) would find the temp project's `sfdx-project.json`. This is a process-global side effect unsafe under concurrent same-process invocations. Fix adds an optional `repoRoot` parameter to `getPackageDirectories`, `parseManifest`, and `getRegistryValuesBySuffix`, threads it through `DecomposeOptions`/`RecomposeOptions`, and passes `tempProjectDir` explicitly instead of calling `chdir`. Also removes the redundant `process.chdir(repoRoot)` in `getPackageDirectories`, which was unnecessary since all paths already used absolute resolution via `resolve()`.

- **Bug 4 — silent manifest component skip**: When `--manifest` references a component not yet retrieved locally (e.g. `Flow:MyFlow` but `MyFlow.flow-meta.xml` doesn't exist), the component was silently skipped. `parseManifest` now tracks which non-wildcard members resolved to no file and returns them as `unresolvedComponents`. Both `decomposeMetadataTypes` and `recomposeMetadataTypes` emit a `Warning:` log line per unresolved component.

## Test plan

- [ ] All 370 unit tests pass (`npx vitest run`)
- [ ] `tsc --noEmit` clean on src
- [ ] 4 verify unit tests updated to capture temp project path via `opts.repoRoot` instead of `process.cwd()` — same isolation invariant, correct mechanism
- [ ] Verify round-trip still works end-to-end (existing NUTs)
- [ ] Confirm warning appears when running decompose with a manifest that lists a component not present locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)