### PR TITLE
perf(metadata): reuse parseManifest's directory index, skip a redundant walk

### DIFF
--- a/src/core/decomposeMetadataTypes.ts
+++ b/src/core/decomposeMetadataTypes.ts
@@ -42,19 +42,26 @@ export async function decomposeMetadataTypes(options: DecomposeOptions): Promise
     return { metadata: [] };
   }
 
-  // Resolve every requested type's directoryName up front so the filesystem walk below covers
-  // all of them in one pass, instead of each type re-walking the whole package directory tree.
-  // Unsupported/unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call
-  // below still throws (and, in manifest mode, is caught/logged there) exactly as it does today.
-  const directoryNames = new Set<string>();
-  for (const metadataType of effectiveTypes) {
-    try {
-      directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
-    } catch {
-      /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+  // In manifest mode, parseManifest already built a directory index covering every type it
+  // found -- reuse it rather than walking the same tree a second time. Otherwise, resolve every
+  // requested type's directoryName up front so the filesystem walk below covers all of them in
+  // one pass, instead of each type re-walking the whole package directory tree. Unsupported/
+  // unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call below still
+  // throws (and, in manifest mode, is caught/logged there) exactly as it does today.
+  let pathIndex: { index: Map<string, string[]>; ignorePath: string };
+  if (manifestFilter) {
+    pathIndex = manifestFilter.directoryIndex;
+  } else {
+    const directoryNames = new Set<string>();
+    for (const metadataType of effectiveTypes) {
+      try {
+        directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
+      } catch {
+        /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+      }
     }
+    pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
   }
-  const pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
 
   // Limit concurrent metadata type processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);

--- a/src/core/recomposeMetadataTypes.ts
+++ b/src/core/recomposeMetadataTypes.ts
@@ -24,19 +24,26 @@ export async function recomposeMetadataTypes(options: RecomposeOptions): Promise
     return { metadata: [] };
   }
 
-  // Resolve every requested type's directoryName up front so the filesystem walk below covers
-  // all of them in one pass, instead of each type re-walking the whole package directory tree.
-  // Unsupported/unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call
-  // below still throws (and, in manifest mode, is caught/logged there) exactly as it does today.
-  const directoryNames = new Set<string>();
-  for (const metadataType of effectiveTypes) {
-    try {
-      directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
-    } catch {
-      /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+  // In manifest mode, parseManifest already built a directory index covering every type it
+  // found -- reuse it rather than walking the same tree a second time. Otherwise, resolve every
+  // requested type's directoryName up front so the filesystem walk below covers all of them in
+  // one pass, instead of each type re-walking the whole package directory tree. Unsupported/
+  // unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call below still
+  // throws (and, in manifest mode, is caught/logged there) exactly as it does today.
+  let pathIndex: { index: Map<string, string[]>; ignorePath: string };
+  if (manifestFilter) {
+    pathIndex = manifestFilter.directoryIndex;
+  } else {
+    const directoryNames = new Set<string>();
+    for (const metadataType of effectiveTypes) {
+      try {
+        directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
+      } catch {
+        /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+      }
     }
+    pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
   }
-  const pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
 
   // Limit concurrent metadata type processing to prevent file system overload
   const limit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);

--- a/src/core/verifyMetadataTypes.ts
+++ b/src/core/verifyMetadataTypes.ts
@@ -71,19 +71,26 @@ export async function verifyMetadataTypes(options: VerifyOptions): Promise<Verif
     postpurge: false,
   };
 
-  // Resolve every requested type's directoryName up front so the filesystem walk below covers
-  // all of them in one pass, instead of each type re-walking the whole package directory tree.
-  // Unsupported/unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call
-  // below still throws (and, in manifest mode, is caught/logged there) exactly as it does today.
-  const directoryNames = new Set<string>();
-  for (const metadataType of effectiveTypes) {
-    try {
-      directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
-    } catch {
-      /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+  // In manifest mode, parseManifest already built a directory index covering every type it
+  // found -- reuse it rather than walking the same tree a second time. Otherwise, resolve every
+  // requested type's directoryName up front so the filesystem walk below covers all of them in
+  // one pass, instead of each type re-walking the whole package directory tree. Unsupported/
+  // unknown suffixes are skipped here; the per-type getRegistryValuesBySuffix call below still
+  // throws (and, in manifest mode, is caught/logged there) exactly as it does today.
+  let pathIndex: { index: Map<string, string[]>; ignorePath: string };
+  if (manifestFilter) {
+    pathIndex = manifestFilter.directoryIndex;
+  } else {
+    const directoryNames = new Set<string>();
+    for (const metadataType of effectiveTypes) {
+      try {
+        directoryNames.add(`${resolveMetadataTypeEntry(metadataType).directoryName}`);
+      } catch {
+        /* istanbul ignore next -- @preserve: handled per-type by getRegistryValuesBySuffix below */
+      }
     }
+    pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, undefined);
   }
-  const pathIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, undefined);
 
   const typeLimit = pLimit(CONCURRENCY_LIMITS.METADATA_TYPES);
   const typeResults: TypeVerifyResult[] = await Promise.all(

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -14,6 +14,11 @@ export type ManifestFilter = {
   suffixes: string[];
   // Non-wildcard manifest members whose XML file was not found in local source.
   unresolvedComponents: Array<{ type: string; member: string }>;
+  // The package-directory index already built here to resolve manifest entries, covering every
+  // parent type's directoryName found in the manifest. Callers (decomposeMetadataTypes.ts etc.)
+  // reuse this directly in manifest mode instead of building a second, redundant one -- every
+  // suffix that survives into `suffixes` above already has real, verified directories in here.
+  directoryIndex: { index: Map<string, string[]>; ignorePath: string };
 };
 
 type GroupedMembers = {
@@ -64,7 +69,8 @@ export async function parseManifest(
   // per parent type (mirrors buildPackageDirectoryIndex's use in getRegistryValuesBySuffix.ts for
   // the non-manifest path).
   const directoryNames = new Set(groupedEntries.map(({ parentType }) => `${parentType.directoryName}`));
-  const { index: directoryIndex } = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
+  const directoryIndex = await buildPackageDirectoryIndex(directoryNames, ignoreDirs, repoRoot);
+  const { index: directoryPathsByName } = directoryIndex;
 
   const resolvedPerGroup = await Promise.all(
     groupedEntries.map(async ({ parentType, parentMembers, wildcard }) => {
@@ -72,7 +78,7 @@ export async function parseManifest(
       /* istanbul ignore next -- @preserve: parent metadata types always declare a suffix in SDR's registry. Stryker disable next-line all */
       if (!suffix) return undefined;
 
-      const typeDirs = directoryIndex.get(`${parentType.directoryName}`) ?? [];
+      const typeDirs = directoryPathsByName.get(`${parentType.directoryName}`) ?? [];
       // Stryker disable next-line ConditionalExpression
       if (typeDirs.length === 0) {
         const unresolvedMembers = wildcard ? [] : [...parentMembers];
@@ -135,7 +141,7 @@ export async function parseManifest(
     }
   }
 
-  return { parentXmlsBySuffix, suffixes: orderedSuffixes, unresolvedComponents };
+  return { parentXmlsBySuffix, suffixes: orderedSuffixes, unresolvedComponents, directoryIndex };
 }
 
 /**

--- a/test/units/parseManifest.test.ts
+++ b/test/units/parseManifest.test.ts
@@ -218,6 +218,26 @@ describe('parseManifest', () => {
     );
   });
 
+  it('exposes a directoryIndex covering every parent type found in the manifest, reusable by callers instead of a second walk', async () => {
+    // decomposeMetadataTypes.ts/recomposeMetadataTypes.ts/verifyMetadataTypes.ts reuse this
+    // directly in manifest mode instead of building a second buildPackageDirectoryIndex over the
+    // same tree. Assert it's populated for every distinct parent type the manifest declares.
+    const permissionsetDir = join(project.forceAppDir, 'permissionsets');
+    const workflowDir = join(project.forceAppDir, 'workflows');
+    await writeMetaFile(join(permissionsetDir, 'HR.permissionset-meta.xml'));
+    await writeMetaFile(join(workflowDir, 'Account.workflow-meta.xml'));
+
+    const manifest = await writeManifest(project.root, [
+      { name: 'PermissionSet', members: ['HR'] },
+      { name: 'Workflow', members: ['Account'] },
+    ]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.directoryIndex.index.get('permissionsets')).toEqual([resolve(permissionsetDir)]);
+    expect(result.directoryIndex.index.get('workflows')).toEqual([resolve(workflowDir)]);
+    expect(result.directoryIndex.ignorePath).toBe(resolve(project.root, '.sfdecomposerignore'));
+  });
+
   it('honours ignoreDirs by basename match, skipping the filtered package directory', async () => {
     const kept = join(project.forceAppDir, 'permissionsets', 'Keep.permissionset-meta.xml');
     const skipped = join(project.altDir, 'permissionsets', 'Skip.permissionset-meta.xml');


### PR DESCRIPTION
## Summary

- Follow-up to #549/#550. After both landed, `--manifest` mode ended up doing the shared package-directory walk **twice**: once for real inside `parseManifest` (#550, to resolve actual xml file paths), and once more, unconditionally, in `decomposeMetadataTypes.ts`/`recomposeMetadataTypes.ts`/`verifyMetadataTypes.ts`'s own pre-pass (#549) — even though in manifest mode `decomposeFileHandler`/`recomposeFileHandler` route through `decomposeFromManifest`/`recomposeFromManifest` and never touch `metaAttributes.metadataPaths` for actual path resolution.
- That second walk's only real job was feeding `getRegistryValuesBySuffix`'s "no directories named X found" check and one `basename(metadataPaths[0])` for forceignore/gitattributes bookkeeping — both already provably satisfied by `parseManifest` having found real xml files for that type.
- Fix: `ManifestFilter` now exposes the `{ index, ignorePath }` `parseManifest` already built internally. The three core files reuse it directly when `manifestFilter` is set, instead of building a second one. Non-manifest mode is unaffected (still builds its own index, as in #549).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx biome check`
- [x] `npx vitest run` — full suite, 497/497 passing. Added one test asserting `parseManifest`'s returned `directoryIndex` covers every parent type declared in the manifest, proving the value being reused is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)