### PR TITLE
perf(metadata): batch package-directory walk across metadata types

### DIFF
--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -5,7 +5,8 @@ import { resolveDecomposeOptionsForType } from '../helpers/configOverrides.js';
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
 import { pLimit } from '../helpers/pLimit.js';
 import { DecomposeOptions, DecomposerResult } from '../helpers/types.js';
-import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
+import { buildPackageDirectoryIndex } from '../metadata/getPackageDirectories.js';
+import { getRegistryValuesBySuffix, resolveMetadataTypeEntry } from '../metadata/getRegistryValuesBySuffix.js';
 import { resolveEffectiveMetadataTypes } from '../metadata/parseManifest.js';
 import { ProcessedMeta, updateForceignoreFile } from '../service/core/updateForceignore.js';
 import { updateGitattributesFile } from '../service/core/updateGitattributes.js';
@@ -41,6 +42,20 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
     return { metadata: [] };
   }
 
+  // Resolve every requested type's directoryName up front so the filesystem walk below covers
+  // all of them in one pass, instead of each type re-walking the whole package directory tree.
+  // Unsupported/unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call
+  // below still throws (and, in manifest mode, is caught/logged there) exactly as it does today.
+  const directoryNames = new Set<string>();
+  for (const metadataType of effectiveTypes) {
+    try {
+      directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
+    } catch {
+      /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+    }
+  }
+  const pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
+
   // Limit concurrent metadata type processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);
 
@@ -71,6 +86,7 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
           ignoreDirs,
           repoRoot,
           typeResolved.uniqueIdElements,
+          pathIndex,
         ));
       } catch (err) {
         /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -3,7 +3,8 @@
 import { CONCURRENCY_LIMITS } from '../helpers/constants.js';
 import { pLimit } from '../helpers/pLimit.js';
 import { DecomposerResult, RecomposeOptions } from '../helpers/types.js';
-import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
+import { buildPackageDirectoryIndex } from '../metadata/getPackageDirectories.js';
+import { getRegistryValuesBySuffix, resolveMetadataTypeEntry } from '../metadata/getRegistryValuesBySuffix.js';
 import { resolveEffectiveMetadataTypes } from '../metadata/parseManifest.js';
 import { recomposeFileHandler } from '../service/recompose/recomposeFileHandler.js';
 
@@ -23,6 +24,20 @@ export async function recomposeMetadataTypes(options: RecomposeOptions): Promise
     return { metadata: [] };
   }
 
+  // Resolve every requested type's directoryName up front so the filesystem walk below covers
+  // all of them in one pass, instead of each type re-walking the whole package directory tree.
+  // Unsupported/unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call
+  // below still throws (and, in manifest mode, is caught/logged there) exactly as it does today.
+  const directoryNames = new Set<string>();
+  for (const metadataType of effectiveTypes) {
+    try {
+      directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
+    } catch {
+      /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+    }
+  }
+  const pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
+
   // Limit concurrent metadata type processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);
 
