### PR TITLE
feat: add --update-gitattributes flag to decompose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,13 +558,13 @@ The sf-decomposer prerun hook recomposes automatically when `sf project deploy s
 
 If you use the prerun hook, do not combine it with `--postpurge` and sgd. The compatible combinations are:
 
-| Setup | Works? |
-|---|---|
-| No `--postpurge` + sgd + hook | ✅ Root files in git; hook recompose at deploy is harmless |
-| No `--postpurge` + sgd, no hook | ✅ Recompose manually before commit |
-| `--postpurge` + hook, no sgd | ✅ Full deploy; hook recomposes at deploy time |
-| `--postpurge` + sgd + CI recompose commit, no hook | ✅ Explicit recompose step before sgd |
-| `--postpurge` + sgd + hook | ❌ sgd runs before hook; delta is wrong |
+| Setup                                              | Works?                                                    |
+|----------------------------------------------------|-----------------------------------------------------------|
+| No `--postpurge` + sgd + hook                      | ✅ Root files in git; hook recompose at deploy is harmless |
+| No `--postpurge` + sgd, no hook                    | ✅ Recompose manually before commit                        |
+| `--postpurge` + hook, no sgd                       | ✅ Full deploy; hook recomposes at deploy time             |
+| `--postpurge` + sgd + CI recompose commit, no hook | ✅ Explicit recompose step before sgd                      |
+| `--postpurge` + sgd + hook                         | ❌ sgd runs before hook; delta is wrong                    |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Add `.sfdecomposer.config.json` to your project root. Copy and customize one of 
 | `strategy`                   | No          | `unique-id` \| `grouped-by-tag` (default: unique-id).                                                                                              |
 | `decomposeNestedPermissions` | No          | With `grouped-by-tag`, set `true` to further decompose permission set and muting permission set object/field permissions.                          |
 | `updateForceignore`          | No          | Set `true` to automatically add decomposed file paths to `.forceignore` after each hook-triggered decomposition (default: false).                  |
+| `updateGitattributes`        | No          | Set `true` to automatically add root metadata file patterns to `.gitattributes` after each hook-triggered decomposition (default: false).          |
 | `overrides`                  | No          | Array of per-type and/or per-component overrides. See [CONFIGURATION.md](CONFIGURATION.md).                                                        |
 
 ---
@@ -160,6 +161,7 @@ FLAGS
   -p, --decompose-nested-permissions      With grouped-by-tag, further decompose permission set and muting permission set object/field permissions
   -c, --config                            Load per-type and per-component overrides from .sfdecomposer.config.json in the repo root. Only the "overrides" array is consumed. [default: false]
   --update-forceignore                    Automatically add decomposed file paths to .forceignore after successful decomposition [default: false]
+  --update-gitattributes                  Automatically add root metadata file patterns to .gitattributes after successful decomposition [default: false]
 
 GLOBAL FLAGS
   --json  Output as JSON.
@@ -517,10 +519,15 @@ sf-decomposer is compatible with sgd as long as those root files are present in 
 
 Without `--postpurge`, the original root metadata file stays in the repo alongside the decomposed pieces. When you recompose before committing (or via pre-commit hook), the root file is updated in git and sgd detects the change normally. No extra sgd configuration is needed.
 
-**Suppressing diff noise on root files.** Keeping root files in git means `git diff` and GitHub PR views show both the root file and the decomposed pieces. To eliminate that noise, add the root file patterns to `.gitattributes`:
+**Suppressing diff noise on root files.** Keeping root files in git means `git diff` and GitHub PR views show both the root file and the decomposed pieces. Pass `--update-gitattributes` on your first `sf decomposer decompose` run to suppress that noise automatically:
+
+```bash
+sf decomposer decompose -m "flow" -m "permissionset" --update-gitattributes
+```
+
+This appends patterns like the following to `.gitattributes`, creating the file if it doesn't exist:
 
 ```gitattributes
