### PR TITLE
fix(metadata): add configName unique id for genComputingSummaryDefAccess

### DIFF
--- a/src/metadata/uniqueIdElements.ts
+++ b/src/metadata/uniqueIdElements.ts
@@ -125,6 +125,7 @@ export default [
         'agentName',
         'externalCredentialPrincipal',
         'servicePresenceStatus',
+        'configName',
       ],
     },
     omniSupervisorConfig: {
@@ -153,6 +154,7 @@ export default [
         'agentName',
         'externalCredentialPrincipal',
         'servicePresenceStatus',
+        'configName',
       ],
     },
     profile: {


### PR DESCRIPTION
## Summary
- Checked `PermissionSet`'s repeating child elements against the [Metadata API reference](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_permissionset.htm) against `src/metadata/uniqueIdElements.ts`'s `permissionset` entry.
- Found one gap: `genComputingSummaryDefAccess` (API v66+) is keyed by `configName`, same as it already is for `profile`, but `permissionset` was missing it — that element was falling back to a SHA-256 hash filename on decompose instead of a readable `configName`-based one.
- `mutingpermissionset` mirrors `permissionset`'s access model 1:1 in this file, so it gets the same key added.
- All `name`/`fullName`-keyed elements (customPermissions, userPermissions, etc.) were already fine — those are covered by the default fallback, not this override list.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run test/units/uniqueIdElements.test.ts test/units/configOverrides.test.ts test/units/decomposeFileHandler.test.ts` — 253 passed
- [ ] Perf job (same-runner PR diff) should show no regressions — this only adds a key, doesn't change existing behavior for other types

🤖 Generated with [Claude Code](https://claude.com/claude-code)