### PR TITLE
test(perf): measure median-of-N repeats for a trustworthy timing signal

### DIFF
--- a/scripts/perf-to-benchmark.mjs
+++ b/scripts/perf-to-benchmark.mjs
@@ -3,17 +3,21 @@
 // by benchmark-action/github-action-benchmark (customSmallerIsBetter mode).
 //
 // Inputs:  perf-results/*.json
-// Outputs: perf-runtime.json - sample.elapsedMs in ms, one entry per
+// Outputs: perf-runtime.json - sample.elapsedMedianMs in ms, one entry per
 //                              (profile, format, sample.label)
-//          perf-memory.json  - sample.heapUsedDeltaBytes in MB, same keys.
+//          perf-memory.json  - sample.heapUsedMedianBytes in MB, same keys.
 //                              JS heap only, sampled around a forced GC on both sides
 //                              (see test/perf/utils/measure.ts) -- not whole-process RSS,
 //                              which was mostly measuring GC/allocator timing noise rather
 //                              than the operation's actual memory cost.
 //
-// One metric per (profile, format, label) tuple; if multiple reports cover
-// the same tuple (e.g. a re-run within the same job) only the most recent
-// timestamp is kept so the dashboard timeline stays one datapoint per run.
+// Each perf run writes TWO reports per (profile, format): the correctness test's report
+// (round-trip fidelity / idempotence assertions; samples populated, medianSamples empty)
+// and the dedicated timing test's report (median-of-N repeats; medianSamples populated,
+// samples empty). Reports are merged by (profile, format) rather than "latest wins" so
+// both contribute -- in practice only medianSamples ends up non-empty per key, since
+// that's the only field this script publishes (samples is diagnostic-only; see
+// test/perf/utils/measure.ts's PerfReport doc comment).
 
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -31,24 +35,27 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-const latest = new Map();
+const merged = new Map();
 for (const f of files.sort()) {
   const r = JSON.parse(await readFile(join(dir, f), 'utf8'));
-  latest.set(`${r.profile}|${r.format}`, r);
+  const key = `${r.profile}|${r.format}`;
+  const existing = merged.get(key) ?? { profile: r.profile, medianSamples: [] };
+  existing.medianSamples.push(...(r.medianSamples ?? []));
+  merged.set(key, existing);
 }
 
 const runtime = [];
 const memory = [];
-for (const r of latest.values()) {
-  for (const s of r.samples) {
-    // sample.label already begins with the format (e.g. "xml.decompose.pass1");
+for (const r of merged.values()) {
+  for (const s of r.medianSamples) {
+    // sample.label already begins with the format (e.g. "xml.decompose");
     // prefix only the profile to avoid stuttering.
     const name = `${r.profile}.${s.label}`;
-    runtime.push({ name, unit: 'ms', value: Number(s.elapsedMs.toFixed(2)) });
+    runtime.push({ name, unit: 'ms', value: Number(s.elapsedMedianMs.toFixed(2)) });
     memory.push({
       name,
       unit: 'MB',
-      value: Number((s.heapUsedDeltaBytes / 1024 / 1024).toFixed(3)),
+      value: Number((s.heapUsedMedianBytes / 1024 / 1024).toFixed(3)),
     });
   }
 }

--- a/test/perf/decompose.perf.ts
+++ b/test/perf/decompose.perf.ts
@@ -7,7 +7,16 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { generate, type Profile } from '../../scripts/gen-perf-fixtures.js';
 import { decomposeMetadataTypes } from '../../src/core/decomposeMetadataTypes.js';
 import { recomposeMetadataTypes } from '../../src/core/recomposeMetadataTypes.js';
-import { dirBytes, formatBytes, formatMs, type MeasureResult, measure, writeReport } from './utils/measure.js';
+import {
+  dirBytes,
+  formatBytes,
+  formatMs,
+  type MeasureResult,
+  type MedianSample,
+  measure,
+  summarizeMedian,
+  writeReport,
+} from './utils/measure.js';
 
 // Performance tests are intentionally heavy and DO NOT run as part of `npm test`.
 // They:
@@ -42,6 +51,12 @@ function envString<T extends string>(name: string, fallback: T): T {
   const raw = process.env[name];
   return !raw || raw.trim() === '' ? fallback : (raw as T);
 }
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 const PROFILE = envString<Profile>('PERF_PROFILE', 'large');
 const FORMATS = envList('PERF_FORMATS', ['xml', 'json', 'json5', 'yaml']);
@@ -68,6 +83,12 @@ const DEFAULT_METADATA_TYPES =
         'entitlementProcess',
       ];
 const METADATA_TYPES = envList('PERF_TYPES', DEFAULT_METADATA_TYPES);
+// Number of independent repeats used to compute the median timing/memory sample that
+// actually gets published to the dashboard (see the "measures timing" test below and
+// scripts/perf-to-benchmark.mjs). A single sample on a shared CI runner routinely swings
+// 15-20% for identical code; the median of several repeats is far more resistant to any
+// one of them landing on a GC pause / noisy neighbor / scheduler hiccup.
+const PERF_REPEATS = envNumber('PERF_REPEATS', 5);
 
 const FIXTURE_ROOT = resolve('perf-fixtures');
 
@@ -219,6 +240,11 @@ describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
         }
 
         // ---- write report --------------------------------------------------
