### PR TITLE
test(perf): measure heapUsed with forced GC instead of raw RSS delta

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -163,7 +163,7 @@ jobs:
           fi
           echo "## Perf results (profile=${PERF_PROFILE:-large})" >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo '| Format | Sample | Elapsed (ms) | RSS Δ (MB) |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| Format | Sample | Elapsed (ms) | Heap Δ (MB) |' >> "$GITHUB_STEP_SUMMARY"
           echo '|---|---|---:|---:|' >> "$GITHUB_STEP_SUMMARY"
           node -e '
             const fs = require("fs"), path = require("path");
@@ -173,8 +173,8 @@ jobs:
               const r = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
               for (const s of r.samples) {
                 const ms = s.elapsedMs.toFixed(1);
-                const rss = (s.rssDeltaBytes / 1024 / 1024).toFixed(2);
-                process.stdout.write(`| ${r.format} | ${s.label} | ${ms} | ${rss} |\n`);
+                const heap = (s.heapUsedDeltaBytes / 1024 / 1024).toFixed(2);
+                process.stdout.write(`| ${r.format} | ${s.label} | ${ms} | ${heap} |\n`);
               }
             }
           ' >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/perf-to-benchmark.mjs
+++ b/scripts/perf-to-benchmark.mjs
@@ -5,7 +5,11 @@
 // Inputs:  perf-results/*.json
 // Outputs: perf-runtime.json - sample.elapsedMs in ms, one entry per
 //                              (profile, format, sample.label)
-//          perf-memory.json  - sample.rssDeltaBytes in MB, same keys
+//          perf-memory.json  - sample.heapUsedDeltaBytes in MB, same keys.
+//                              JS heap only, sampled around a forced GC on both sides
+//                              (see test/perf/utils/measure.ts) -- not whole-process RSS,
+//                              which was mostly measuring GC/allocator timing noise rather
+//                              than the operation's actual memory cost.
 //
 // One metric per (profile, format, label) tuple; if multiple reports cover
 // the same tuple (e.g. a re-run within the same job) only the most recent
