### PR TITLE
chore(perf): diff PR benchmarks against same-runner base ref

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -141,12 +141,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-        with:
-          # Full history on pull_request so the base-ref checkout below (used
-          # for the same-runner baseline benchmark) can find the base sha.
-          # Every other trigger only ever benchmarks the checked-out ref, so
-          # a shallow clone is fine there.
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -179,7 +173,13 @@ jobs:
 
       - name: Checkout PR base ref
         if: github.event_name == 'pull_request'
-        run: git checkout --detach --force "${{ github.event.pull_request.base.sha }}"
+        # The default checkout above is a shallow, single-commit fetch of the
+        # PR merge ref, so the base sha usually isn't present locally yet -
+        # fetch it explicitly rather than unshallowing the whole repo just to
+        # reach one commit.
+        run: |
+          git fetch --no-tags --prune --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          git checkout --detach --force "${{ github.event.pull_request.base.sha }}"
 
       - name: Install base-ref dependencies
         if: github.event_name == 'pull_request'

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -7,16 +7,18 @@
 #                          updates, runner-image refreshes, V8/Rust upstream.
 #   - workflow_call      : invoked by release.yml after a successful publish so
 #                          every version on npm has a perf artifact attached.
-#   - pull_request       : compares the PR head against the gh-pages baseline
-#                          and posts a sticky comment with the deltas. Runs the
-#                          same profile/formats as the baseline so bench names
-#                          line up; otherwise the action would render the PR's
-#                          metrics as brand-new charts instead of new points on
-#                          the existing series. Skipped for fork PRs because
+#   - pull_request       : benchmarks the PR base ref, then the PR head ref,
+#                          back to back on the same runner, and posts a sticky
+#                          comment with the deltas (scripts/compare-perf-baseline.mjs).
+#                          Same-runner/same-moment diffing avoids the 20-30%
+#                          run-to-run swings a gh-pages-history comparison
+#                          would inherit from running on different runners at
+#                          different times. Skipped for fork PRs because
 #                          GITHUB_TOKEN is read-only there - re-introduce via
 #                          a workflow_run companion if/when external
 #                          contributions need this. Doc-only PRs are filtered
-#                          out so they don't pay the ~3-4 minute cost.
+#                          out so they don't pay the ~6-8 minute cost (base +
+#                          head runs).
 #
 # Profile matrix: schedule/pull_request run BOTH `large` (single-huge-file shape) and
 # `manyfiles` (many-small-files-in-one-directory shape, the one that actually exercises
@@ -57,7 +59,8 @@ on:
     # Mondays 05:00 UTC - quiet hours on the GitHub-hosted runner pool.
     - cron: '0 5 * * 1'
   pull_request:
-    # Skip cosmetic/doc-only PRs so they don't burn ~3-4 minutes of CI per push.
+    # Skip cosmetic/doc-only PRs so they don't burn ~6-8 minutes of CI per push
+    # (base-ref + head-ref runs - see the trigger comment above).
     # Code that can plausibly affect runtime/memory lives outside these paths.
     paths-ignore:
       - '**/*.md'
@@ -90,7 +93,7 @@ permissions:
   contents: read
 
 # Cancel in-progress perf runs for the same PR/branch when a new commit lands.
-# Without this, force-pushing N times to a PR queues N x ~3-4 minute jobs. The
+# Without this, force-pushing N times to a PR queues N x ~6-8 minute jobs. The
 # release/schedule/dispatch flows run on main or detached refs, where each run
 # gets a unique group key, so this only collapses redundant PR runs.
 concurrency:
@@ -114,8 +117,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      # Only pull_request is safe to fully parallelize: its publish steps use
-      # auto-push:false/save-data-file:false, so there's no gh-pages write to race. Every
+      # Only pull_request is safe to fully parallelize: its comparison is same-runner-only
+      # and never touches gh-pages, so there's no gh-pages write to race. Every
       # other trigger that reaches this matrix with 2+ profiles (schedule) pushes to the
       # same gh-pages branch/file per profile; running those concurrently risks one
       # matrix entry's push getting rejected (or racing) against the other's. Serialize