+        // medianSamples is intentionally empty here: this test measures a single pass1/pass2
+        // pair for correctness (round-trip fidelity, idempotence), not a trustworthy timing
+        // signal. The dedicated "measures timing" test below produces the median-of-N samples
+        // that actually get published (see scripts/perf-to-benchmark.mjs, which merges every
+        // report matching a (profile, format) pair rather than picking just one).
         const reportFile = await writeReport({
           timestamp: new Date().toISOString(),
           node: process.version,
@@ -229,9 +255,79 @@ describe(`perf: decompose/recompose round-trip (profile=${PROFILE})`, () => {
           fixtureBytes,
           fixtureFiles,
           samples,
+          medianSamples: [],
         });
 
         printSummary(format, fixtureBytes, samples, decomposedSnapshot, retention, reportFile);
+      });
+
+      it(`measures decompose/recompose timing over ${PERF_REPEATS} repeats in ${format.toUpperCase()}`, async () => {
+        // Independent of the correctness test above: this test's only job is producing a
+        // trustworthy timing/memory number, so it never checks round-trip fidelity and never
+        // reuses a workDir across iterations. Each repeat gets its own pristine fixture copy --
+        // decompose/recompose mutate the working tree (prepurge/postpurge), so reusing one
+        // directory across repeats would measure a different operation on repeat 2..N than on
+        // repeat 1 (an already-decomposed tree behaves differently than a pristine one).
+        const log = (): void => {};
+        const decomposeSamples: MeasureResult[] = [];
+        const recomposeSamples: MeasureResult[] = [];
+
+        for (let rep = 0; rep < PERF_REPEATS; rep++) {
+          const repDir = await mkdtemp(join(tmpdir(), `sf-decomposer-perf-median-${format}-`));
+          try {
+            await cp(FIXTURE_ROOT, repDir, { recursive: true, force: true });
+            process.chdir(repDir);
+
+            const { sample: decomposeSample } = await measure(`${format}.decompose`, async () => {
+              await decomposeMetadataTypes({
+                metadataTypes: METADATA_TYPES,
+                prepurge: true,
+                postpurge: true,
+                format,
+                strategy: 'unique-id',
+                decomposeNestedPerms: false,
+                log,
+              });
+            });
+            decomposeSamples.push(decomposeSample);
+
+            // Recompose immediately after this same rep's decompose, so its precondition
+            // (decomposed shards present, no parent -meta.xml) is naturally satisfied without
+            // a separate untimed setup step.
+            const { sample: recomposeSample } = await measure(`${format}.recompose`, async () => {
+              await recomposeMetadataTypes({
+                metadataTypes: METADATA_TYPES,
+                postpurge: true,
+                log,
+              });
+            });
+            recomposeSamples.push(recomposeSample);
+          } finally {
+            process.chdir(originalCwd);
+            // eslint-disable-next-line no-await-in-loop -- each repeat must clean up before the next one starts
+            await rm(repDir, { recursive: true, force: true });
+          }
+        }
+
+        const medianSamples: MedianSample[] = [
+          summarizeMedian(`${format}.decompose`, decomposeSamples),
+          summarizeMedian(`${format}.recompose`, recomposeSamples),
+        ];
+
+        const reportFile = await writeReport({
+          timestamp: new Date().toISOString(),
+          node: process.version,
+          platform: process.platform,
+          arch: process.arch,
+          profile: PROFILE,
+          format,
+          fixtureBytes,
+          fixtureFiles,
+          samples: [],
+          medianSamples,
+        });
+
+        printMedianSummary(format, medianSamples, reportFile);
       });
     });
   }
@@ -339,4 +435,19 @@ function printSummary(
 
 function formatPercent(ratio: number): string {
   return `${(ratio * 100).toFixed(2)}%`;
+}
+
+function printMedianSummary(format: string, medianSamples: MedianSample[], reportFile: string): void {
+  const lines = ['', `[perf] median timing (format=${format}, ${medianSamples[0]?.repeats ?? 0} repeats)`];
+  for (const s of medianSamples) {
+    lines.push(
+      `[perf]   ${s.label.padEnd(20)} median=${formatMs(s.elapsedMedianMs).padStart(10)}   ` +
+        `range=[${formatMs(s.elapsedMinMs)}, ${formatMs(s.elapsedMaxMs)}]   ` +
+        `heapΔ median=${formatBytes(s.heapUsedMedianBytes)}`,
+    );
+  }
+  lines.push(`[perf]   report=${reportFile}`);
+
+  // eslint-disable-next-line no-console
+  console.log(lines.join('\n'));
 }

--- a/test/perf/utils/measure.ts
+++ b/test/perf/utils/measure.ts
@@ -63,6 +63,45 @@ export async function measure<T>(label: string, fn: () => Promise<T>): Promise<{
   };
 }
 
