### PR TITLE
test(perf): add manyfiles fixture profile to exercise directory concurrency

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -31,6 +31,7 @@ on:
           - medium
           - large
           - xlarge
+          - manyfiles
       formats:
         description: 'Comma-separated formats to test (xml,json,json5,yaml)'
         type: string

--- a/scripts/gen-perf-fixtures.ts
+++ b/scripts/gen-perf-fixtures.ts
@@ -19,7 +19,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export type Profile = 'small' | 'medium' | 'large' | 'xlarge';
+export type Profile = 'small' | 'medium' | 'large' | 'xlarge' | 'manyfiles';
 
 export interface SizeSpec {
   permissionSet: {
@@ -57,7 +57,7 @@ export interface SizeSpec {
   entitlementProcess: { milestones: number };
 }
 
-const PROFILES: Record<Profile, SizeSpec> = {
+const PROFILES: Record<Exclude<Profile, 'manyfiles'>, SizeSpec> = {
   small: {
     permissionSet: {
       fieldPerms: 200,
@@ -175,6 +175,24 @@ const PROFILES: Record<Profile, SizeSpec> = {
   },
 };
 
+// `manyfiles` targets a different shape than the size-scaled profiles above:
+// instead of one enormous file per metadata type (which is what real orgs
+// almost never look like outside custom labels), it generates many small,
+// independent permission-set files in a single directory -- the shape that
+// actually exercises config-disassembler's directory-mode concurrent fan-out
+// (see config-disassembler#97/#99). Each file is modest on its own so
+// generation stays fast even at a few hundred files.
+const MANYFILES_FILE_COUNT = 300;
+const MANYFILES_PERMISSION_SET_SPEC: SizeSpec['permissionSet'] = {
+  fieldPerms: 150,
+  objectPerms: 30,
+  appVis: 10,
+  classAccesses: 30,
+  pageAccesses: 15,
+  tabSettings: 15,
+  recordTypeVis: 15,
+};
+
 // ---------------------------------------------------------------------------
 // XML helpers
 // ---------------------------------------------------------------------------
@@ -182,7 +200,7 @@ const PROFILES: Record<Profile, SizeSpec> = {
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8"?>\n';
 const NS = ' xmlns="http://soap.sforce.com/2006/04/metadata"';
 
-function escape(s: string): string {
+function escapeXml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -566,7 +584,7 @@ function genCustomLabels(spec: SizeSpec['labels']): string {
     lines.push('        <language>en_US</language>');
     lines.push('        <protected>false</protected>');
     lines.push(`        <shortDescription>Sample Label ${i}</shortDescription>`);
-    lines.push(`        <value>${escape(`Synthetic label ${i} value used for performance testing only.`)}</value>`);
+    lines.push(`        <value>${escapeXml(`Synthetic label ${i} value used for performance testing only.`)}</value>`);
     lines.push('    </labels>');
   }
 
@@ -851,7 +869,6 @@ export interface GenerateResult {
 
 export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   const profile: Profile = opts.profile ?? 'large';
-  const spec = PROFILES[profile];
   const outDir = resolve(opts.outDir);
 
   if (opts.cleanFirst) {
@@ -863,6 +880,25 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   const base = 'force-app/main/default';
 
   await writeFile(join(outDir, 'sfdx-project.json'), JSON.stringify(SFDX_PROJECT_JSON, null, 2) + '\n', 'utf8');
+
+  if (profile === 'manyfiles') {
+    for (let i = 1; i <= MANYFILES_FILE_COUNT; i++) {
+      const content = genPermissionSet(MANYFILES_PERMISSION_SET_SPEC).replace(
+        '<label>Mega Permission Set</label>',
+        `<label>Sample Permission Set ${pad(i, 4)}</label>`,
+      );
+      await writeOut(
+        outDir,
+        `${base}/permissionsets/Sample_PermSet_${pad(i, 4)}.permissionset-meta.xml`,
+        content,
+        files,
+      );
+    }
+    const totalBytes = files.reduce((s, f) => s + f.bytes, 0);
+    return { outDir, profile, files, totalBytes };
+  }
+
+  const spec = PROFILES[profile];
 
   await writeOut(
     outDir,
@@ -907,6 +943,8 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
 // CLI
 // ---------------------------------------------------------------------------
 
+const ALL_PROFILES: Profile[] = [...Object.keys(PROFILES), 'manyfiles'] as Profile[];
+
 function parseArgs(argv: string[]): { profile: Profile; outDir: string; clean: boolean } {
   let profile: Profile = 'large';
   let outDir = 'perf-fixtures';
@@ -915,8 +953,8 @@ function parseArgs(argv: string[]): { profile: Profile; outDir: string; clean: b
     const arg = argv[i];
     if (arg === '--profile' && argv[i + 1]) {
       const next = argv[++i] as Profile;
-      if (!(next in PROFILES))
-        throw new Error(`Unknown profile: ${next}. Use one of: ${Object.keys(PROFILES).join(', ')}.`);
+      if (!ALL_PROFILES.includes(next))
+        throw new Error(`Unknown profile: ${next}. Use one of: ${ALL_PROFILES.join(', ')}.`);
       profile = next;
     } else if (arg === '--out' && argv[i + 1]) {
       outDir = argv[++i] as string;
@@ -928,7 +966,7 @@ function parseArgs(argv: string[]): { profile: Profile; outDir: string; clean: b
           'gen-perf-fixtures.ts',
           '',
           'Options:',
-          '  --profile <small|medium|large|xlarge>   Default: large',
+          '  --profile <small|medium|large|xlarge|manyfiles>   Default: large',
           '  --out <dir>                             Default: perf-fixtures',
           '  --no-clean                              Do not wipe out dir first',
           '',

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -45,22 +45,28 @@ function envString<T extends string>(name: string, fallback: T): T {
 
 const PROFILE = envString<Profile>('PERF_PROFILE', 'large');
 const FORMATS = envList('PERF_FORMATS', ['xml', 'json', 'json5', 'yaml']);
-const DEFAULT_METADATA_TYPES = [
-  'permissionset',
-  'mutingpermissionset',
-  'profile',
-  'flow',
-  'workflow',
-  'labels',
-  'bot',
-  'app',
-  'globalValueSet',
-  // entitlementProcess intentionally exercises path-segment sanitization: the
-  // generator plants `/` and `:` in milestoneName values so a regression of
-  // the config-disassembler 0.5.0 sanitization fix would shrink the
-  // recomposed file below the RETENTION_THRESHOLD guard below.
-  'entitlementProcess',
-];
+// `manyfiles` only generates permission sets (see scripts/gen-perf-fixtures.ts) --
+// many small files in one directory, to exercise config-disassembler's directory-mode
+// concurrent fan-out, rather than the single-huge-file shape the other profiles use.
+const DEFAULT_METADATA_TYPES =
+  PROFILE === 'manyfiles'
+    ? ['permissionset']
+    : [
+        'permissionset',
+        'mutingpermissionset',
+        'profile',
+        'flow',
+        'workflow',
+        'labels',
+        'bot',
+        'app',
+        'globalValueSet',
+        // entitlementProcess intentionally exercises path-segment sanitization: the
+        // generator plants `/` and `:` in milestoneName values so a regression of
+        // the config-disassembler 0.5.0 sanitization fix would shrink the
+        // recomposed file below the RETENTION_THRESHOLD guard below.
+        'entitlementProcess',
+      ];
 const METADATA_TYPES = envList('PERF_TYPES', DEFAULT_METADATA_TYPES);
 
 const FIXTURE_ROOT = resolve('perf-fixtures');


### PR DESCRIPTION
## Summary
- Every existing perf profile (small/medium/large/xlarge) generates one giant XML file per metadata type — the shape real orgs almost never have outside custom labels, and the one shape that gets zero benefit from config-disassembler's directory-mode concurrent fan-out (mcarvin8/config-disassembler#97, #99). The perf suite couldn't tell that fix apart from doing nothing.
- Adds a `manyfiles` profile: 300 small, independent permission-set files in one directory — the shape the fix actually targets.
- Wired into `decompose.perf.ts` (defaults `METADATA_TYPES` to just `permissionset` for this profile, since that's the only type this profile generates) and the `workflow_dispatch` dropdown so it can be run ad-hoc / with `publish=true` to seed its own gh-pages baseline.
- Bench names are namespaced by profile (`${profile}.${label}`, see `scripts/perf-to-benchmark.mjs`), so this starts an independent trend line alongside the existing `large`/`xlarge`/etc series — nothing already on gh-pages is touched or renamed.
- Not yet wired into the scheduled/PR/release automatic runs (those still default to `profile=large`); promoting it to run automatically is a follow-up once there's baseline history to compare against.

## Test plan
- [x] `npm run test:perf:gen -- --profile manyfiles` — generates 300 files (~48.2 KB each, ~14 MB total)
- [x] `PERF_PROFILE=manyfiles PERF_FORMATS=xml npx vitest run --config ./vitest.perf.config.ts` — passes; decompose ~7s, recompose ~10s, retention 100.00% on every file, idempotent across both passes
- [x] `npm test` (compile + tests + lint) — clean