### PR TITLE
feat: user-configurable uniqueIdElements in overrides config

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,17 +479,18 @@ By default, a single decompose run uses one format and one strategy across every
 
 #### What can be overridden
 
-| Field                        | Notes                                                                                                                                                                                                                                                        |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `metadataTypes`              | Optional (required if `components` is omitted). Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override.                                                                      |
-| `components`                 | Optional (required if `metadataTypes` is omitted). Array of `<metadataSuffix>:<fullName>` keys (e.g. `permissionset:HR_Admin`, `report:MyFolder/MyReport`). Each component may appear in at most one override.                                               |
-| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                                                                                                                                        |
-| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                                                                |
-| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`. Sets a known-good `splitTags` default; ignored if `splitTags` is also set in the same scope.                                                                                  |
-| `splitTags`                  | Custom `splitTags` spec for `grouped-by-tag` strategy. See [splitTags grammar](#splittags-grammar). Ignored when the resolved strategy is not `grouped-by-tag`.                                                                                              |
-| `multiLevel`                 | One or more `multiLevel` specs for nested-array decomposition. Pass a string, a `string[]`, or a `;`-separated string. See [multiLevel grammar](#multilevel-grammar). When set, replaces the hardcoded `loyaltyProgramSetup` default for the targeted scope. |
-| `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                                                                           |
-| `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                                                                         |
+| Field                        | Notes                                                                                                                                                                                                                                                                             |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `metadataTypes`              | Optional (required if `components` is omitted). Array of metadata suffixes (same vocabulary as `--metadata-type` / `metadataSuffixes`). Each suffix may appear in at most one override.                                                                                           |
+| `components`                 | Optional (required if `metadataTypes` is omitted). Array of `<metadataSuffix>:<fullName>` keys (e.g. `permissionset:HR_Admin`, `report:MyFolder/MyReport`). Each component may appear in at most one override.                                                                    |
+| `decomposedFormat`           | `xml` \| `json` \| `json5` \| `yaml`.                                                                                                                                                                                                                                             |
+| `strategy`                   | `unique-id` \| `grouped-by-tag`. Hard rules still win — `labels` and `loyaltyProgramSetup` are always treated as `unique-id`.                                                                                                                                                     |
+| `decomposeNestedPermissions` | Only applies to `permissionset` / `mutingpermissionset` with `grouped-by-tag`. Sets a known-good `splitTags` default; ignored if `splitTags` is also set in the same scope.                                                                                                       |
+| `splitTags`                  | Custom `splitTags` spec for `grouped-by-tag` strategy. See [splitTags grammar](#splittags-grammar). Ignored when the resolved strategy is not `grouped-by-tag`.                                                                                                                   |
+| `multiLevel`                 | One or more `multiLevel` specs for nested-array decomposition. Pass a string, a `string[]`, or a `;`-separated string. See [multiLevel grammar](#multilevel-grammar). When set, replaces the hardcoded `loyaltyProgramSetup` default for the targeted scope.                      |
+| `uniqueIdElements`           | Comma-separated list of XML element names (or compound `+`-joined keys) used to derive stable filenames for `unique-id` decomposition. When set, replaces the built-in per-type registry entry for the targeted scope. See [uniqueIdElements grammar](#uniqueidelements-grammar). |
+| `prePurge`                   | Per-scope prePurge (decompose). Component-scope `prePurge` only purges the named component's decomposed directory.                                                                                                                                                                |
+| `postPurge`                  | Per-scope postPurge (decompose: remove originals after decomposing).                                                                                                                                                                                                              |
 
 Run-scope options (`metadataSuffixes`, `manifest`, `ignorePackageDirectories`) are **not** valid inside an override; the plugin will throw if they are present.
 
@@ -591,6 +592,48 @@ Within one scope, the `(file_pattern, root_to_strip)` pair must be unique across
 > **Built-in defaults.** `bot` and `loyaltyProgramSetup` ship with built-in `multiLevel` rules, so you do not need an override to get the canonical layout — supply your own only to replace the default. Full registry: [`src/metadata/multiLevelDefaults.ts`](https://github.com/mcarvin8/sf-decomposer/blob/main/src/metadata/multiLevelDefaults.ts).
 >
 > **Pass all rules at once.** Sequential single-rule decomposes rewrite `.multi_level.json` and only the last rule survives — bundle every rule for a given component into one override. Use [`sf decomposer verify`](#sf-decomposer-verify) to confirm a new config round-trips before committing it.
+
+#### uniqueIdElements grammar
+
+`uniqueIdElements` lets you specify which XML element names the disassembler crate uses to derive stable, human-readable filenames during `unique-id` decomposition. The plugin ships with a built-in registry covering the most common metadata types ([`src/metadata/uniqueIdElements.ts`](https://github.com/mcarvin8/sf-decomposer/blob/main/src/metadata/uniqueIdElements.ts)); use this override when a type is missing from the registry or when the built-in selection produces collisions for your org's data.
+
+**When to use:**
+
+- A metadata type released after the last plugin update is not in the built-in registry and produces SHA-256 hash filenames (`abc1234.mytype-meta.xml`) instead of readable ones.
+- You see `RUST_LOG=warn` collision warnings for an existing type and want to add a tiebreaker compound key without waiting for a plugin release.
+- You want to replace the built-in element list for a specific type or component with a narrower or wider set.
+
+**Spec:** Comma-separated list of element names. Each entry is either a simple name or a compound key whose fields are joined by `+`. The disassembler tries each entry in order; the first one that resolves to a non-empty, unique value within the parent element wins. The global defaults `fullName` and `name` are always prepended regardless — you do not need to include them.
+
+```
+<element>[+<element>...][,<element>[+<element>...]...]
+```
+
+**Error behaviour:**
+
+- An empty string or an entry with empty comma slots is rejected at **config-load time** — the command fails immediately before any decomposition starts.
+- Element names that pass format validation but do not exist in the XML are silently ignored by the disassembler crate; it falls back to SHA-256 hash filenames for the affected elements (the same behaviour as today when no registry entry matches). The plugin does not throw an error and continues decomposing all remaining files.
+
+**Examples:**
+
+```json
+"overrides": [
+  {
+    "metadataTypes": ["myNewSalesforceType"],
+    "uniqueIdElements": "developerName"
+  },
+  {
+    "metadataTypes": ["serviceChannel"],
+    "uniqueIdElements": "type+value,value"
+  },
+  {
+    "components": ["app:My_App"],
+    "uniqueIdElements": "actionName+pageOrSobjectType+formFactor+profile+recordType,actionName+pageOrSobjectType+formFactor+profile,actionName+pageOrSobjectType+formFactor+recordType,actionName+pageOrSobjectType+formFactor"
+  }
+]
+```
+
+> **Tip:** If you resolve a collision by adding a compound key and it works, consider opening an issue or PR to add it to the built-in registry so other orgs benefit automatically.
 
 #### Opting in from the CLI
 

--- a/examples/.sfdecomposer.config.overrides.json
+++ b/examples/.sfdecomposer.config.overrides.json
@@ -21,6 +21,10 @@
       "components": ["permissionset:HR_Admin"],
       "strategy": "unique-id",
       "decomposedFormat": "json"
+    },
+    {
+      "metadataTypes": ["myNewSalesforceType"],
+      "uniqueIdElements": "developerName,apiName"
     }
   ]
 }

--- a/messages/decomposer.decompose.md
+++ b/messages/decomposer.decompose.md
@@ -50,7 +50,7 @@ Additionally decompose object and field permissions on a permission set when str
 
 # flags.config.summary
 
-Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root. When set, the file's "overrides" array is applied (format, strategy, decomposeNestedPermissions, prePurge, postPurge per type or per individual component). Other top-level config fields are ignored when invoking the CLI directly.
+Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root. When set, the file's "overrides" array is applied (format, strategy, decomposeNestedPermissions, uniqueIdElements, prePurge, postPurge per type or per individual component). Other top-level config fields are ignored when invoking the CLI directly.
 
 # error.missingMetadataOrManifest
 

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -59,24 +59,6 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
     limit(async () => {
       const manifestXmlPaths = manifestFilter?.parentXmlsBySuffix.get(metadataType);
 
-      let metaAttributes;
-      let ignorePath: string;
-      try {
-        ({ metaAttributes, ignorePath } = await getRegistryValuesBySuffix(
-          metadataType,
-          'decompose',
-          ignoreDirs,
-          repoRoot,
-        ));
-      } catch (err) {
-        /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
-        if (!manifestFilter) throw err;
-        /* istanbul ignore next -- @preserve: getRegistryValuesBySuffix always throws Error instances */
-        const message = err instanceof Error ? err.message : String(err);
-        log(`Skipping ${metadataType}: ${message}`);
-        return;
-      }
-
       // Type-scope resolved options serve as the base for component-scope resolution further
       // down the call stack. Hard strategy rules (labels / loyaltyProgramSetup) are applied per
       // file inside the disassembler so they remain in force even when a component-scope override
@@ -86,6 +68,25 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
         { format, strategy, decomposeNestedPerms, prepurge, postpurge },
         overrides,
       );
+
+      let metaAttributes;
+      let ignorePath: string;
+      try {
+        ({ metaAttributes, ignorePath } = await getRegistryValuesBySuffix(
+          metadataType,
+          'decompose',
+          ignoreDirs,
+          repoRoot,
+          typeResolved.uniqueIdElements,
+        ));
+      } catch (err) {
+        /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
+        if (!manifestFilter) throw err;
+        /* istanbul ignore next -- @preserve: getRegistryValuesBySuffix always throws Error instances */
+        const message = err instanceof Error ? err.message : String(err);
+        log(`Skipping ${metadataType}: ${message}`);
+        return;
+      }
 
       await decomposeFileHandler(metaAttributes, typeResolved, ignorePath, overrides, manifestXmlPaths);
 

--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -49,6 +49,12 @@ export type ResolvedDecomposeTypeOptions = {
    * a single `;`-separated string is treated by the crate as multiple rules.
    */
   multiLevel?: string | string[];
+  /**
+   * Resolved custom `uniqueIdElements` spec, when explicitly set in an override. Replaces
+   * the hardcoded per-type list; the global defaults (`fullName`, `name`) are still
+   * prepended by `getRegistryValuesBySuffix` regardless.
+   */
+  uniqueIdElements?: string;
 };
 
 const SPLIT_TAGS_MODES = new Set<string>(['split', 'group']);
@@ -166,6 +172,10 @@ function validateOverrideValues(override: DecomposerOverride, i: number): void {
 
   if (override.multiLevel !== undefined) {
     validateMultiLevelSpec(override.multiLevel, i);
+  }
+
+  if (override.uniqueIdElements !== undefined) {
+    validateUniqueIdElementsSpec(override.uniqueIdElements, i);
   }
 }
 
@@ -302,6 +312,26 @@ function validateSingleMultiLevelRule(rule: string, i: number): { filePattern: s
   return { filePattern, rootToStrip };
 }
 
+/**
+ * Validate the `uniqueIdElements` spec at config-load time. Must be a non-empty
+ * comma-separated list of element names. Each entry may use `+` to join fields
+ * into a compound key (e.g. `"actionName+pageOrSobjectType+formFactor"`). Deeper
+ * validation (whether the named elements actually exist in the XML) is left to the
+ * runtime crate.
+ */
+export function validateUniqueIdElementsSpec(spec: string, i: number): void {
+  if (typeof spec !== 'string' || spec.trim() === '') {
+    throw new Error(`Override at index ${i} has an empty "uniqueIdElements" string.`);
+  }
+
+  const entries = spec.split(',').map((e) => e.trim());
+  for (const entry of entries) {
+    if (entry === '') {
+      throw new Error(`Override at index ${i} "uniqueIdElements" contains an empty entry.`);
+    }
+  }
+}
+
 function validateMetadataTypeEntries(metadataTypes: string[], i: number, seenTypes: Set<string>): void {
   for (const metadataType of metadataTypes) {
     if (typeof metadataType !== 'string' || metadataType.trim() === '') {
@@ -409,6 +439,7 @@ export function resolveDecomposeOptionsForType(
     postpurge: override.postPurge ?? base.postpurge,
     splitTags: override.splitTags ?? base.splitTags,
     multiLevel: override.multiLevel ?? base.multiLevel,
+    uniqueIdElements: override.uniqueIdElements ?? base.uniqueIdElements,
   };
 }
 
@@ -438,5 +469,6 @@ export function resolveDecomposeOptionsForComponent(
     postpurge: componentOverride.postPurge ?? typeResolved.postpurge,
     splitTags: componentOverride.splitTags ?? typeResolved.splitTags,
     multiLevel: componentOverride.multiLevel ?? typeResolved.multiLevel,
+    uniqueIdElements: componentOverride.uniqueIdElements ?? typeResolved.uniqueIdElements,
   };
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -32,6 +32,15 @@ export type DecomposerOverride = {
    * works on a per-file pattern.
    */
   multiLevel?: string | string[];
+  /**
+   * Comma-separated list of XML element names (and optional compound keys joined by `+`)
+   * used to derive stable filenames during `unique-id` decomposition. When set, this
+   * replaces the hardcoded per-type list from the built-in registry (the global defaults
+   * `fullName` and `name` are always prepended regardless). Useful for metadata types not
+   * yet covered by the built-in registry, or when the default selection produces collisions.
+   * Example: `"developerName,apiName"` or `"actionName+pageOrSobjectType+formFactor"`.
+   */
+  uniqueIdElements?: string;
   prePurge?: boolean;
   postPurge?: boolean;
 };

--- a/src/metadata/getRegistryValuesBySuffix.ts
+++ b/src/metadata/getRegistryValuesBySuffix.ts
@@ -22,6 +22,7 @@ export async function getRegistryValuesBySuffix(
   command: string,
   ignoreDirs: string[] | undefined,
   repoRootOverride?: string,
+  uniqueIdOverride?: string,
 ): Promise<{ metaAttributes: MetaAttributes; ignorePath: string }> {
   if (metaSuffix === 'object') {
     throw Error('Custom Objects are not supported by this plugin.');
@@ -47,7 +48,7 @@ export async function getRegistryValuesBySuffix(
   }
 
   let uniqueIdElements: string | undefined;
-  if (command === 'decompose') uniqueIdElements = getUniqueIdElements(metaSuffix);
+  if (command === 'decompose') uniqueIdElements = uniqueIdOverride ?? getUniqueIdElements(metaSuffix);
   const { metadataPaths, ignorePath } = await getPackageDirectories(
     `${metadataTypeEntry.directoryName}`,
     ignoreDirs,

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -10,6 +10,7 @@ import {
   validateOverrides,
   validateSplitTagsSpec,
   validateMultiLevelSpec,
+  validateUniqueIdElementsSpec,
   getOverrideForType,
   getOverrideForComponent,
   hasComponentOverridesForType,
@@ -208,6 +209,35 @@ describe('configOverrides helper', () => {
       ];
       expect(() => validateOverrides(overrides)).not.toThrow();
     });
+
+    it('accepts a well-formed uniqueIdElements spec (single element)', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['myCustomType'], uniqueIdElements: 'developerName' }];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('accepts a well-formed uniqueIdElements spec (multiple comma-separated elements)', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['myCustomType'], uniqueIdElements: 'developerName,apiName' },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('accepts a well-formed uniqueIdElements spec (compound key with +)', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['app'], uniqueIdElements: 'actionName+pageOrSobjectType+formFactor' },
+      ];
+      expect(() => validateOverrides(overrides)).not.toThrow();
+    });
+
+    it('rejects an empty uniqueIdElements string', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['flow'], uniqueIdElements: '' }];
+      expect(() => validateOverrides(overrides)).toThrow(/empty "uniqueIdElements" string/);
+    });
+
+    it('rejects a uniqueIdElements string with an empty entry between commas', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['flow'], uniqueIdElements: 'developerName,,apiName' }];
+      expect(() => validateOverrides(overrides)).toThrow(/"uniqueIdElements" contains an empty entry/);
+    });
   });
 
   describe('validateSplitTagsSpec', () => {
@@ -386,6 +416,49 @@ describe('configOverrides helper', () => {
     });
   });
 
+  describe('validateUniqueIdElementsSpec', () => {
+    it('accepts a single element name', () => {
+      expect(() => validateUniqueIdElementsSpec('developerName', 0)).not.toThrow();
+    });
+
+    it('accepts multiple comma-separated elements', () => {
+      expect(() => validateUniqueIdElementsSpec('developerName,apiName', 0)).not.toThrow();
+    });
+
+    it('accepts a compound key joined by "+"', () => {
+      expect(() => validateUniqueIdElementsSpec('actionName+pageOrSobjectType+formFactor', 0)).not.toThrow();
+    });
+
+    it('accepts a mix of simple elements and compound keys', () => {
+      expect(() =>
+        validateUniqueIdElementsSpec(
+          'actionName+pageOrSobjectType+formFactor+profile,actionName+pageOrSobjectType+formFactor',
+          0,
+        ),
+      ).not.toThrow();
+    });
+
+    it('rejects an empty string', () => {
+      expect(() => validateUniqueIdElementsSpec('', 0)).toThrow(/empty "uniqueIdElements" string/);
+    });
+
+    it('rejects a whitespace-only string', () => {
+      expect(() => validateUniqueIdElementsSpec('   ', 0)).toThrow(/empty "uniqueIdElements" string/);
+    });
+
+    it('rejects an empty entry between commas', () => {
+      expect(() => validateUniqueIdElementsSpec('developerName,,apiName', 0)).toThrow(
+        /"uniqueIdElements" contains an empty entry/,
+      );
+    });
+
+    it('rejects a trailing comma that produces an empty entry', () => {
+      expect(() => validateUniqueIdElementsSpec('developerName,', 0)).toThrow(
+        /"uniqueIdElements" contains an empty entry/,
+      );
+    });
+  });
+
   describe('getOverrideForType', () => {
     const overrides: DecomposerOverride[] = [
       { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
@@ -554,6 +627,20 @@ describe('configOverrides helper', () => {
         'botSteps:botSteps:type',
       ]);
     });
+
+    it('threads a type-scope uniqueIdElements through resolution', () => {
+      const overrides: DecomposerOverride[] = [
+        { metadataTypes: ['myCustomType'], uniqueIdElements: 'developerName,apiName' },
+      ];
+      expect(resolveDecomposeOptionsForType('myCustomType', base, overrides).uniqueIdElements).toBe(
+        'developerName,apiName',
+      );
+    });
+
+    it('returns undefined uniqueIdElements when no override sets one', () => {
+      const overrides: DecomposerOverride[] = [{ metadataTypes: ['flow'], decomposedFormat: 'yaml' }];
+      expect(resolveDecomposeOptionsForType('flow', base, overrides).uniqueIdElements).toBeUndefined();
+    });
   });
 
   describe('resolveDecomposeOptionsForComponent', () => {
@@ -632,6 +719,22 @@ describe('configOverrides helper', () => {
       expect(
         resolveDecomposeOptionsForComponent('loyaltyProgramSetup', 'Custom', typeResolved, overrides).multiLevel,
       ).toBe('rules:rules:ruleName');
+    });
+
+    it('lets a component override replace a type-scoped uniqueIdElements', () => {
+      const typeResolved = { ...base, uniqueIdElements: 'developerName' };
+      const overrides: DecomposerOverride[] = [{ components: ['myType:Special'], uniqueIdElements: 'apiName,label' }];
+      expect(resolveDecomposeOptionsForComponent('myType', 'Special', typeResolved, overrides).uniqueIdElements).toBe(
+        'apiName,label',
+      );
+    });
+
+    it('inherits a type-scoped uniqueIdElements when the component override does not set one', () => {
+      const typeResolved = { ...base, uniqueIdElements: 'developerName' };
+      const overrides: DecomposerOverride[] = [{ components: ['myType:Other'], decomposedFormat: 'yaml' }];
+      expect(resolveDecomposeOptionsForComponent('myType', 'Other', typeResolved, overrides).uniqueIdElements).toBe(
+        'developerName',
+      );
     });
 
     it('inherits a type-scoped multiLevel when the component override does not set one', () => {

--- a/test/units/getRegistryValuesBySuffix.test.ts
+++ b/test/units/getRegistryValuesBySuffix.test.ts
@@ -149,6 +149,34 @@ describe('getRegistryValuesBySuffix', () => {
     expect(second.ignorePath).toBe(first.ignorePath);
   });
 
+  it('uses the uniqueIdOverride in place of the hardcoded registry elements when provided', async () => {
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix(
+      'permissionset',
+      'decompose',
+      undefined,
+      undefined,
+      'customField,customKey',
+    );
+
+    expect(metaAttributes.uniqueIdElements).toBe(`${DEFAULT_UNIQUE_ID_ELEMENTS},customField,customKey`);
+  });
+
+  it('uniqueIdOverride has no effect for the recompose command', async () => {
+    await mkdir(join(project.forceAppDir, 'permissionsets'), { recursive: true });
+
+    const { metaAttributes } = await getRegistryValuesBySuffix(
+      'permissionset',
+      'recompose',
+      undefined,
+      undefined,
+      'customField,customKey',
+    );
+
+    expect(metaAttributes.uniqueIdElements).toBe(DEFAULT_UNIQUE_ID_ELEMENTS);
+  });
+
   it('threads ignoreDirs through to getPackageDirectories so filtered packages drop out', async () => {
     // Two package dirs; ignore the alt one. (Note: this test rewrites the sfdx-project.json
     // for this run only — the per-test temp project is torn down in afterEach.)


### PR DESCRIPTION
## Summary

- Adds optional `uniqueIdElements` field to the `overrides` array in `.sfdecomposer.config.json`
- When set on a type-scope or component-scope override, replaces the hardcoded per-type registry entry in `uniqueIdElements.ts` — the global defaults (`fullName`, `name`) are always prepended regardless
- Supports simple element names (`developerName`) and compound `+`-joined keys (`actionName+pageOrSobjectType+formFactor`)
- Validation at config-load time: empty string or empty comma entries throw immediately (command fails before any decomposition starts)
- Element names that are absent from the XML at runtime are silently ignored by the disassembler crate — it falls back to SHA-256 hash filenames as usual (no error thrown, no metadata type skipped)

## Use cases

- Metadata type released after the last plugin update is not in the built-in registry and produces hash-named shards
- `RUST_LOG=warn` shows collision warnings for an existing type — user can add a tiebreaker compound key themselves
- Override an existing built-in list for a specific org's data without waiting for a plugin release

## Test plan

- [ ] 390 unit tests pass (`npx vitest run`)
- [ ] `tsc --noEmit` clean
- [ ] `validateUniqueIdElementsSpec` unit tests: valid single element, compound key, multiple entries, empty string rejection, empty-between-commas rejection
- [ ] `validateOverrides` integration tests: accepts valid specs, rejects empty/malformed
- [ ] `resolveDecomposeOptionsForType` + `resolveDecomposeOptionsForComponent` tests: threads `uniqueIdElements` correctly, component scope wins over type scope
- [ ] `getRegistryValuesBySuffix` tests: override is used in place of registry, no effect on recompose command

🤖 Generated with [Claude Code](https://claude.com/claude-code)