@@ -44,7 +48,7 @@ for (const r of latest.values()) {
     memory.push({
       name,
       unit: 'MB',
-      value: Number((s.rssDeltaBytes / 1024 / 1024).toFixed(3)),
+      value: Number((s.heapUsedDeltaBytes / 1024 / 1024).toFixed(3)),
     });
   }
 }

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -291,7 +291,7 @@ function printSummary(
   reportFile: string,
 ): void {
   const totalElapsed = samples.reduce((s, x) => s + x.elapsedMs, 0);
-  const peakRssDelta = samples.reduce((m, x) => Math.max(m, x.rssDeltaBytes), 0);
+  const peakHeapUsedDelta = samples.reduce((m, x) => Math.max(m, x.heapUsedDeltaBytes), 0);
   const lines = [
     '',
     `[perf] format=${format.padEnd(5)} input=${formatBytes(inputBytes)} ` +
@@ -300,10 +300,13 @@ function printSummary(
   for (const s of samples) {
     lines.push(
       `[perf]   ${s.label.padEnd(28)} ${formatMs(s.elapsedMs).padStart(10)}   ` +
-        `rssΔ ${formatBytes(s.rssDeltaBytes).padStart(10)}`,
+        `heapΔ ${formatBytes(s.heapUsedDeltaBytes).padStart(10)}   ` +
+        `(rssΔ ${formatBytes(s.rssDeltaBytes).padStart(10)})`,
     );
   }
-  lines.push(`[perf]   total=${formatMs(totalElapsed)}  peak rssΔ=${formatBytes(peakRssDelta)}  report=${reportFile}`);
+  lines.push(
+    `[perf]   total=${formatMs(totalElapsed)}  peak heapΔ=${formatBytes(peakHeapUsedDelta)}  report=${reportFile}`,
+  );
 
   // Per-file retention breakdown. Sorted ascending so any file that's eaten
   // bytes shows at the top - that's where you look first when investigating

--- a/test/perf/utils/measure.ts
+++ b/test/perf/utils/measure.ts
@@ -7,30 +7,58 @@ import { performance } from 'node:perf_hooks';
 export type MeasureResult = {
   label: string;
   elapsedMs: number;
+  // Primary memory metric: JS heap only, sampled immediately after a forced GC on both
+  // sides of the measured block. RSS (below) is whole-process resident memory -- it
+  // includes native/Rust allocations across the napi boundary, tokio thread stacks, and
+  // page-cache noise, none of which is attributable to the measured operation, and
+  // without a forced GC it's mostly measuring V8's collection timing luck rather than
+  // actual memory cost. Untouched code paths were observed swinging 10-90x run to run
+  // under the old RSS-based metric; heapUsed does not have that problem.
+  heapUsedBeforeBytes: number;
+  heapUsedAfterBytes: number;
+  heapUsedDeltaBytes: number;
+  // Diagnostic only, not fed to the benchmark dashboard (see scripts/perf-to-benchmark.mjs).
+  // Kept for local investigation; expect it to be noisier than heapUsedDeltaBytes.
   rssBeforeBytes: number;
   rssAfterBytes: number;
   rssDeltaBytes: number;
-  heapUsedBeforeBytes: number;
-  heapUsedAfterBytes: number;
 };
 
-/** Run an async block, capturing wall time and process memory deltas. */
+/**
+ * Run an async block, capturing wall time and a memory delta for it.
+ *
+ * Requires `global.gc` (run with `--expose-gc`; wired via vitest.perf.config.ts's fork
+ * pool `execArgv`). Forcing a collection immediately before and after the block means
+ * `heapUsed` reflects what the block actually retained, not whatever V8 hadn't gotten
+ * around to collecting yet.
+ */
 export async function measure<T>(label: string, fn: () => Promise<T>): Promise<{ result: T; sample: MeasureResult }> {
+  if (typeof global.gc !== 'function') {
+    throw new Error(
+      'global.gc is not available. Run the perf suite with --expose-gc ' +
+        '(vitest.perf.config.ts already sets this via poolOptions.forks.execArgv; ' +
+        'if you see this, you are likely invoking vitest/node directly without that config).',
+    );
+  }
+
+  global.gc();
   const memBefore = process.memoryUsage();
   const start = performance.now();
   const result = await fn();
   const elapsedMs = performance.now() - start;
+  global.gc();
   const memAfter = process.memoryUsage();
   return {
     result,
     sample: {
       label,
       elapsedMs,
+      heapUsedBeforeBytes: memBefore.heapUsed,
+      heapUsedAfterBytes: memAfter.heapUsed,
+      heapUsedDeltaBytes: memAfter.heapUsed - memBefore.heapUsed,
       rssBeforeBytes: memBefore.rss,
       rssAfterBytes: memAfter.rss,
       rssDeltaBytes: memAfter.rss - memBefore.rss,
-      heapUsedBeforeBytes: memBefore.heapUsed,
-      heapUsedAfterBytes: memAfter.heapUsed,
     },
   };
 }

--- a/vitest.perf.config.ts
+++ b/vitest.perf.config.ts
@@ -19,5 +19,12 @@ export default defineConfig({
     hookTimeout: 1_800_000,
     clearMocks: true,
     reporters: ['verbose'],
+    // Forked (not worker-thread) so `--expose-gc` reliably attaches `global.gc` in the
+    // process that runs the tests. test/perf/utils/measure.ts calls it to force a clean
+    // heap snapshot before/after each measured block -- without it, memory deltas are
+    // contaminated by whatever garbage V8 happened not to have collected yet, which is
+    // most of why memory readings were noisy before this.
+    pool: 'forks',
+    execArgv: ['--expose-gc'],
   },
 });


### PR DESCRIPTION
## Summary
- `process.memoryUsage().rss` delta (no forced GC) was the tracked memory metric. RSS is whole-process resident memory — native/Rust allocations across the napi boundary, tokio thread stacks, page-cache noise — none of which is attributable to the measured operation, and without a forced GC it mostly measured V8's collection timing luck. Untouched code paths were observed swinging 10–90x run to run under it (e.g. an unrelated JSON5 memory ratio of `71.05` on mcarvin8/sf-decomposer#523's PR comment).
- `measure()` now calls `global.gc()` immediately before and after each measured block and reports **heapUsed delta** as the primary memory metric. Requires `--expose-gc`, wired via `vitest.perf.config.ts`'s `pool: 'forks'` + top-level `execArgv: ['--expose-gc']`.
- RSS is kept on `MeasureResult` and in the console summary as diagnostic-only; it's no longer fed to `scripts/perf-to-benchmark.mjs` or the gh-pages dashboard.

## ⚠️ Needs a decision: existing profile history
This changes what the memory metric under every **existing** profile name (`large`/`xlarge`/`small`/`medium`) means on gh-pages: data points before this merges are RSS-based, points after are heapUsed-based, and they are not comparable under the same benchmark name/series. Only `manyfiles` has no prior history to worry about (started fresh this week).

Options, your call:
1. Do nothing — accept one discontinuity in the `large`/etc series (methodology change is visible as a comment/note, chart just has a jump).
2. Rename those profiles going forward (e.g. `large` → `largev2`) so old RSS-based history stays frozen under its old name and new heapUsed-based data starts a clean series.

## Test plan
- [x] `PERF_PROFILE=manyfiles PERF_FORMATS=xml npx vitest run --config ./vitest.perf.config.ts` — passes, heapΔ now in tens of KB (vs RSS swinging into the hundreds of MB in the same run)
- [x] `PERF_PROFILE=small PERF_FORMATS=xml npx vitest run --config ./vitest.perf.config.ts` — passes, same sane heapΔ behavior
- [x] `npm test` (compile + tests + lint) — clean