### PR TITLE
feat(updateForceignore): add support for bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ The post-retrieve hook automatically picks up `overrides` from `.sfdecomposer.co
 
 The Salesforce CLI must **ignore** decomposed files and **allow** recomposed files. Use `--update-forceignore` on your first `sf decomposer decompose` run to populate this file automatically, or copy the [sample .forceignore](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.forceignore) and set patterns for the extensions you use (`.xml`, `.json`, `.yaml`, etc.).
 
-> **Note:** For each processed type, `--update-forceignore` adds a pattern like `**/flows/**/*.xml` (ignore all decomposed pieces) plus `!**/flows/*.flow-meta.xml` (re-allow the original file). Labels use a flat pattern (`**/labels/*.xml` + `!**/labels/CustomLabels.labels-meta.xml`) since they decompose directly into the type directory. Strict-directory types (e.g. `bot`) are skipped — their patterns require multiple allow entries at a non-standard path depth; add them manually using the [sample .forceignore](https://raw.githubusercontent.com/mcarvin8/sf-decomposer/main/examples/.forceignore) as a reference.
+> **Note:** For each processed type, `--update-forceignore` adds a pattern like `**/flows/**/*.xml` (ignore all decomposed pieces) plus `!**/flows/*.flow-meta.xml` (re-allow the original file). Labels use a flat pattern (`**/labels/*.xml` + `!**/labels/CustomLabels.labels-meta.xml`) since they decompose directly into the type directory. Bots use a component-dir pattern (`**/bots/**/*.xml` + `!**/bots/*/*.bot-meta.xml` + `!**/bots/*/*.botVersion-meta.xml`) to handle nested decomposed files and both original suffixes.
 
 #### .sfdecomposerignore
 

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -101,7 +101,6 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
         processedMeta.push({
           directoryName: basename(metaAttributes.metadataPaths[0]),
           metaSuffix: metaAttributes.metaSuffix,
-          strictDirectoryName: metaAttributes.strictDirectoryName,
           format: typeResolved.format,
         });
         effectiveRepoRoot ??= dirname(ignorePath);

--- a/src/service/core/updateForceignore.ts
+++ b/src/service/core/updateForceignore.ts
@@ -6,7 +6,6 @@ import { readFile, writeFile } from 'node:fs/promises';
 export type ProcessedMeta = {
   directoryName: string;
   metaSuffix: string;
-  strictDirectoryName: boolean;
   format: string;
 };
 
@@ -15,6 +14,15 @@ function buildPatterns(directoryName: string, metaSuffix: string, format: string
     // Labels decompose to flat files in the labels dir — one level deep is enough.
     // Allow only the original monolithic file; all individual label files stay ignored.
     return [`**/${directoryName}/*.${format}`, `!**/${directoryName}/CustomLabels.labels-meta.xml`];
+  }
+  if (metaSuffix === 'bot') {
+    // Bots have component dirs at bots/BotName/ containing decomposed pieces; originals are
+    // BotName.bot-meta.xml and BotName.botVersion-meta.xml at that level.
+    return [
+      `**/${directoryName}/**/*.${format}`,
+      `!**/${directoryName}/*/*.bot-meta.xml`,
+      `!**/${directoryName}/*/*.botVersion-meta.xml`,
+    ];
   }
   // General case: ignore everything nested inside the type dir (decomposed pieces),
   // then re-allow the original -meta.xml at the root level of that dir.
@@ -36,11 +44,7 @@ export async function updateForceignoreFile(processedMeta: ProcessedMeta[], repo
   const existingSet = new Set(existingLines.map((l) => l.trim()));
 
   const toAdd: string[] = [];
-  for (const { directoryName, metaSuffix, strictDirectoryName, format } of processedMeta) {
-    // Component container dirs for strict types (e.g. bots/MyBot/) are valid SF DX source.
-    // The decomposed pieces inside are handled by the component's main XML; skip them.
-    if (strictDirectoryName) continue;
-
+  for (const { directoryName, metaSuffix, format } of processedMeta) {
     for (const pattern of buildPatterns(directoryName, metaSuffix, format)) {
       if (!existingSet.has(pattern)) {
         toAdd.push(pattern);

--- a/test/units/updateForceignore.test.ts
+++ b/test/units/updateForceignore.test.ts
@@ -28,7 +28,7 @@ describe('updateForceignoreFile', () => {
 
   it('creates .forceignore with ignore and allow patterns for a standard type', async () => {
     const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'permissionsets', metaSuffix: 'permissionset', strictDirectoryName: false, format: 'xml' },
+      { directoryName: 'permissionsets', metaSuffix: 'permissionset', format: 'xml' },
     ];
     await updateForceignoreFile(processedMeta, repoRoot);
 
@@ -42,9 +42,7 @@ describe('updateForceignoreFile', () => {
   });
 
   it('adds flat ignore and specific allow pattern for labels', async () => {
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'labels', metaSuffix: 'labels', strictDirectoryName: false, format: 'xml' },
-    ];
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'labels', metaSuffix: 'labels', format: 'xml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
     const content = await readForceignore();
@@ -56,9 +54,7 @@ describe('updateForceignoreFile', () => {
   });
 
   it('uses the decomposed format in the ignore pattern', async () => {
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'flows', metaSuffix: 'flow', strictDirectoryName: false, format: 'yaml' },
-    ];
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'yaml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
     const content = await readForceignore();
@@ -72,9 +68,7 @@ describe('updateForceignoreFile', () => {
   it('appends new entries to existing .forceignore', async () => {
     await writeForceignore('# existing entry\nsome/path\n');
 
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'flows', metaSuffix: 'flow', strictDirectoryName: false, format: 'xml' },
-    ];
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
     const content = await readForceignore();
@@ -86,9 +80,7 @@ describe('updateForceignoreFile', () => {
   it('preserves existing content at the top with no blank line between', async () => {
     await writeForceignore('# sf-decomposer\n*.xml\n');
 
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'flows', metaSuffix: 'flow', strictDirectoryName: false, format: 'xml' },
-    ];
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
     const content = await readForceignore();
@@ -99,7 +91,7 @@ describe('updateForceignoreFile', () => {
     await writeForceignore('**/permissionsets/**/*.xml\n!**/permissionsets/*.permissionset-meta.xml\n');
 
     const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'permissionsets', metaSuffix: 'permissionset', strictDirectoryName: false, format: 'xml' },
+      { directoryName: 'permissionsets', metaSuffix: 'permissionset', format: 'xml' },
     ];
     await updateForceignoreFile(processedMeta, repoRoot);
 
@@ -113,9 +105,7 @@ describe('updateForceignoreFile', () => {
   it('deduplicates entries with surrounding whitespace in .forceignore', async () => {
     await writeForceignore('  **/flows/**/*.xml  \n');
 
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'flows', metaSuffix: 'flow', strictDirectoryName: false, format: 'xml' },
-    ];
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
     const content = await readForceignore();