@@ -138,6 +141,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history on pull_request so the base-ref checkout below (used
+          # for the same-runner baseline benchmark) can find the base sha.
+          # Every other trigger only ever benchmarks the checked-out ref, so
+          # a shallow clone is fine there.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -146,6 +155,61 @@ jobs:
           cache: npm
 
       - name: Install Dependencies
+        run: npm ci
+
+      # -----------------------------------------------------------------
+      # Same-runner baseline benchmark (PR only).
+      #
+      # Benchmarks the PR's base ref first, on this exact runner, then
+      # switches back to the PR head and reinstalls before the normal
+      # "Run performance suite" step below benchmarks the head. Both runs
+      # share the same machine/OS image/moment in time, so
+      # scripts/compare-perf-baseline.mjs (further down) can use a much
+      # tighter regression threshold than the gh-pages-history comparison
+      # the schedule/workflow_call paths use.
+      #
+      # perf-results/ is cleared after converting the base run so the head
+      # run's own perf-results/ doesn't get merged with the base run's
+      # reports by scripts/perf-to-benchmark.mjs (it merges every *.json in
+      # the directory by (profile, format) key).
+      # -----------------------------------------------------------------
+      - name: Save current ref
+        if: github.event_name == 'pull_request'
+        run: echo "CURRENT_REF=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Checkout PR base ref
+        if: github.event_name == 'pull_request'
+        run: git checkout --detach --force "${{ github.event.pull_request.base.sha }}"
+
+      - name: Install base-ref dependencies
+        if: github.event_name == 'pull_request'
+        run: npm ci
+
+      - name: Run baseline performance suite (base ref)
+        if: github.event_name == 'pull_request'
+        run: npm run test:perf
+        env:
+          PERF_PROFILE: ${{ matrix.profile }}
+          PERF_FORMATS: ${{ inputs.formats || 'xml,json,json5,yaml' }}
+          PERF_TYPES: ${{ inputs.types }}
+          SF_DISABLE_TELEMETRY: true
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          RUST_LOG: warn
+
+      - name: Convert baseline perf-results to benchmark JSON
+        if: github.event_name == 'pull_request'
+        run: |
+          node scripts/perf-to-benchmark.mjs
+          cp perf-runtime.json perf-runtime-base.json
+          cp perf-memory.json perf-memory-base.json
+          rm -rf perf-results perf-runtime.json perf-memory.json
+
+      - name: Restore PR head ref
+        if: github.event_name == 'pull_request'
+        run: git checkout --force "$CURRENT_REF"
+
+      - name: Reinstall head-ref dependencies
+        if: github.event_name == 'pull_request'
         run: npm ci
 
       - name: Print runner facts
@@ -213,6 +277,9 @@ jobs:
           name: perf-results-${{ matrix.profile }}-${{ github.run_id }}
           path: |
             perf-results/
+            perf-comparison.md
+            perf-runtime-base.json
+            perf-memory-base.json
           retention-days: 90
           if-no-files-found: warn
 
@@ -281,60 +348,29 @@ jobs:
           benchmark-data-dir-path: dev/bench/memory
 
       # ---------------------------------------------------------------------
-      # PR comparison comment (Phase 2).
+      # PR comparison comment: same-runner baseline diff.
       #
-      # On pull_request events, generate the same benchmark JSON as the
-      # publish path, but instead of pushing to gh-pages we ask the action
-      # to read the existing baseline, render a sticky comment with the
-      # per-bench deltas, and discard the new data point. comment-always
-      # (vs comment-on-alert) is intentional: even green runs are useful
-      # signal on perf-sensitive PRs, and a single sticky comment beats
-      # scrolling for a status check.
+      # perf-results/ here only holds the head-ref run (the base-ref run was
+      # already converted and cleared out by "Convert baseline perf-results
+      # to benchmark JSON" above), so this conversion produces the head-ref's
+      # perf-runtime.json / perf-memory.json. scripts/compare-perf-baseline.mjs
+      # diffs those against perf-runtime-base.json / perf-memory-base.json
+      # (same runner, same job, benchmarked moments earlier) and posts/updates
+      # a sticky PR comment - see that script for the threshold rationale.
       #
-      # auto-push:false + save-data-file:false ensures the timeline on
-      # gh-pages stays a clean record of merged code; PR runs never appear
-      # there. fail-on-alert stays false to match the publish steps - perf
-      # regressions surface as a comment, not a required-check failure.
-      #
-      # If the bench names emitted by this run don't already exist on
-      # gh-pages (e.g. someone changed PERF_FORMATS / PERF_TYPES to something
-      # the baseline doesn't cover), the action posts the values without a
-      # delta. That's fine - it just means there's no apples-to-apples
-      # comparison yet, not that anything is broken.
+      # This never touches gh-pages (no auto-push/save-data-file here at
+      # all) and never fails the job: regressions surface as a comment and a
+      # ::warning:: annotation, matching the rest of this workflow's
+      # fail-on-alert: false stance.
       # ---------------------------------------------------------------------
       - name: Convert perf-results for PR comparison
         if: github.event_name == 'pull_request'
         run: node scripts/perf-to-benchmark.mjs
 
-      - name: Compare runtime against baseline (PR)
+      - name: Compare against same-runner baseline (PR)
         if: github.event_name == 'pull_request'
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Decompose Runtime (${{ matrix.profile }})
-          tool: customSmallerIsBetter
-          output-file-path: ./perf-runtime.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-          save-data-file: false
-          alert-threshold: '150%'
-          fail-on-alert: false
-          comment-always: true
-          summary-always: true
-          benchmark-data-dir-path: dev/bench/runtime
-
-      - name: Compare memory against baseline (PR)
-        if: github.event_name == 'pull_request'
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Decompose Memory (${{ matrix.profile }})
-          tool: customSmallerIsBetter
-          output-file-path: ./perf-memory.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-          save-data-file: false
-          skip-fetch-gh-pages: true
-          alert-threshold: '200%'
-          fail-on-alert: false
-          comment-always: true
-          summary-always: true
-          benchmark-data-dir-path: dev/bench/memory
+        run: node scripts/compare-perf-baseline.mjs
+        env:
+          PERF_PROFILE: ${{ matrix.profile }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ perf-results
 # benchmark-action/github-action-benchmark inputs (built from perf-results in CI)
 perf-runtime.json
 perf-memory.json
+# same-runner PR baseline comparison artifacts (see scripts/compare-perf-baseline.mjs)
+perf-runtime-base.json
+perf-memory-base.json
+perf-comparison.md
 
 # stryker mutation testing
 .stryker-tmp

--- a/scripts/compare-perf-baseline.mjs
+++ b/scripts/compare-perf-baseline.mjs
@@ -1,0 +1,136 @@
+// Compares this PR's perf-runtime.json / perf-memory.json (built from a run
+// against the PR head) with perf-runtime-base.json / perf-memory-base.json
+// (built from an identical run against the PR base ref, on the same runner,
+// immediately before). See perf.yml's "Run baseline performance suite"
+// step for how the *-base.json files are produced.
+//
+// This exists because comparing against gh-pages history (a different run on
+// a different runner, possibly days old) swings 20-30% between otherwise
+// identical code -- see perf.yml's alert-threshold comments. Same-runner,
+// same-moment diffing removes most of that noise, so this uses a tighter
+// threshold than the gh-pages-based publish steps.
+//
+// Inputs:  perf-runtime.json, perf-memory.json (head)
+//          perf-runtime-base.json, perf-memory-base.json (base)
+// Env:     PERF_PROFILE      - included in the sticky-comment marker so the
+//                              `large`/`manyfiles` matrix jobs each get their
+//                              own comment instead of overwriting each other.
+//          GITHUB_TOKEN      - posts/updates the PR comment when set.
+//          GITHUB_REPOSITORY - "owner/repo", set automatically by Actions.
+//          PR_NUMBER         - the PR to comment on.
+// Output:  perf-comparison.md, plus a sticky PR comment when the env above
+//          is present. Never exits non-zero: regressions are informational
+//          (surfaced via the comment and a ::warning::), not a required-check
+//          failure -- matches the rest of perf.yml's fail-on-alert: false.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+// Both metrics are "smaller is better" (elapsed ms, heap delta MB), unlike
+// sfdx-git-delta's ops/sec runtime metric -- so both use the same ratio
+// direction (pr / base) below.
+const RUNTIME_THRESHOLD = 1.3;
+const MEMORY_THRESHOLD = 1.5;
+
+const loadJson = (path) => (existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : []);
+
+const prRuntime = loadJson('perf-runtime.json');
+const baseRuntime = loadJson('perf-runtime-base.json');
+const prMemory = loadJson('perf-memory.json');
+const baseMemory = loadJson('perf-memory-base.json');
+
+const toMap = (entries) => new Map(entries.map((e) => [e.name, e.value]));
+const baseRuntimeMap = toMap(baseRuntime);
+const baseMemoryMap = toMap(baseMemory);
+
+const regressions = [];
+const improvements = [];
+const stable = [];
+
+function compare(name, baseVal, prVal, unit, threshold) {
+  const ratio = prVal / baseVal;
+  const pct = ((ratio - 1) * 100).toFixed(1);
+  const row = {
+    name,
+    base: baseVal,
+    pr: prVal,
+    unit,
+    ratio: ratio.toFixed(2),
+    change: ratio > 1 ? `+${pct}%` : `-${Math.abs(pct)}%`,
+  };
+  if (ratio >= threshold) regressions.push(row);
+  else if (ratio <= 1 / threshold) improvements.push(row);
+  else stable.push(row);
+}
+
+for (const entry of prRuntime) {
+  const baseVal = baseRuntimeMap.get(entry.name);
+  if (baseVal == null) continue; // new bench name -- no baseline to diff against yet
+  compare(entry.name, baseVal, entry.value, 'ms', RUNTIME_THRESHOLD);
+}
+for (const entry of prMemory) {
+  const baseVal = baseMemoryMap.get(entry.name);
+  if (baseVal == null) continue;
+  compare(`${entry.name} (heap)`, baseVal, entry.value, 'MB', MEMORY_THRESHOLD);
+}
+
+const profile = process.env.PERF_PROFILE || 'large';
+
+const tableHeader = '| Benchmark | Base | PR | Ratio | Change |\n|---|---:|---:|---:|---:|';
+const tableRow = (r) => `| ${r.name} | ${r.base}${r.unit} | ${r.pr}${r.unit} | ${r.ratio} | ${r.change} |`;
+
+const lines = [`# Performance comparison (same runner, profile=${profile})\n`];
+
+if (regressions.length > 0) {
+  lines.push('## Regressions\n', tableHeader, ...regressions.map(tableRow), '');
+}
+if (improvements.length > 0) {
+  lines.push('## Improvements\n', tableHeader, ...improvements.map(tableRow), '');
+}
+lines.push('## Stable\n', tableHeader, ...(stable.length > 0 ? stable.map(tableRow) : ['| _none_ | | | | |']), '');
+
+const report = lines.join('\n');
+writeFileSync('perf-comparison.md', report);
+console.log(report);
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
+const prNumber = process.env.PR_NUMBER;
+
+if (token && repo && prNumber) {
+  const commentMarker = `<!-- same-runner-perf:${profile} -->`;
+  const commentBody = `${commentMarker}\n${report}`;
+  const [owner, repoName] = repo.split('/');
+  const apiBase = `https://api.github.com/repos/${owner}/${repoName}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+    'Content-Type': 'application/json',
+  };
+
+  const commentsRes = await fetch(`${apiBase}/issues/${prNumber}/comments?per_page=100`, { headers });
+  const comments = await commentsRes.json();
+  const existing = Array.isArray(comments) ? comments.find((c) => c.body?.includes(commentMarker)) : undefined;
+
+  if (existing) {
+    await fetch(`${apiBase}/issues/comments/${existing.id}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ body: commentBody }),
+    });
+  } else {
+    await fetch(`${apiBase}/issues/${prNumber}/comments`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ body: commentBody }),
+    });
+  }
+}
+
+if (regressions.length > 0) {
+  console.warn(
+    `\n::warning::${regressions.length} performance regression(s) detected on the same runner ` +
+      `(runtime threshold: ${RUNTIME_THRESHOLD}x, memory threshold: ${MEMORY_THRESHOLD}x) -- see PR comment for details`,
+  );
+} else {
+  console.info('No regressions detected.');
+}

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -116,25 +116,39 @@ To enable on first run:
 
 ## Pull-request comparison comment
 