+export type MedianSample = {
+  label: string;
+  repeats: number;
+  elapsedMedianMs: number;
+  elapsedMinMs: number;
+  elapsedMaxMs: number;
+  heapUsedMedianBytes: number;
+};
+
+/** Median of a non-empty array of numbers (average of the two middle values on an even count). */
+export function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Reduce repeated `measure()` results for the same operation into one median-based summary.
+ *
+ * A single sample on a shared CI runner routinely swings 15-20% run to run for identical
+ * code, which makes a single elapsedMs/heapUsedDeltaBytes reading useless for telling a real
+ * regression apart from runner noise. The median of several independent repeats is far more
+ * stable than any one of them, since it takes an outlier sample (a GC pause, a noisy
+ * neighbor, a scheduler hiccup) landing on *most* of the repeats to move it -- one bad run
+ * among several good ones just gets outvoted instead of being the only data point.
+ */
+export function summarizeMedian(label: string, results: readonly MeasureResult[]): MedianSample {
+  const elapsed = results.map((r) => r.elapsedMs);
+  const heapUsed = results.map((r) => r.heapUsedDeltaBytes);
+  return {
+    label,
+    repeats: results.length,
+    elapsedMedianMs: median(elapsed),
+    elapsedMinMs: Math.min(...elapsed),
+    elapsedMaxMs: Math.max(...elapsed),
+    heapUsedMedianBytes: median(heapUsed),
+  };
+}
+
 /** Recursively sum byte sizes of all files under a directory. */
 export async function dirBytes(dir: string): Promise<{ files: number; bytes: number }> {
   // Walk the tree breadth-first and stat in parallel batches. The naive
@@ -104,7 +143,14 @@ export type PerfReport = {
   format: string;
   fixtureBytes: number;
   fixtureFiles: number;
+  // Single-shot samples from the correctness round-trip (see decompose.perf.ts's main
+  // test): useful for local debugging, but too noisy on a shared CI runner to trust as a
+  // trend signal on their own. Not read by scripts/perf-to-benchmark.mjs.
   samples: MeasureResult[];
+  // Median-of-N samples from a dedicated, correctness-agnostic timing loop (see
+  // decompose.perf.ts's "measures timing" test). This is what feeds the gh-pages
+  // dashboard / PR comparison comments.
+  medianSamples: MedianSample[];
 };
 
 const RESULTS_DIR = resolve(process.cwd(), 'perf-results');


### PR DESCRIPTION
## Summary
- A single sample on a shared CI runner routinely swings 15-20% for identical code (observed `xml.decompose.pass2` go 1.03x → 1.18x between two runs of the same commit on mcarvin8/sf-decomposer#523). That noise is why `alert-threshold` sits at 150-200% — tight enough to be meaningful would false-positive constantly. It also means a real 10-20% regression is currently invisible: indistinguishable from noise.
- Adds a dedicated timing test per format, separate from the existing correctness (round-trip fidelity / idempotence) test. It repeats a decompose+recompose cycle `PERF_REPEATS` times (default 5, env-overridable), **each against its own pristine fixture copy** — decompose/recompose mutate the working tree via prepurge/postpurge, so reusing one directory across repeats would measure a different operation on repeat 2..N than on repeat 1 — and reports the **median** elapsed time and median heapUsed delta. Median resists a single outlier repeat (GC pause, noisy neighbor, scheduler hiccup) dragging the result, unlike a mean or a lone sample.
- `scripts/perf-to-benchmark.mjs` now merges every report matching a `(profile, format)` pair instead of picking the latest by timestamp, and publishes `medianSamples` (not the correctness test's single-shot `samples`) to the dashboard.

## Heads up: another series-naming change, same basis as #526
This collapses the previous `pass1`/`pass2` series into one per operation (`xml.decompose`, `xml.recompose`) — `pass1` vs `pass2` was only ever a correctness/idempotence concept, not a distinct performance scenario, so nothing meaningful is lost. But combined with #526's heapUsed value-semantics change, this is a second structural change to what's on gh-pages. Filing this under the same "accept the one-time chart jump" call you already made for #526, not asking again — flagging so it's visible in the PR history.

## Why this matters
This is what makes tightening `alert-threshold` and eventually enabling `fail-on-alert` viable — a real regression no longer hides inside the noise floor.

## Test plan
- [x] `PERF_PROFILE=manyfiles PERF_FORMATS=xml PERF_REPEATS=3 npx vitest run --config ./vitest.perf.config.ts` — both tests pass; median timing printed correctly (`xml.decompose median=8.11s range=[8.05s, 8.44s]`)
- [x] `node scripts/perf-to-benchmark.mjs` — correctly merges the two reports per (profile, format), publishes exactly 2 runtime + 2 memory metrics (decompose, recompose) instead of 4 (no more pass1/pass2 split)
- [x] `npm test` (compile + tests + lint) — clean