### PR TITLE
perf: bump config-disassembler to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@salesforce/core": "8.31.4",
         "@salesforce/sf-plugins-core": "12.2.25",
         "@salesforce/source-deploy-retrieve": "12.37.0",
-        "config-disassembler": "3.0.0"
+        "config-disassembler": "3.0.2"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.1",
@@ -6220,29 +6220,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.0.0.tgz",
-      "integrity": "sha512-uvgh9mAGsj679Rtv+MSxMX6V/rFBRTeexfr+W1QafgctsCiofjoKJAlWaXRYCY4cfWIRGjb/Sh8WPTxp66uIiQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.0.2.tgz",
+      "integrity": "sha512-ylfVPUY9eVPF7YPl40rFFByWU9WWERBmEo3nVS/zD84AeHZEowHH9cxBraS3LETieCJGSZQJeCEXQmax909rmw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.0.0",
-        "config-disassembler-darwin-x64": "3.0.0",
-        "config-disassembler-linux-arm64-gnu": "3.0.0",
-        "config-disassembler-linux-arm64-musl": "3.0.0",
-        "config-disassembler-linux-x64-gnu": "3.0.0",
-        "config-disassembler-linux-x64-musl": "3.0.0",
-        "config-disassembler-win32-arm64-msvc": "3.0.0",
-        "config-disassembler-win32-ia32-msvc": "3.0.0",
-        "config-disassembler-win32-x64-msvc": "3.0.0"
+        "config-disassembler-darwin-arm64": "3.0.2",
+        "config-disassembler-darwin-x64": "3.0.2",
+        "config-disassembler-linux-arm64-gnu": "3.0.2",
+        "config-disassembler-linux-arm64-musl": "3.0.2",
+        "config-disassembler-linux-x64-gnu": "3.0.2",
+        "config-disassembler-linux-x64-musl": "3.0.2",
+        "config-disassembler-win32-arm64-msvc": "3.0.2",
+        "config-disassembler-win32-ia32-msvc": "3.0.2",
+        "config-disassembler-win32-x64-msvc": "3.0.2"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.0.0.tgz",
-      "integrity": "sha512-iHQEmwXQ4dFe+hkl+aQWGq4Nl1Uyb42HLNJ5xogQ/JEjLjSPktJmW74wmlRwqHfSV4U+IhJjEZxa3SB+ZCXEEg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.0.2.tgz",
+      "integrity": "sha512-7NpfzwFRR3G4/mzj0YF12wxpUhwXRtTIruZyXV6QbBdncLaWlNeRVNeSe+yY6374AC5Gz92k5tqUezjX0gAYYg==",
       "cpu": [
         "arm64"
       ],
@@ -6256,9 +6256,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.0.0.tgz",
-      "integrity": "sha512-WKJ9q00Hn3XCMzDcdfM+RExo70EYiF1DocHd3+Ff5IIapThcuegUsEUhCG9ygYFd2FjgcZmwdEfTPOkqKqGpnA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.0.2.tgz",
+      "integrity": "sha512-p1flfEuc4eQNZGaTSWp5pFwWh6U25otCiU9R8sygshrGXukqUEg7p7qdx4YmYpNuG3ESw6P4YPkKDPat0HYZ7g==",
       "cpu": [
         "x64"
       ],
@@ -6272,9 +6272,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.0.0.tgz",
-      "integrity": "sha512-IRZHKRzGMpoL8MzHr//xfuDUPZyeBeW6eezBu7QL8dJxYDyVJGxb+lbzq0WQRLwXU/BGXzrJjbiWJdnweCZWkA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.0.2.tgz",
+      "integrity": "sha512-J/u1pzlNhPUt0kFrk6CY89aLLSRJWHYA6EC0pKqL3GtEiBMjJwyUw4Po7FQBZnERoMXsZqLbNsxWI4O9rufefQ==",
       "cpu": [
         "arm64"
       ],
@@ -6291,9 +6291,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.0.0.tgz",
-      "integrity": "sha512-mAY8Vvv2mvIczGMB386p+QiZJQY/LTmrFSdDIA4bMeMcI2JHgZgc6mEgfjHGE525JVpieYfqYK1cLVX9iAhX6w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.0.2.tgz",
+      "integrity": "sha512-WeA7/mYf58D+CP365ID7T8NdNdZETSszqM5Vkdx7/vDaAUw47qHdtAdXqmzg9rcZAIgzMoGAOJ+0h43dD0hDMw==",
       "cpu": [
         "arm64"
       ],
