### PR TITLE
perf: index override lookups instead of linear-scanning per file

### DIFF
--- a/src/helpers/configOverrides.ts
+++ b/src/helpers/configOverrides.ts
@@ -520,6 +520,42 @@ export function parseComponentKey(key: string): { metadataType: string; fullName
   return { metadataType, fullName };
 }
 
+type OverrideIndex = {
+  byType: Map<string, DecomposerOverride>;
+  byComponent: Map<string, DecomposerOverride>;
+  typesWithComponentOverrides: Set<string>;
+};
+
+// Keyed by the overrides array's own identity: a decompose/verify run passes the same array
+// through repeatedly (once per file/component being resolved), so building the lookup indices
+// once per run instead of re-scanning the array on every call keeps override resolution O(1)
+// per file instead of O(files * overrides).
+const overrideIndexCache = new WeakMap<DecomposerOverride[], OverrideIndex>();
+
+function getOverrideIndex(overrides: DecomposerOverride[]): OverrideIndex {
+  const cached = overrideIndexCache.get(overrides);
+  if (cached) return cached;
+
+  const byType = new Map<string, DecomposerOverride>();
+  const byComponent = new Map<string, DecomposerOverride>();
+  const typesWithComponentOverrides = new Set<string>();
+
+  for (const override of overrides) {
+    for (const metadataType of override.metadataTypes ?? []) {
+      if (!byType.has(metadataType)) byType.set(metadataType, override);
+    }
+    for (const component of override.components ?? []) {
+      if (!byComponent.has(component)) byComponent.set(component, override);
+      const colonIdx = component.indexOf(':');
+      if (colonIdx > 0) typesWithComponentOverrides.add(component.slice(0, colonIdx));
+    }
+  }
+
+  const index: OverrideIndex = { byType, byComponent, typesWithComponentOverrides };
+  overrideIndexCache.set(overrides, index);
+  return index;
+}
+
 /**
  * Find the override (if any) that targets a specific metadata suffix.
  */
@@ -529,7 +565,7 @@ export function getOverrideForType(
 ): DecomposerOverride | undefined {
   // Stryker disable next-line ConditionalExpression
   if (!overrides || overrides.length === 0) return undefined;
-  return overrides.find((override) => override.metadataTypes?.includes(metadataType));
+  return getOverrideIndex(overrides).byType.get(metadataType);
 }
 
 /**
@@ -543,8 +579,7 @@ export function getOverrideForComponent(
 ): DecomposerOverride | undefined {
   // Stryker disable next-line ConditionalExpression
   if (!overrides || overrides.length === 0) return undefined;
-  const key = `${metadataType}:${fullName}`;
-  return overrides.find((override) => override.components?.includes(key));
+  return getOverrideIndex(overrides).byComponent.get(`${metadataType}:${fullName}`);
 }
 
 /**
@@ -554,8 +589,7 @@ export function getOverrideForComponent(
 export function hasComponentOverridesForType(metadataType: string, overrides?: DecomposerOverride[]): boolean {
   // Stryker disable next-line ConditionalExpression
   if (!overrides || overrides.length === 0) return false;
-  const prefix = `${metadataType}:`;
-  return overrides.some((override) => override.components?.some((component) => component.startsWith(prefix)));
+  return getOverrideIndex(overrides).typesWithComponentOverrides.has(metadataType);
 }
 
 /**

--- a/test/units/configOverrides.test.ts
+++ b/test/units/configOverrides.test.ts
@@ -565,6 +565,16 @@ describe('configOverrides helper', () => {
       const componentsOnly: DecomposerOverride[] = [{ components: ['flow:My_Flow'], decomposedFormat: 'yaml' }];
       expect(getOverrideForType('flow', componentsOnly)).toBeUndefined();
     });
+
+    it('resolves the earliest override when the same type appears in more than one (index build path)', () => {
+      // `validateOverrides` normally forbids this, but the lookup itself doesn't re-validate, so
+      // this exercises the index-building dedupe guard directly: first-seen override must win.
+      const duplicated: DecomposerOverride[] = [
+        { metadataTypes: ['flow'], decomposedFormat: 'yaml' },
+        { metadataTypes: ['flow'], decomposedFormat: 'json' },
+      ];
+      expect(getOverrideForType('flow', duplicated)).toBe(duplicated[0]);
+    });
   });
 
   describe('getOverrideForComponent', () => {
@@ -590,6 +600,16 @@ describe('configOverrides helper', () => {
     it('returns undefined for an unmatched component', () => {
       expect(getOverrideForComponent('permissionset', 'Unknown', overrides)).toBeUndefined();
       expect(getOverrideForComponent('flow', 'My_Flow', overrides)).toBeUndefined();
+    });
+
+    it('resolves the earliest override when the same component key appears in more than one (index build path)', () => {
+      // `validateOverrides` normally forbids this, but the lookup itself doesn't re-validate, so
+      // this exercises the index-building dedupe guard directly: first-seen override must win.
+      const duplicated: DecomposerOverride[] = [
+        { components: ['permissionset:HR_Admin'], strategy: 'grouped-by-tag' },
+        { components: ['permissionset:HR_Admin'], strategy: 'unique-id' },
+      ];
+      expect(getOverrideForComponent('permissionset', 'HR_Admin', duplicated)).toBe(duplicated[0]);
     });
   });
 
@@ -617,6 +637,14 @@ describe('configOverrides helper', () => {
       // `permission` is a prefix of `permissionset` but must not match.
       const sneaky: DecomposerOverride[] = [{ components: ['permissionset:HR_Admin'] }];
       expect(hasComponentOverridesForType('permission', sneaky)).toBe(false);
+    });
+
+    it('does not crash on a malformed component key with no colon (index build path)', () => {
+      // `validateOverrides` normally rejects a colon-less component key before this is ever
+      // reached, but the lookup itself doesn't re-validate, so this exercises the index's
+      // colon-index guard directly rather than relying on that upstream validation.
+      const malformed: DecomposerOverride[] = [{ components: ['no-colon-here'] }];
+      expect(hasComponentOverridesForType('permissionset', malformed)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- `getOverrideForType`/`getOverrideForComponent`/`hasComponentOverridesForType` re-scanned the `overrides` array (and each override's `components` array) on every file/component resolved during decompose — O(files × overrides).
- Builds a `Map`/`Set` index once per `overrides` array (cached by array identity in a `WeakMap`), so repeated lookups within a run are O(1) after a one-time O(overrides) build.
- No behavior change: first-match-wins semantics preserved (matches prior `.find()`/`.some()` ordering).

## Test plan
- [x] `npx vitest run --coverage` — 487 tests pass, 100% statement/branch/function/line coverage
- [x] `npm test` (compile + tests + lint) — clean