-PRs that touch non-doc files automatically run the same `large` profile and
-post a sticky comment showing per-bench deltas vs the latest gh-pages
-baseline. The comment updates in place on subsequent pushes (the action keys
-off the bench name + PR number).
+PRs that touch non-doc files run the `large` and `manyfiles` profiles as
+parallel matrix jobs. Each job benchmarks the PR's base ref and then its head
+ref, back to back, **on the same runner**, then posts a sticky comment (one
+per profile) showing the per-bench deltas between the two
+(`scripts/compare-perf-baseline.mjs`). The comment updates in place on
+subsequent pushes (keyed off an HTML marker containing the profile name).
+
+This is deliberately not a comparison against the gh-pages history: that
+history comes from a different run on a different runner, possibly days old,
+and swings 20-30% between otherwise-identical code (see the `alert-threshold`
+comments in `perf.yml`). Benchmarking base and head back to back on one
+runner removes most of that noise, so the PR comparison uses a tighter
+threshold (130% runtime / 150% memory) than the gh-pages-based publish steps
+(150%/200%).
 
 Behavior:
 
 - Runs only on PRs from branches in this repo. Fork PRs are skipped because
   `GITHUB_TOKEN` is read-only there and can't post comments.
 - Concurrency-limited: a new push cancels the in-progress perf run for the