@@ -6310,9 +6310,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.0.0.tgz",
-      "integrity": "sha512-kQ7y3KC5IhavWjy86KBMo8sz05bl/ZGMIXIua8gIMbOzuYPa1TMH1XDQ3iAZEeA7gL8sYQPlHpQk1Jj2+jlNfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.0.2.tgz",
+      "integrity": "sha512-ZVm57g7Z6ETm5hqHbKHnhoYDwJ1NE9z/Ma35BI30a9Zn7Dfy24jfh6l7PorlB+Y7r8pCTQy4cPMNa7J0heQpnQ==",
       "cpu": [
         "x64"
       ],
@@ -6329,9 +6329,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.0.0.tgz",
-      "integrity": "sha512-/ICfNXWnSt2ceyP9T/isPFngYJCZgLNzMTPpbdSqsQ4YB4er6Yt5Om936LA8FCItYcYc15QqH7XJ757ce2q7lQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.0.2.tgz",
+      "integrity": "sha512-KbA2KOzbkoN+5EgVZxvgR2ZSGR1NfHpK2ijGJyXA5dUVjR7hWgTgvND8ODoxMRhkdpMsW9k1HTatzNBS5aBRUg==",
       "cpu": [
         "x64"
       ],
@@ -6348,9 +6348,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.0.0.tgz",
-      "integrity": "sha512-tMPpCJFUjaB5MzWcABJDLEg6YHYAHDW+YrGx6LjuiHBWESwqxJpnm2hXSfhe+B+NorgVzVl+x/dYzU7+AkxZ/w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.0.2.tgz",
+      "integrity": "sha512-uPuJf3JYUjKhaqbsZ1AEXcZkLzrDqHsetl3zbYejpu/e1Ut67cM2fMeaNzU/fj2gXuyrTdXR01PGkn+3/BVj1g==",
       "cpu": [
         "arm64"
       ],
@@ -6364,9 +6364,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.0.0.tgz",
-      "integrity": "sha512-1ahlCiTq0SlXk13rw+pHr/3dQMxPTuzi1+8boHFm7+lSZ1maI7wGhBDRhMyTHnpjW8aErRhEkaBtZ85yaig43w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.0.2.tgz",
+      "integrity": "sha512-89J0gFBHi8E3qtSlgNtX2gBOtOn+l6UO6RaGbb9BbI52KiLwnV5lR5tzb6KXqaZdcBUj/p1i6btfhTku65OB6Q==",
       "cpu": [
         "ia32"
       ],
@@ -6380,9 +6380,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.0.0.tgz",
-      "integrity": "sha512-pa0t0oOHMHSZ+4XY1SAsWJg/5B1XVQgb9VgC7zuQvOkrjRG4LdrhhCvqpexKYtbc7sBPiCHm+Jm7NVNCofpWJA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.0.2.tgz",
+      "integrity": "sha512-N7SIkjqt2H0ejqyulc7PQ3tN/UghsgwYitCMQRGwBZNll6uIRHSYz2Wi1GTdblFKPmteuu6q+AgzlBtzbuH79g==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@salesforce/core": "8.31.4",
     "@salesforce/sf-plugins-core": "12.2.25",
     "@salesforce/source-deploy-retrieve": "12.37.0",
-    "config-disassembler": "3.0.0"
+    "config-disassembler": "3.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.1",


### PR DESCRIPTION
## Summary
- Bumps `config-disassembler` 3.0.0 → 3.0.2, picking up the core rust crate's directory-mode concurrency work (mcarvin8/config-disassembler#97, #99; wired through mcarvin8/config-disassembler-node#49): a single bulk `disassemble()` call over a metadata type's directory now fans files out across a bounded pool of concurrent tasks instead of processing them one at a time for the common no-override case, while skipping that setup entirely for single-file directories (which get no benefit from it).
- No API change — no code changes needed here beyond the version bump.

## Test plan
- [x] `npx vitest run --coverage` — 487 tests pass, 100% coverage
- [x] `npm test` (compile + tests + lint) — clean