@@ -34,7 +49,14 @@ export async function recomposeMetadataTypes(options: RecomposeOptions): Promise
 
       let metaAttributes;
       try {
-        ({ metaAttributes } = await getRegistryValuesBySuffix(metadataType, 'recompose', ignoreDirs, repoRoot));
+        ({ metaAttributes } = await getRegistryValuesBySuffix(
+          metadataType,
+          'recompose',
+          ignoreDirs,
+          repoRoot,
+          undefined,
+          pathIndex,
+        ));
       } catch (err) {
         /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */
         if (!manifestFilter) throw err;

--- a/src/core/verifyMetadataTypes.ts
+++ b/src/core/verifyMetadataTypes.ts
@@ -12,7 +12,8 @@ import {
 import { CONCURRENCY_LIMITS, SFDX_PROJECT_FILE_NAME } from '../helpers/constants.js';
 import { pLimit } from '../helpers/pLimit.js';
 import { SfdxProject, VerifyDrift, VerifyOptions, VerifyResult } from '../helpers/types.js';
-import { getRegistryValuesBySuffix } from '../metadata/getRegistryValuesBySuffix.js';
+import { buildPackageDirectoryIndex } from '../metadata/getPackageDirectories.js';
+import { getRegistryValuesBySuffix, resolveMetadataTypeEntry } from '../metadata/getRegistryValuesBySuffix.js';
 import { listParentXmlFilesForType } from '../metadata/listParentXmlFiles.js';
 import { resolveEffectiveMetadataTypes } from '../metadata/parseManifest.js';
 import { getRepoRoot } from '../service/core/getRepoRoot.js';
@@ -70,6 +71,20 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
     postpurge: false,
   };
 
+  // Resolve every requested type's directoryName up front so the filesystem walk below covers
+  // all of them in one pass, instead of each type re-walking the whole package directory tree.
+  // Unsupported/unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call
+  // below still throws (and, in manifest mode, is caught/logged there) exactly as it does today.
+  const directoryNames = new Set<string>();
+  for (const metadataType of effectiveTypes) {
+    try {
+      directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
+    } catch {
+      /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+    }
+  }
+  const pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, undefined);
+
   const typeLimit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);
   const typeResults: TypeVerifyResult[] = await Promise.all(
     effectiveTypes.map((metadataType) =>
@@ -85,6 +100,7 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
             ignoreDirs,
             undefined,
             typeResolved.uniqueIdElements,
+            pathIndex,
           ));
         } catch (err) {
           /* istanbul ignore if -- @preserve: preserves non-manifest behavior; unreachable via known CLI types */

--- a/src/metadata/getPackageDirectories.ts
+++ b/src/metadata/getPackageDirectories.ts
@@ -6,11 +6,14 @@ import { IGNORE_FILE, SFDX_PROJECT_FILE_NAME } from '../helpers/constants.js';
 import { SfdxProject } from '../helpers/types.js';
 import { getRepoRoot } from '../service/core/getRepoRoot.js';
 
-export async function getPackageDirectories(
-  metaDirectory: string,
+/**
+ * Resolves repoRoot/ignorePath/package-directory list once, shared by both
+ * `getPackageDirectories` (single target) and `buildPackageDirectoryIndex` (batched).
+ */
+async function resolvePackageDirContext(
   ignoreDirs: string[] | undefined,
   repoRootOverride?: string,
-): Promise<{ metadataPaths: string[]; ignorePath: string }> {
+): Promise<{ ignorePath: string; packageDirectories: string[] }> {
   const { repoRoot, dxConfigFilePath } = repoRootOverride
     ? { repoRoot: repoRootOverride, dxConfigFilePath: join(repoRootOverride, SFDX_PROJECT_FILE_NAME) }
     : ((await getRepoRoot()) as { repoRoot: string; dxConfigFilePath: string });
@@ -22,19 +25,81 @@ export async function getPackageDirectories(
   // non-empty one by a real directory named after the mutant's placeholder text, which isn't a
   // meaningful test.
   const normalizedIgnoreDirs = (ignoreDirs ?? []).map((dir) => basename(dir));
-  const packageDirectories = sfdxProject.packageDirectories.map((directory) => resolve(repoRoot, directory.path));
+  const packageDirectories = sfdxProject.packageDirectories
+    .map((directory) => resolve(repoRoot, directory.path))
+    .filter((directory) => !normalizedIgnoreDirs.includes(basename(directory)));
 
-  const searchPromises = packageDirectories.map(async (directory) => {
-    if (!normalizedIgnoreDirs.includes(basename(directory))) {
-      return searchRecursively(directory, metaDirectory);
-    }
-    return [];
-  });
+  return { ignorePath, packageDirectories };
+}
+
+export async function getPackageDirectories(
+  metaDirectory: string,
+  ignoreDirs: string[] | undefined,
+  repoRootOverride?: string,
+): Promise<{ metadataPaths: string[]; ignorePath: string }> {
+  const { ignorePath, packageDirectories } = await resolvePackageDirContext(ignoreDirs, repoRootOverride);
+
+  const searchPromises = packageDirectories.map((directory) => searchRecursively(directory, metaDirectory));
 
   const results = await Promise.all(searchPromises);
   const metadataPaths = results.flat().map((filePath) => resolve(filePath));
 
   return { metadataPaths, ignorePath };
+}
+
+/**
+ * Resolves matching directories for every name in `directoryNames` in a single shared walk per
+ * package directory, instead of one full walk per metadata type. Preserves the exact per-name
+ * semantics of `getPackageDirectories`/`searchRecursively` — including "don't recurse into an
+ * already-matched directory for that same name" — while allowing a different name's directory to
+ * still be found nested beneath one that already matched another name (since independent
+ * single-target calls, run separately per type today, would find it too).
+ */
+export async function buildPackageDirectoryIndex(
+  directoryNames: Iterable<string>,
+  ignoreDirs: string[] | undefined,
+  repoRootOverride?: string,
+): Promise<{ index: Map<string, string[]>; ignorePath: string }> {
+  const { ignorePath, packageDirectories } = await resolvePackageDirContext(ignoreDirs, repoRootOverride);
+  const watchedNames = new Set(directoryNames);
+  const index = new Map<string, string[]>();
+  for (const name of watchedNames) index.set(name, []);
+
+  await Promise.all(
+    packageDirectories.map((directory) => searchMultiTargetRecursively(directory, watchedNames, index, new Set())),
+  );
+
+  return { index, ignorePath };
+}
+
+async function searchMultiTargetRecursively(
+  dir: string,
+  watchedNames: Set<string>,
+  index: Map<string, string[]>,
+  matchedAncestors: ReadonlySet<string>,
+): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (_error) {
+    // Handle permission errors or other filesystem errors gracefully
+    /* istanbul ignore next -- @preserve: Filesystem permission errors are platform-specific */
+    return;
+  }
+
+  const dirs = entries.filter((entry) => entry.isDirectory());
+
+  await Promise.all(
+    dirs.map((entry) => {
+      const childPath = join(dir, entry.name);
+      const isFreshMatch = watchedNames.has(entry.name) && !matchedAncestors.has(entry.name);
+      if (isFreshMatch) {
+        (index.get(entry.name) as string[]).push(resolve(childPath));
+      }
+      const nextAncestors = isFreshMatch ? new Set([...matchedAncestors, entry.name]) : matchedAncestors;
+      return searchMultiTargetRecursively(childPath, watchedNames, index, nextAncestors);
+    }),
+  );
 }
 
 async function searchRecursively(dxDirectory: string, subDirectoryName: string): Promise<string[]> {

--- a/src/metadata/getRegistryValuesBySuffix.ts
+++ b/src/metadata/getRegistryValuesBySuffix.ts
@@ -35,13 +35,14 @@ function getChildSuffixMap(registryAccess: RegistryAccess): Map<string, Metadata
   return childSuffixMap;
 }
 
-export async function getRegistryValuesBySuffix(
-  metaSuffix: string,
-  command: string,
-  ignoreDirs: string[] | undefined,
-  repoRootOverride?: string,
-  uniqueIdOverride?: string,
-): Promise<{ metaAttributes: MetaAttributes; ignorePath: string }> {
+/**
+ * Resolves and validates the SDR registry entry for a metadata suffix (rejects `object`, unknown
+ * suffixes, and unsupported adapter strategies). Synchronous and side-effect free, so callers can
+ * use it to learn a type's `directoryName` ahead of time — e.g. to build a shared
+ * `buildPackageDirectoryIndex` covering every requested type in one filesystem walk — without
+ * duplicating this lookup logic.
+ */
+export function resolveMetadataTypeEntry(metaSuffix: string): MetadataType {
   if (metaSuffix === 'object') {
     throw Error('Custom Objects are not supported by this plugin.');
   }
@@ -64,13 +65,28 @@ export async function getRegistryValuesBySuffix(
     );
   }
 
+  return metadataTypeEntry;
+}
+
+export async function getRegistryValuesBySuffix(
+  metaSuffix: string,
+  command: string,
+  ignoreDirs: string[] | undefined,
+  repoRootOverride?: string,
+  uniqueIdOverride?: string,
+  pathIndex?: { index: Map<string, string[]>; ignorePath: string },
+): Promise<{ metaAttributes: MetaAttributes; ignorePath: string }> {
+  const metadataTypeEntry = resolveMetadataTypeEntry(metaSuffix);
+
   let uniqueIdElements: string | undefined;
   if (command === 'decompose') uniqueIdElements = uniqueIdOverride ?? getUniqueIdElements(metaSuffix);
-  const { metadataPaths, ignorePath } = await getPackageDirectories(
-    `${metadataTypeEntry.directoryName}`,
-    ignoreDirs,
-    repoRootOverride,
-  );
+
+  const { metadataPaths, ignorePath } = pathIndex
+    ? {
+        metadataPaths: pathIndex.index.get(`${metadataTypeEntry.directoryName}`) ?? [],
+        ignorePath: pathIndex.ignorePath,
+      }
+    : await getPackageDirectories(`${metadataTypeEntry.directoryName}`, ignoreDirs, repoRootOverride);
   if (metadataPaths.length === 0)
     throw Error(`No directories named ${metadataTypeEntry.directoryName} were found in any package directory.`);
 

--- a/test/units/getPackageDirectories.test.ts
+++ b/test/units/getPackageDirectories.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getPackageDirectories } from '../../src/metadata/getPackageDirectories.js';
+import { buildPackageDirectoryIndex, getPackageDirectories } from '../../src/metadata/getPackageDirectories.js';
 import { SFDX_CONFIG_FILE } from '../utils/constants.js';
 
 // `getPackageDirectories` resolves `<metaDirectory>` under each package dir declared
@@ -206,5 +206,95 @@ describe('getPackageDirectories', () => {
     const { metadataPaths } = await getPackageDirectories('permissionsets', undefined);
 
     expect(metadataPaths).toEqual([resolve(outer)]);
+  });
+});
+
+// `buildPackageDirectoryIndex` answers the same "find directories named X" query as
+// `getPackageDirectories`, but for every requested name in one shared walk instead of one walk
+// per name. It must reproduce each name's independent result exactly, including the
+// nested-same-name exclusion above, while still finding a *different* name's directory nested
+// inside a directory that already matched some other name (since two independent
+// `getPackageDirectories` calls, run separately per type today, would each find their own match
+// regardless of what the other call matched).
+describe('buildPackageDirectoryIndex', () => {
+  const originalCwd = process.cwd();
+  let project: Project;
+
+  beforeEach(async () => {
+    project = await makeProject();
+    process.chdir(project.root);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(project.root, { recursive: true, force: true });
+  });
+
+  it('resolves matches for multiple directory names in a single call', async () => {
+    const permsDir = join(project.forceAppDir, 'permissionsets');
+    const workflowsDir = join(project.altDir, 'workflows');
+    await mkdir(permsDir, { recursive: true });
+    await mkdir(workflowsDir, { recursive: true });
+
+    const { index } = await buildPackageDirectoryIndex(['permissionsets', 'workflows'], undefined);
+
+    expect(index.get('permissionsets')).toEqual([resolve(permsDir)]);
+    expect(index.get('workflows')).toEqual([resolve(workflowsDir)]);
+  });
+
+  it('returns an empty array for a requested name with no match anywhere', async () => {
+    const { index } = await buildPackageDirectoryIndex(['missingDir'], undefined);
+
+    expect(index.get('missingDir')).toEqual([]);
+  });
+
+  it('finds nested-depth matches, matching getPackageDirectories', async () => {
+    const deep = join(project.forceAppDir, 'main', 'default', 'permissionsets');
+    await mkdir(deep, { recursive: true });
+
+    const { index } = await buildPackageDirectoryIndex(['permissionsets'], undefined);
+
+    expect(index.get('permissionsets')).toEqual([resolve(deep)]);
+  });
+
+  it('honours ignoreDirs across every requested name', async () => {
+    const inForceApp = join(project.forceAppDir, 'permissionsets');
+    const inAlt = join(project.altDir, 'permissionsets');
+    await mkdir(inForceApp, { recursive: true });
+    await mkdir(inAlt, { recursive: true });
+
+    const { index } = await buildPackageDirectoryIndex(['permissionsets'], ['package']);
+
+    expect(index.get('permissionsets')).toEqual([resolve(inForceApp)]);
+  });
+
+  it('does not double-count a same-named directory nested inside its own match', async () => {
+    const outer = join(project.forceAppDir, 'permissionsets');
+    const nested = join(outer, 'permissionsets');
+    await mkdir(nested, { recursive: true });
+
+    const { index } = await buildPackageDirectoryIndex(['permissionsets'], undefined);
+
+    expect(index.get('permissionsets')).toEqual([resolve(outer)]);
+  });
+
+  it('still finds a different requested name nested inside a directory that already matched another name', async () => {
+    // "permissionsets" matches first; "workflows" nested inside it must still be found, since
+    // independent single-target searches (today's per-type calls) would each find their own name
+    // with no knowledge of the other.
+    const outer = join(project.forceAppDir, 'permissionsets');
+    const inner = join(outer, 'workflows');
+    await mkdir(inner, { recursive: true });
+
+    const { index } = await buildPackageDirectoryIndex(['permissionsets', 'workflows'], undefined);
+
+    expect(index.get('permissionsets')).toEqual([resolve(outer)]);
+    expect(index.get('workflows')).toEqual([resolve(inner)]);
+  });
+
+  it('returns the same ignorePath as getPackageDirectories', async () => {
+    const { ignorePath } = await buildPackageDirectoryIndex(['permissionsets'], undefined);
+
+    expect(ignorePath).toBe(resolve(project.root, '.sfdecomposerignore'));
   });
 });