-  same PR so we don't queue redundant ~3-4 minute jobs.
-- Does **not** push to `gh-pages` (`auto-push: false`, `save-data-file:
-false`). The PR's numbers are compared against the baseline and discarded;
-  the trend dashboard only contains merged-code data points.
-- Does **not** fail the check on regression (`fail-on-alert: false`). The
-  comment surfaces it; reviewers decide. Tune via `alert-threshold` in
-  `.github/workflows/perf.yml` if the noise floor changes.
+  same PR so we don't queue redundant jobs.
+- Never touches `gh-pages`: base and head results are both discarded after
+  the comment is posted, so the trend dashboard only ever contains data from
+  the schedule/release-triggered runs.
+- Does **not** fail the check on regression. The comment (and a
+  `::warning::` annotation) surfaces it; reviewers decide. Tune the
+  thresholds in `scripts/compare-perf-baseline.mjs` if the noise floor
+  changes.
 - Honors the same paths-ignore filter the workflow uses, so doc-only PRs
   skip the run entirely rather than posting a stale comment.
+- Costs roughly double a single-profile run (base + head, each profile run
+  serially within its matrix job) - budget ~6-8 minutes per profile instead
+  of ~3-4.
 
 [bench]: https://github.com/benchmark-action/github-action-benchmark
 


### PR DESCRIPTION
## Summary
- PR perf job now benchmarks the PR base ref and head ref back-to-back on the same runner and diffs those directly, instead of comparing against gh-pages history (a different run, different runner, possibly days old — swings 20-30% between otherwise identical code).
- New `scripts/compare-perf-baseline.mjs` posts/updates a sticky PR comment per matrix profile with regression/improvement/stable tables, using a tighter threshold (1.3x runtime / 1.5x memory) than the old gh-pages comparison (1.5x/2x) since same-runner noise is much lower.
- gh-pages publishing (weekly schedule + release.yml) is unchanged — the trend dashboard still only gets merged-code data points.
- Cost: PR perf runs roughly double (base + head run per profile), so doc-only paths-ignore filter now matters more.

## Test plan
- [x] `node --check scripts/compare-perf-baseline.mjs`
- [x] `biome check scripts/compare-perf-baseline.mjs`
- [x] Ran the compare script against synthetic runtime/memory fixtures — correctly flagged a 40% regression, left 2%/4% deltas as stable, exits 0 without `GITHUB_TOKEN`/`PR_NUMBER` set.
- [x] Validated `perf.yml` YAML syntax
- [ ] Confirm the workflow itself runs green on this PR (perf job will exercise the new base/head diff live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)