### PR TITLE
fix(metadata): add leftValueReference/label unique ids for flow

### DIFF
--- a/src/metadata/uniqueIdElements.ts
+++ b/src/metadata/uniqueIdElements.ts
@@ -56,6 +56,16 @@ export default [
       uniqueIdElements: ['milestoneName'],
     },
     flow: {
+      // `<conditions>` (decisions/rules, record filters, start-element criteria,
+      // wait events) has no `<name>`; `<leftValueReference>` is the variable/field
+      // being tested, the closest thing it has to a natural key.
+      //
+      // `<exitRules>` (segment-triggered flows, API 61+) has no `<name>` either;
+      // `<label>` is its closest natural key. `transformValues` (Transform
+      // element) also lacks a name - its `<transformValueName>` field exists in
+      // the schema but is documented as reserved for future use (not populated
+      // today), so it isn't a usable key and is intentionally left out; those
+      // shards fall back to the SHA-256 hash until Salesforce actually populates it.
       uniqueIdElements: [
         'apexClass',
         'object',
@@ -66,6 +76,8 @@ export default [
         'assignToReference',
         'choiceText',
         'promptText',
+        'leftValueReference',
+        'label',
       ],
     },
     genAiPlugin: {


### PR DESCRIPTION
## Summary
- Checked Flow's `<conditions>` shape against the real fixture (`fixtures/package-dir-2/flows/Get_Info.flow-meta.xml:85-94`) and the perf generator (`scripts/gen-perf-fixtures.ts:427-434`) — both confirm `<conditions>` has no `<name>`, just `leftValueReference`/`operator`/`rightValue`. Added `leftValueReference` as its natural key.
- Added `label` for `<exitRules>` (segment-triggered flows, API 61+), which also has no `<name>`.
- Skipped `transformValues`: its `transformValueName` field is documented as reserved for future use, not populated today — not a usable key yet.

**Important caveat found via smoke test:** none of `flow`'s nested-element keys — this pair included, and the 9 already there (`targetReference`, `assignToReference`, `choiceText`, `promptText`, etc.) — are exercised under default flow decomposition. Flow has no entry in `src/metadata/multiLevelDefaults.ts`, so `unique-id` splitting stays single-level: `<conditions>`/`<exitRules>` stay embedded in their parent shard's XML rather than becoming separate files needing a name. This list only activates for a consumer who configures a deeper `multiLevel` rule for `flow` via `.sfdecomposer.config.json`. This PR keeps that pre-existing pattern consistent rather than changing decomposition depth.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run test/units/uniqueIdElements.test.ts test/units/configOverrides.test.ts test/units/decomposeFileHandler.test.ts` — 253 passed
- [x] Smoke-decomposed `fixtures/package-dir-2/flows/Get_Info.flow-meta.xml` to confirm current single-level shard behavior (no regression, no new shard dirs introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)