### PR TITLE
perf: update config-disassembler to 3.0.0 and await its now-async calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "8.31.4",
         "@salesforce/sf-plugins-core": "12.2.25",
         "@salesforce/source-deploy-retrieve": "12.37.0",
-        "config-disassembler": "2.9.0"
+        "config-disassembler": "3.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.1",
@@ -6220,29 +6220,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-2.9.0.tgz",
-      "integrity": "sha512-xUsgtY/BKy52fBW1aphuS/gAEPf+e+HoWWi6Afqv7TT7+HlnwUhrHOnJtkEJUK/Pk2O/g4DI6XWoSP+ive0FHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.0.0.tgz",
+      "integrity": "sha512-uvgh9mAGsj679Rtv+MSxMX6V/rFBRTeexfr+W1QafgctsCiofjoKJAlWaXRYCY4cfWIRGjb/Sh8WPTxp66uIiQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "2.9.0",
-        "config-disassembler-darwin-x64": "2.9.0",
-        "config-disassembler-linux-arm64-gnu": "2.9.0",
-        "config-disassembler-linux-arm64-musl": "2.9.0",
-        "config-disassembler-linux-x64-gnu": "2.9.0",
-        "config-disassembler-linux-x64-musl": "2.9.0",
-        "config-disassembler-win32-arm64-msvc": "2.9.0",
-        "config-disassembler-win32-ia32-msvc": "2.9.0",
-        "config-disassembler-win32-x64-msvc": "2.9.0"
+        "config-disassembler-darwin-arm64": "3.0.0",
+        "config-disassembler-darwin-x64": "3.0.0",
+        "config-disassembler-linux-arm64-gnu": "3.0.0",
+        "config-disassembler-linux-arm64-musl": "3.0.0",
+        "config-disassembler-linux-x64-gnu": "3.0.0",
+        "config-disassembler-linux-x64-musl": "3.0.0",
+        "config-disassembler-win32-arm64-msvc": "3.0.0",
+        "config-disassembler-win32-ia32-msvc": "3.0.0",
+        "config-disassembler-win32-x64-msvc": "3.0.0"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-2.9.0.tgz",
-      "integrity": "sha512-1yMDeVKp8IVrfvYBvjpyStT4OVu7dVXB/gl75ppgn5ZWIfPPdn40/OEU7QgARsd6jTuC/Iz3PWJODxYVSnQfPw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.0.0.tgz",
+      "integrity": "sha512-iHQEmwXQ4dFe+hkl+aQWGq4Nl1Uyb42HLNJ5xogQ/JEjLjSPktJmW74wmlRwqHfSV4U+IhJjEZxa3SB+ZCXEEg==",
       "cpu": [
         "arm64"
       ],
@@ -6256,9 +6256,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-2.9.0.tgz",
-      "integrity": "sha512-Aw5CYPBaxCzrSofLxMrbfoE+mb4eeC0bDuI0LygS0RCCvLPkR9wi62lXtXJEy5duyaoBwm8FYbjIeX5HnN71Yw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.0.0.tgz",
+      "integrity": "sha512-WKJ9q00Hn3XCMzDcdfM+RExo70EYiF1DocHd3+Ff5IIapThcuegUsEUhCG9ygYFd2FjgcZmwdEfTPOkqKqGpnA==",
       "cpu": [
         "x64"
       ],
@@ -6272,9 +6272,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-2.9.0.tgz",
-      "integrity": "sha512-/UeAJLw8V8rvOk1gwx2B0URZpynVkd7AWrmVQTlyo93uraRg6bE+Nrhxe7mcURNL6UvUAitcp95I3JUtF9JBaA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.0.0.tgz",
+      "integrity": "sha512-IRZHKRzGMpoL8MzHr//xfuDUPZyeBeW6eezBu7QL8dJxYDyVJGxb+lbzq0WQRLwXU/BGXzrJjbiWJdnweCZWkA==",
       "cpu": [
         "arm64"
       ],
@@ -6291,9 +6291,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-2.9.0.tgz",
-      "integrity": "sha512-dgcA0ckUr8zS8H1pp2aDI19xO9iT/70EmwtmcZbiuHJezaX21s06T78lVLWSFWDrO7YM0x9pZNUi0VRHWsHOUA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.0.0.tgz",
+      "integrity": "sha512-mAY8Vvv2mvIczGMB386p+QiZJQY/LTmrFSdDIA4bMeMcI2JHgZgc6mEgfjHGE525JVpieYfqYK1cLVX9iAhX6w==",
       "cpu": [
         "arm64"
       ],