-# suppress diff on recomposed root files; decomposed pieces still show normal diffs
 **/flows/*.flow-meta.xml -diff linguist-generated=true
 **/permissionsets/*.permissionset-meta.xml -diff linguist-generated=true
 ```
@@ -528,7 +535,7 @@ Without `--postpurge`, the original root metadata file stays in the repo alongsi
 - `-diff` — `git diff` / `git show` skip textual content for these files
 - `linguist-generated=true` — GitHub collapses the file in PR diff views (still expandable)
 
-The patterns follow the same shape as `--update-forceignore`: `**/<directoryName>/*.<suffix>-meta.xml`. Git still tracks the files (sgd works); they are invisible noise during code review.
+Git still tracks the root files (sgd works); they become invisible noise during code review. You can also set `updateGitattributes: true` in `.sfdecomposer.config.json` to apply this automatically after every hook-triggered decomposition.
 
 #### If you use `--postpurge`
 

--- a/messages/decomposer.decompose.md
+++ b/messages/decomposer.decompose.md
@@ -56,6 +56,10 @@ Load per-type and per-component overrides from .sfdecomposer.config.json in the 
 
 Automatically add decomposed file paths to .forceignore after successful decomposition.
 
+# flags.update-gitattributes.summary
+
+Automatically add root metadata file patterns to .gitattributes after successful decomposition, suppressing noisy diffs on recomposed files while keeping them tracked for tools like sfdx-git-delta.
+
 # error.missingMetadataOrManifest
 
 Either --metadata-type (-m) or --manifest (-x) must be provided.

--- a/src/commands/decomposer/decompose.ts
+++ b/src/commands/decomposer/decompose.ts
@@ -77,6 +77,11 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
       required: false,
       default: false,
     }),
+    'update-gitattributes': Flags.boolean({
+      summary: messages.getMessage('flags.update-gitattributes.summary'),
+      required: false,
+      default: false,
+    }),
   };
 
   public async run(): Promise<DecomposerResult> {
@@ -99,6 +104,7 @@ export default class DecomposerDecompose extends SfCommand<DecomposerResult> {
       manifest: flags['manifest'],
       overrides,
       updateForceignore: flags['update-forceignore'],
+      updateGitattributes: flags['update-gitattributes'],
       log: this.log.bind(this),
     });
   }

--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -8,6 +8,7 @@ import { DecomposeOptions, DecomposerResult } from '../helpers/types.js';
 import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
 import { ManifestFilter, parseManifest } from '../metadata/parseManifest.js';
 import { ProcessedMeta, updateForceignoreFile } from '../service/core/updateForceignore.js';
+import { updateGitattributesFile } from '../service/core/updateGitattributes.js';
 import { decomposeFileHandler } from '../service/decompose/decomposeFileHandler.js';
 
 export async function decomposeMetadataTypes(options: DecomposeOptions): Promise<DecomposerResult> {
@@ -22,6 +23,7 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
     manifest,
     overrides,
     updateForceignore,
+    updateGitattributes,
     log,
     repoRoot,
   } = options;
@@ -101,7 +103,7 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
       await decomposeFileHandler(metaAttributes, typeResolved, ignorePath, overrides, manifestXmlPaths);
 
       processed.push(metadataType);
-      if (updateForceignore) {
+      if (updateForceignore || updateGitattributes) {
         processedMeta.push({
           directoryName: basename(metaAttributes.metadataPaths[0]),
           metaSuffix: metaAttributes.metaSuffix,
@@ -118,6 +120,11 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
   if (updateForceignore && processedMeta.length > 0 && effectiveRepoRoot) {
     await updateForceignoreFile(processedMeta, effectiveRepoRoot);
     log('Updated .forceignore with decomposed file paths.');
+  }
+
+  if (updateGitattributes && processedMeta.length > 0 && effectiveRepoRoot) {
+    await updateGitattributesFile(processedMeta, effectiveRepoRoot);
+    log('Updated .gitattributes with root metadata file patterns.');
   }
 
   return { metadata: processed };

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -62,6 +62,7 @@ export type ConfigFile = {
   strategy: string;
   decomposeNestedPermissions: boolean;
   updateForceignore?: boolean;
+  updateGitattributes?: boolean;
   manifest?: string;
   overrides?: DecomposerOverride[];
 };
@@ -97,6 +98,7 @@ export type DecomposeOptions = {
   manifest?: string;
   overrides?: DecomposerOverride[];
   updateForceignore?: boolean;
+  updateGitattributes?: boolean;
   log: (msg: string) => void;
   repoRoot?: string;
 };

--- a/src/hooks/scopedPostRetrieve.ts
+++ b/src/hooks/scopedPostRetrieve.ts
@@ -45,6 +45,7 @@ function buildDecomposeOptions(configFile: ConfigFile, log: (msg: string) => voi
     strategy: configFile.strategy || 'unique-id',
     decomposeNestedPerms: configFile.decomposeNestedPermissions || false,
     updateForceignore: configFile.updateForceignore ?? false,
+    updateGitattributes: configFile.updateGitattributes ?? false,
     manifest: manifest.trim() !== '' ? manifest.trim() : undefined,
     overrides: configFile.overrides,
     log,

--- a/src/service/core/updateGitattributes.ts
+++ b/src/service/core/updateGitattributes.ts
@@ -1,0 +1,50 @@
+'use strict';
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { type ProcessedMeta } from './updateForceignore.js';
+
+const ATTRS = '-diff linguist-generated=true';
+
+function buildPatterns(directoryName: string, metaSuffix: string): string[] {
+  if (metaSuffix === 'labels') {
+    return [`**/labels/CustomLabels.labels-meta.xml ${ATTRS}`];
+  }
+  if (metaSuffix === 'bot') {
+    return [`**/${directoryName}/*/*.bot-meta.xml ${ATTRS}`, `**/${directoryName}/*/*.botVersion-meta.xml ${ATTRS}`];
+  }
+  return [`**/${directoryName}/*.${metaSuffix}-meta.xml ${ATTRS}`];
+}
+
+export async function updateGitattributesFile(processedMeta: ProcessedMeta[], repoRoot: string): Promise<void> {
+  const gitattributesPath = join(repoRoot, '.gitattributes');
+
+  let existingContent = '';
+  try {
+    existingContent = await readFile(gitattributesPath, 'utf-8');
+  } catch {
+    // .gitattributes doesn't exist yet; start fresh
+  }
+
+  // Stryker disable next-line ArrayDeclaration -- empty-array fallback; ["Stryker was here"] is observationally equivalent since no real pattern matches that sentinel
+  const existingLines = existingContent ? existingContent.split('\n') : [];
+  const existingSet = new Set(existingLines.map((l) => l.trim()));
+
+  const toAdd: string[] = [];
+  for (const { directoryName, metaSuffix } of processedMeta) {
+    for (const pattern of buildPatterns(directoryName, metaSuffix)) {
+      if (!existingSet.has(pattern)) {
+        toAdd.push(pattern);
+        existingSet.add(pattern);
+      }
+    }
+  }
+
+  if (toAdd.length === 0) return;
+
+  const trimmedContent = existingContent.trimEnd();
+  const content = (trimmedContent ? trimmedContent + '\n' : '') + toAdd.join('\n') + '\n';
+  // Stryker disable next-line StringLiteral -- encoding sentinel "" is not a meaningful substitution; Node behaviour with invalid encoding is environment-specific
+  await writeFile(gitattributesPath, content, 'utf-8');
+}

--- a/test/units/edgeCases.test.ts
+++ b/test/units/edgeCases.test.ts
@@ -305,5 +305,28 @@ describe('Edge case coverage tests', () => {
       expect(forceignoreContent).toContain('**/labels/*.xml');
       expect(forceignoreContent).toContain('!**/labels/CustomLabels.labels-meta.xml');
     });