--- a/test/units/getRegistryValuesBySuffix.test.ts
+++ b/test/units/getRegistryValuesBySuffix.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DEFAULT_UNIQUE_ID_ELEMENTS } from '../../src/helpers/constants.js';
+import { buildPackageDirectoryIndex } from '../../src/metadata/getPackageDirectories.js';
 import { getRegistryValuesBySuffix } from '../../src/metadata/getRegistryValuesBySuffix.js';
 import { SFDX_CONFIG_FILE } from '../utils/constants.js';
 
@@ -209,5 +210,33 @@ describe('getRegistryValuesBySuffix', () => {
     const { metaAttributes } = await getRegistryValuesBySuffix('permissionset', 'decompose', ['altpkg']);
 
     expect(metaAttributes.metadataPaths).toEqual([resolve(project.forceAppDir, 'permissionsets')]);
+  });
+
+  it('uses a pre-built pathIndex instead of walking the filesystem when provided', async () => {
+    const dir = join(project.forceAppDir, 'permissionsets');
+    await mkdir(dir, { recursive: true });
+
+    const withoutIndex = await getRegistryValuesBySuffix('permissionset', 'decompose', undefined);
+
+    const pathIndex = await buildPackageDirectoryIndex(['permissionsets'], undefined);
+    const withIndex = await getRegistryValuesBySuffix(
+      'permissionset',
+      'decompose',
+      undefined,
+      undefined,
+      undefined,
+      pathIndex,
+    );
+
+    expect(withIndex.metaAttributes).toEqual(withoutIndex.metaAttributes);
+    expect(withIndex.ignorePath).toBe(withoutIndex.ignorePath);
+  });
+
+  it('throws the same not-found error via pathIndex when the type directory is absent', async () => {
+    const pathIndex = await buildPackageDirectoryIndex(['animationRules'], undefined);
+
+    await expect(
+      getRegistryValuesBySuffix('animationRule', 'decompose', undefined, undefined, undefined, pathIndex),
+    ).rejects.toThrow('No directories named animationRules were found in any package directory.');
   });
 });