@@ -6310,9 +6310,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-2.9.0.tgz",
-      "integrity": "sha512-wDzjaZ3Qujsf1iMQUqotDLC9dSRNdqs3WcqItSQ9mI6DwNVfqeZarkzXH/XIacw1DypKQ9/bC+oDdqejEA8epA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.0.0.tgz",
+      "integrity": "sha512-kQ7y3KC5IhavWjy86KBMo8sz05bl/ZGMIXIua8gIMbOzuYPa1TMH1XDQ3iAZEeA7gL8sYQPlHpQk1Jj2+jlNfA==",
       "cpu": [
         "x64"
       ],
@@ -6329,9 +6329,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-2.9.0.tgz",
-      "integrity": "sha512-pJxF4/+ad5GFTajLGnQ4TaalWNZxeTYhzo5BaB0DPyzpsaBhm0cHRGu7awD51g7Gdd9gVrJloqXuE/3L/dWt0A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.0.0.tgz",
+      "integrity": "sha512-/ICfNXWnSt2ceyP9T/isPFngYJCZgLNzMTPpbdSqsQ4YB4er6Yt5Om936LA8FCItYcYc15QqH7XJ757ce2q7lQ==",
       "cpu": [
         "x64"
       ],
@@ -6348,9 +6348,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-2.9.0.tgz",
-      "integrity": "sha512-ZCMOjBGxwimrGJp+E97u51dPrDivSbiFIMLFho6RWWOkz96oozAScafRYr3Sh6S9wzcPYdGMsuDVIoGB4nYmXQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.0.0.tgz",
+      "integrity": "sha512-tMPpCJFUjaB5MzWcABJDLEg6YHYAHDW+YrGx6LjuiHBWESwqxJpnm2hXSfhe+B+NorgVzVl+x/dYzU7+AkxZ/w==",
       "cpu": [
         "arm64"
       ],
@@ -6364,9 +6364,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-2.9.0.tgz",
-      "integrity": "sha512-RHdO0/7ZRmG9WH11UNqBBuMAFqLFG8h2d6aBEEdPzSX2Q/wUVsfgNpBiZgWyxTihAn28C+c6sbQak/kOol+Z4g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.0.0.tgz",
+      "integrity": "sha512-1ahlCiTq0SlXk13rw+pHr/3dQMxPTuzi1+8boHFm7+lSZ1maI7wGhBDRhMyTHnpjW8aErRhEkaBtZ85yaig43w==",
       "cpu": [
         "ia32"
       ],
@@ -6380,9 +6380,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-2.9.0.tgz",
-      "integrity": "sha512-r9f79UpHtKbmfAp19yvQhfVCVa0Bz5gcKyTyrcQ0/N1PSMNbxPmwpalfQATGw6oR44zlXrNSAJ4arMQs8YduaQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.0.0.tgz",
+      "integrity": "sha512-pa0t0oOHMHSZ+4XY1SAsWJg/5B1XVQgb9VgC7zuQvOkrjRG4LdrhhCvqpexKYtbc7sBPiCHm+Jm7NVNCofpWJA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "8.31.4",
     "@salesforce/sf-plugins-core": "12.2.25",
     "@salesforce/source-deploy-retrieve": "12.37.0",
-    "config-disassembler": "2.9.0"
+    "config-disassembler": "3.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.1",

