### PR TITLE
chore(ci): type-check test files in CI and fix existing TS errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
         env:
           SF_DISABLE_TELEMETRY: true
 
+      - name: Type-check tests
+        if: runner.os == 'Linux' && matrix.node-version == '20'
+        run: npm run test:compile
+
       - name: Upload coverage
         if: runner.os == 'Linux' && matrix.node-version == '20'
         uses: codecov/codecov-action@v6

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "prepack": "wireit",
     "prepare": "husky && patch-package",
     "test": "wireit",
+    "test:compile": "wireit",
     "test:nuts": "oclif manifest && vitest run --config ./vitest.nut.config.ts",
     "test:only": "wireit",
     "test:perf": "vitest run --config ./vitest.perf.config.ts",

--- a/test/units/decomposeFileHandler.test.ts
+++ b/test/units/decomposeFileHandler.test.ts
@@ -481,7 +481,7 @@ describe('decomposeFileHandler', () => {
       );
 
       expect(renameWorkflowsSpy).toHaveBeenCalledTimes(2);
-      const calledDirs = renameWorkflowsSpy.mock.calls.map((c) => c[0] as string).sort();
+      const calledDirs = (renameWorkflowsSpy.mock.calls as unknown[][]).map((c) => c[0] as string).sort();
       expect(calledDirs).toEqual(['force-app/workflows', 'other-pkg/workflows']);
     });
 

--- a/test/units/recomposeFileHandler.test.ts
+++ b/test/units/recomposeFileHandler.test.ts
@@ -240,10 +240,10 @@ describe('recomposeFileHandler', () => {
       await recomposeFileHandler(makeAttrs({ metaSuffix: 'labels' }), true, xmls);
 
       expect(reassembleLabelsSpy).toHaveBeenCalledTimes(2);
-      const dirs = reassembleLabelsSpy.mock.calls.map((c) => c[0] as string).sort();
+      const dirs = (reassembleLabelsSpy.mock.calls as unknown[][]).map((c) => c[0] as string).sort();
       expect(dirs).toEqual(['force-app/labels', 'other-pkg/labels']);
       // Postpurge propagates.
-      for (const call of reassembleLabelsSpy.mock.calls) {
+      for (const call of reassembleLabelsSpy.mock.calls as unknown[][]) {
         expect(call[2]).toBe(true);
       }
     });
@@ -287,7 +287,7 @@ describe('recomposeFileHandler', () => {
       await recomposeFileHandler(makeAttrs({ metaSuffix: 'bot', strictDirectoryName: true }), false, xmls);
 
       expect(renameBotVersionFileSpy).toHaveBeenCalledTimes(2);
-      const containerDirs = renameBotVersionFileSpy.mock.calls.map((c) => c[0] as string).sort();
+      const containerDirs = (renameBotVersionFileSpy.mock.calls as unknown[][]).map((c) => c[0] as string).sort();
       expect(containerDirs).toEqual([join(TMP_ROOT, 'force-app', 'bots'), join(TMP_ROOT, 'other-pkg', 'bots')]);
     });
 


### PR DESCRIPTION
## Summary

- `test:only` (vitest) never invoked `test:compile` (tsc on `test/`), so TypeScript errors in test files were silently ignored by CI
- Adds a dedicated `Type-check tests` step to the `unit-tests` job, gated to ubuntu/node20 (same condition as coverage upload) — fails the job without affecting coverage output or running redundantly across the 9-entry matrix
- Fixes 7 pre-existing TS2352/TS2493 errors in `decomposeFileHandler` and `recomposeFileHandler` tests caused by vitest inferring spy `mock.calls` as zero-parameter tuples; cast to `unknown[][]` at each use site

## Test plan

- [ ] CI `unit-tests` job passes on all matrix entries
- [ ] `Type-check tests` step runs and passes on ubuntu/node20
- [ ] `npm run test:compile` passes locally with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)