@@ -127,27 +117,27 @@ describe('updateForceignoreFile', () => {
     const existingContent = '**/flows/**/*.xml\n!**/flows/*.flow-meta.xml\n';
     await writeForceignore(existingContent);
 
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'flows', metaSuffix: 'flow', strictDirectoryName: false, format: 'xml' },
-    ];
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
     expect(await readForceignore()).toBe(existingContent);
   });
 
-  it('skips strict-directory types without creating .forceignore', async () => {
-    const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'bots', metaSuffix: 'bot', strictDirectoryName: true, format: 'xml' },
-    ];
+  it('adds bot patterns with component dir depth and two allow entries', async () => {
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'bots', metaSuffix: 'bot', format: 'xml' }];
     await updateForceignoreFile(processedMeta, repoRoot);
 
-    await expect(readForceignore()).rejects.toThrow();
+    const content = await readForceignore();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines).toContain('**/bots/**/*.xml');
+    expect(lines).toContain('!**/bots/*/*.bot-meta.xml');
+    expect(lines).toContain('!**/bots/*/*.botVersion-meta.xml');
   });
 
   it('handles multiple metadata types in a single call', async () => {
     const processedMeta: ProcessedMeta[] = [
-      { directoryName: 'flows', metaSuffix: 'flow', strictDirectoryName: false, format: 'xml' },
-      { directoryName: 'permissionsets', metaSuffix: 'permissionset', strictDirectoryName: false, format: 'xml' },
+      { directoryName: 'flows', metaSuffix: 'flow', format: 'xml' },
+      { directoryName: 'permissionsets', metaSuffix: 'permissionset', format: 'xml' },
     ];
     await updateForceignoreFile(processedMeta, repoRoot);
 


### PR DESCRIPTION
## Summary

Add bot pattern generation to `--update-forceignore` with component-dir depth and dual allow suffixes (`bot-meta.xml` + `botVersion-meta.xml`). Remove `strictDirectoryName` from `ProcessedMeta` type since all types now have auto-pattern support.

## Changes

- **updateForceignore.ts**: Added bot case to `buildPatterns()` with correct allow pattern depth; removed strict-type skip logic
- **decomposeMetadataTypes.ts**: Removed `strictDirectoryName` field from ProcessedMeta object
- **updateForceignore.test.ts**: Updated tests to remove strictDirectoryName; replaced old bot-skip test with bot-pattern verification
- **README.md**: Updated note to describe bot patterns instead of "skipped" language

## Test plan

- ✅ Type check passes
- ✅ All updateForceignore tests pass (10 tests including new bot pattern test)
- ✅ Bot patterns correctly generated: `**/bots/**/*.xml`, `!**/bots/*/*.bot-meta.xml`, `!**/bots/*/*.botVersion-meta.xml`