### PR DESCRIPTION
## Summary

- `getPackageDirectories` ran a full recursive filesystem walk **per metadata type** requested by decompose/recompose/verify, each processed in parallel but still N full walks total for N types.
- Investigated swapping this for SDR's `ComponentSet.fromSource`/`MetadataResolver`, since it walks a tree once and returns typed components for every type in one pass. That turned out to be unsafe: `getPackageDirectories`' contract is "find a directory by name, regardless of what's inside it" (tested with empty directories), while SDR's resolver requires real parseable metadata files to produce a component — pointed at an empty directory it returns nothing.
- Fixed the actual problem instead: batching. Added `buildPackageDirectoryIndex`, which resolves every requested type's directory in **one** shared walk per invocation instead of one walk per type. `getPackageDirectories` itself, and its existing tests, are untouched — still used standalone. `getRegistryValuesBySuffix` gained an optional trailing `pathIndex` param; omitted, it behaves exactly as before (used that way by two audit scripts and its own test suite).
- A genuine SDR-based opportunity remains for a follow-up: `listParentXmlFiles.ts`/`decomposeFileHandler.ts`'s hand-rolled per-file/child matching (bots, folder types, decomposed children) could become a like-for-like swap to `SourceComponent`/`getChildren()`, since those code paths already require real files to exist.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx biome check` on changed files
- [x] `npx vitest run` — full suite, 496/496 passing (including new cases for `buildPackageDirectoryIndex` and the `pathIndex` param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)