+
+    it('writes .gitattributes and logs update message when updateGitattributes is true', async () => {
+      const logMock = vi.fn();
+
+      await decomposeMetadataTypes({
+        metadataTypes: ['labels'],
+        prepurge: true,
+        postpurge: false,
+        format: 'xml',
+        strategy: 'unique-id',
+        decomposeNestedPerms: false,
+        ignoreDirs: undefined,
+        updateGitattributes: true,
+        log: logMock,
+      });
+
+      const output = logMock.mock.calls.flat().join('\n');
+      expect(output).toContain('All metadata files have been decomposed for the metadata type: labels');
+      expect(output).toContain('Updated .gitattributes with root metadata file patterns.');
+
+      const gitattributesContent = await readFile(join(tempProjectDir, '.gitattributes'), 'utf-8');
+      expect(gitattributesContent).toContain('**/labels/CustomLabels.labels-meta.xml -diff linguist-generated=true');
+    });
   });
 });

--- a/test/units/updateGitattributes.test.ts
+++ b/test/units/updateGitattributes.test.ts
@@ -1,0 +1,135 @@
+'use strict';
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type ProcessedMeta } from '../../src/service/core/updateForceignore.js';
+import { updateGitattributesFile } from '../../src/service/core/updateGitattributes.js';
+
+describe('updateGitattributesFile', () => {
+  let repoRoot: string;
+
+  beforeEach(async () => {
+    repoRoot = await mkdtemp(join(tmpdir(), 'gitattributes-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+  });
+
+  async function readGitattributes(): Promise<string> {
+    return readFile(join(repoRoot, '.gitattributes'), 'utf-8');
+  }
+
+  async function writeGitattributes(content: string): Promise<void> {
+    await writeFile(join(repoRoot, '.gitattributes'), content, 'utf-8');
+  }
+
+  it('creates .gitattributes with root file pattern for a standard type', async () => {
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines).toContain('**/flows/*.flow-meta.xml -diff linguist-generated=true');
+    expect(content.endsWith('\n')).toBe(true);
+  });
+
+  it('adds single root file pattern for labels', async () => {
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'labels', metaSuffix: 'labels', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines).toContain('**/labels/CustomLabels.labels-meta.xml -diff linguist-generated=true');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('adds two root file patterns for bot', async () => {
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'bots', metaSuffix: 'bot', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines).toContain('**/bots/*/*.bot-meta.xml -diff linguist-generated=true');
+    expect(lines).toContain('**/bots/*/*.botVersion-meta.xml -diff linguist-generated=true');
+  });
+
+  it('ignores format field — root patterns always use -meta.xml', async () => {
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'yaml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines).toContain('**/flows/*.flow-meta.xml -diff linguist-generated=true');
+    expect(lines).not.toContain('**/flows/*.flow-meta.yaml -diff linguist-generated=true');
+  });
+
+  it('appends new entries to existing .gitattributes', async () => {
+    await writeGitattributes('# existing\n*.json text\n');
+
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    expect(content).toContain('# existing');
+    expect(content).toContain('*.json text');
+    expect(content).toContain('**/flows/*.flow-meta.xml -diff linguist-generated=true');
+  });
+
+  it('preserves existing content with no blank line between', async () => {
+    await writeGitattributes('# sf-decomposer\n*.json text\n');
+
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    expect(content).toBe('# sf-decomposer\n*.json text\n**/flows/*.flow-meta.xml -diff linguist-generated=true\n');
+  });
+
+  it('deduplicates patterns already present in .gitattributes', async () => {
+    await writeGitattributes('**/flows/*.flow-meta.xml -diff linguist-generated=true\n');
+
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const occurrences = content.split('**/flows/*.flow-meta.xml -diff linguist-generated=true').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('deduplicates entries with surrounding whitespace', async () => {
+    await writeGitattributes('  **/flows/*.flow-meta.xml -diff linguist-generated=true  \n');
+
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const occurrences = content.split('**/flows/*.flow-meta.xml -diff linguist-generated=true').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('does not write file when all patterns are already present', async () => {
+    const existingContent = '**/flows/*.flow-meta.xml -diff linguist-generated=true\n';
+    await writeGitattributes(existingContent);
+
+    const processedMeta: ProcessedMeta[] = [{ directoryName: 'flows', metaSuffix: 'flow', format: 'xml' }];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    expect(await readGitattributes()).toBe(existingContent);
+  });
+
+  it('handles multiple metadata types in a single call', async () => {
+    const processedMeta: ProcessedMeta[] = [
+      { directoryName: 'flows', metaSuffix: 'flow', format: 'xml' },
+      { directoryName: 'permissionsets', metaSuffix: 'permissionset', format: 'xml' },
+    ];
+    await updateGitattributesFile(processedMeta, repoRoot);
+
+    const content = await readGitattributes();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines).toContain('**/flows/*.flow-meta.xml -diff linguist-generated=true');
+    expect(lines).toContain('**/permissionsets/*.permissionset-meta.xml -diff linguist-generated=true');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--update-gitattributes` flag to `sf decomposer decompose` — mirrors `--update-forceignore` but targets `.gitattributes`
- Appends `-diff linguist-generated=true` patterns for root metadata files after decomposition, suppressing diff noise while keeping files tracked in git for tools like sfdx-git-delta
- Handles special cases for `labels` (single `CustomLabels` entry) and `bot` (two patterns for `.bot-meta.xml` and `.botVersion-meta.xml`)
- Also exposed as `updateGitattributes` in `.sfdecomposer.config.json` for hook-triggered decomposition via `scopedPostRetrieve`
- 10 unit tests in `test/units/updateGitattributes.test.ts` + branch coverage test in `edgeCases.test.ts`
- README updated: sgd compatibility section now leads with the flag instead of manual pattern examples

## Test plan

- [ ] `npm run build` passes
- [ ] `npx vitest run test/units/updateGitattributes.test.ts` — 10 tests pass
- [ ] `npx vitest run test/units/edgeCases.test.ts` — all tests pass including new `updateGitattributes` branch coverage test
- [ ] Run `sf decomposer decompose -m "flow" --update-gitattributes` in a project and verify `.gitattributes` is created with `**/flows/*.flow-meta.xml -diff linguist-generated=true`
- [ ] Verify subsequent runs deduplicate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)