--- a/src/service/decompose/decomposeFileHandler.ts
+++ b/src/service/decompose/decomposeFileHandler.ts
@@ -58,7 +58,7 @@ export async function decomposeFileHandler(
         const absoluteLabelFilePath = resolve(metadataPath, CUSTOM_LABELS_FILE);
         const relativeLabelFilePath = relative(process.cwd(), absoluteLabelFilePath);
 
-        disassembleHandler(
+        await disassembleHandler(
           relativeLabelFilePath,
           uniqueIdElements,
           { ...typeResolved, prepurge: false },
@@ -69,7 +69,7 @@ export async function decomposeFileHandler(
       } else if (hasComponentOverridesForType(metaSuffix, overrides)) {
         await perFileHandler(metadataPath, uniqueIdElements, typeResolved, ignorePath, metaSuffix, overrides);
       } else {
-        disassembleHandler(metadataPath, uniqueIdElements, typeResolved, ignorePath, metaSuffix);
+        await disassembleHandler(metadataPath, uniqueIdElements, typeResolved, ignorePath, metaSuffix);
       }
       if (metaSuffix === 'workflow') {
         await renameWorkflows(metadataPath);
@@ -101,7 +101,7 @@ async function decomposeFromManifest(
         if (typeResolved.prepurge) await prePurgeLabels(labelDir);
         const absoluteLabelFilePath = resolve(labelDir, CUSTOM_LABELS_FILE);
         const relativeLabelFilePath = relative(process.cwd(), absoluteLabelFilePath);
-        disassembleHandler(
+        await disassembleHandler(
           relativeLabelFilePath,
           uniqueIdElements,
           { ...typeResolved, prepurge: false },
@@ -150,17 +150,17 @@ async function decomposeFromManifest(
   }
 }
 
-function disassembleHandler(
+async function disassembleHandler(
   filePath: string,
   uniqueIdElements: string,
   options: ResolvedDecomposeTypeOptions,
   ignorePath: string,
   metaSuffix: string,
-): void {
+): Promise<void> {
   const handler: DisassembleXMLFileHandler = new DisassembleXMLFileHandler();
   const { strategy, multiLevel, splitTags, sidecarElements } = resolveEffectiveDisassembleOptions(metaSuffix, options);
 
-  handler.disassemble({
+  await handler.disassemble({
     filePath,
     uniqueIdElements,
     prePurge: options.prepurge,

--- a/src/service/recompose/reassembleLabels.ts
+++ b/src/service/recompose/reassembleLabels.ts
@@ -15,7 +15,7 @@ export async function reassembleLabels(metadataPath: string, metaSuffix: string,
   await moveFiles(sourceDirectory, destinationDirectory, (fileName) => fileName !== CUSTOM_LABELS_FILE);
 
   // do not use postpurge flag due to file moving
-  reassembleHandler(join(metadataPath, 'CustomLabels'), `${metaSuffix}-meta.xml`, false);
+  await reassembleHandler(join(metadataPath, 'CustomLabels'), `${metaSuffix}-meta.xml`, false);
 
   sourceDirectory = join(metadataPath, 'CustomLabels', 'labels');
   destinationDirectory = metadataPath;

--- a/src/service/recompose/recomposeFileHandler.ts
+++ b/src/service/recompose/recomposeFileHandler.ts
@@ -91,7 +91,7 @@ async function recomposeFromManifest(
       const decomposedDir = decomposedDirForXml(xmlPath, metaSuffix);
       // Skip files that were never decomposed (e.g. metadata consisting only of leaf elements).
       if (!(await directoryExists(decomposedDir))) return;
-      reassembleHandler(decomposedDir, `${metaSuffix}-meta.xml`, postpurge);
+      await reassembleHandler(decomposedDir, `${metaSuffix}-meta.xml`, postpurge);
     }),
   );
   await Promise.all(tasks);
@@ -115,9 +115,9 @@ async function directoryExists(path: string): Promise<boolean> {
   }
 }
 
-export function reassembleHandler(filePath: string, fileExtension: string, postPurge: boolean): void {
+export async function reassembleHandler(filePath: string, fileExtension: string, postPurge: boolean): Promise<void> {
   const handler: ReassembleXMLFileHandler = new ReassembleXMLFileHandler();
-  handler.reassemble({
+  await handler.reassemble({
     filePath,
     fileExtension,
     postPurge,
@@ -153,7 +153,7 @@ async function reassembleDirectories(
           // recursively call this function and set recurse to false
           await reassembleDirectories(subdirectory, metaSuffix, false, postpurge);
         } else {
-          reassembleHandler(subdirectory, `${metaSuffix}-meta.xml`, postpurge);
+          await reassembleHandler(subdirectory, `${metaSuffix}-meta.xml`, postpurge);
         }
       }),
     );


### PR DESCRIPTION
## Summary
- Bumps `config-disassembler` 2.9.0 → 3.0.0. v3.0.0 makes `disassemble`/`reassemble`/`parseXml`/`verifyXmlRoundtrip` genuine async napi bindings instead of `block_on`-ing the JS main thread per call (mcarvin8/config-disassembler-node#47), so concurrent calls can actually run in parallel instead of serializing on the event loop no matter what concurrency limit was applied JS-side.
- Adds `await` at every `disassemble()`/`reassemble()` call site that was previously fire-and-forget (relying on the old synchronous behavior), so file processing is actually waited on before the caller continues.
- Purely internal — CLI flags, options, and output are unchanged. Not a breaking release for sf-decomposer end users.

## Test plan
- [x] `npx vitest run --coverage` — 487 tests pass (including real, non-mocked end-to-end command tests against the v3.0.0 native module), 100% coverage
- [x] `npm test` (compile + tests + lint) — clean