### PR TITLE
feat(action): add a GitHub Action wrapping decompose/recompose/verify

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+lib
+dist
+.wireit
+.git
+.github
+test
+messages
+docs
+reports
+coverage
+perf-fixtures
+perf-results
+scripts
+*.md
+*.tgz
+*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,49 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "docs: regenerate command reference [skip ci]"
-          file_pattern: README.md           
+          file_pattern: README.md
+
+  # Publishes the GitHub Action's container image to GHCR so consumers pull a prebuilt image
+  # (action.yml's runs.image) instead of every workflow run building it fresh from the
+  # Dockerfile. Pushes the exact version (vX.Y.Z, immutable) and the floating major tag (vX,
+  # force-moved on every release within that major -- action.yml pins to the floating tag so it
+  # doesn't need a commit on every patch/minor release, only when the major version changes).
+  publish-image:
+    name: Publish Action image to GHCR
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags from package.json version
+        id: vars
+        run: |
+          VERSION="v$(node -p "require('./package.json').version")"
+          MAJOR="v$(node -p "require('./package.json').version.split('.')[0]")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/mcarvin8/sf-decomposer:${{ steps.vars.outputs.version }}
+            ghcr.io/mcarvin8/sf-decomposer:${{ steps.vars.outputs.major }}
+            ghcr.io/mcarvin8/sf-decomposer:latest
 
   smoke-test:
     needs: release

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -1,0 +1,184 @@
+# Manual smoke test: exercises the GitHub Action end to end (decompose, recompose, verify)
+# against a synthetic SFDX project, on real GitHub Actions infra.
+#
+# The Action's core functions require the working directory to be inside an SFDX project
+# (an sfdx-project.json ancestor) -- this repo's own checkout is not one, so unlike a
+# single-file-path tool this can't just point `uses: ./` at a bare checkout. Instead: the
+# Action's own source is checked out into `action-src/` (so `uses: ./action-src` builds this
+# PR's actual Dockerfile), while the job's primary workspace root is a synthetic SFDX project
+# written directly by this workflow -- that's where the container's cwd actually lands.
+name: Smoke test (GitHub Action)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/smoke-test-action.yml'
+      - 'action.yml'
+      - 'Dockerfile'
+      - 'src/action/**'
+      - 'src/core/**'
+      - 'src/metadata/**'
+      - 'src/service/**'
+      - 'src/helpers/**'
+
+permissions:
+  contents: read
+
+jobs:
+  decompose-recompose-verify-local:
+    name: decompose -> recompose -> verify round trip (local checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Action source
+        uses: actions/checkout@v7
+        with:
+          path: action-src
+
+      - name: Write a synthetic SFDX project into the workspace
+        run: |
+          mkdir -p force-app/permissionsets
+          cat > sfdx-project.json <<'EOF'
+          {
+            "packageDirectories": [{ "path": "force-app", "default": true }],
+            "namespace": "",
+            "sourceApiVersion": "62.0"
+          }
+          EOF
+          cat > force-app/permissionsets/Smoke_Test.permissionset-meta.xml <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+              <label>Smoke Test</label>
+              <hasActivationRequired>false</hasActivationRequired>
+              <userLicense>Salesforce</userLicense>
+              <objectPermissions>
+                  <object>Account</object>
+                  <allowRead>true</allowRead>
+                  <allowCreate>false</allowCreate>
+                  <allowEdit>false</allowEdit>
+                  <allowDelete>false</allowDelete>
+                  <viewAllRecords>false</viewAllRecords>
+                  <modifyAllRecords>false</modifyAllRecords>
+              </objectPermissions>
+          </PermissionSet>
+          EOF
+          git init -q
+          git add -A
+          git commit -q -m "synthetic fixture" --author="smoke-test <noreply@example.com>"
+
+      - name: Decompose
+        id: decompose
+        uses: ./action-src
+        with:
+          mode: decompose
+          metadata-type: permissionset
+
+      - name: Confirm decompose processed the type
+        run: |
+          echo "metadata: ${{ steps.decompose.outputs.metadata }}"
+          echo "types-count: ${{ steps.decompose.outputs.types-count }}"
+          if [ "${{ steps.decompose.outputs.types-count }}" != "1" ]; then
+            echo "Expected types-count 1, got '${{ steps.decompose.outputs.types-count }}'."
+            exit 1
+          fi
+          if [ ! -d force-app/permissionsets/Smoke_Test ]; then
+            echo "Expected a decomposed force-app/permissionsets/Smoke_Test directory."
+            ls -la force-app/permissionsets/
+            exit 1
+          fi
+
+      - name: Verify (no drift expected after a fresh decompose)
+        id: verify-clean
+        uses: ./action-src
+        with:
+          mode: verify
+          metadata-type: permissionset
+
+      - name: Confirm verify reported zero drift
+        run: |
+          echo "drift-count: ${{ steps.verify-clean.outputs.drift-count }}"
+          if [ "${{ steps.verify-clean.outputs.drift-count }}" != "0" ]; then
+            echo "Expected drift-count 0, got '${{ steps.verify-clean.outputs.drift-count }}'."
+            exit 1
+          fi
+
+      - name: Recompose
+        id: recompose
+        uses: ./action-src
+        with:
+          mode: recompose
+          metadata-type: permissionset
+          postpurge: 'true'
+
+      - name: Confirm recompose restored the original single file
+        run: |
+          echo "metadata: ${{ steps.recompose.outputs.metadata }}"
+          if [ ! -f force-app/permissionsets/Smoke_Test.permissionset-meta.xml ]; then
+            echo "Expected the recomposed force-app/permissionsets/Smoke_Test.permissionset-meta.xml file."
+            ls -la force-app/permissionsets/
+            exit 1
+          fi
+          if [ -d force-app/permissionsets/Smoke_Test ]; then
+            echo "postpurge should have removed the decomposed directory."
+            exit 1
+          fi
+          git diff --exit-code force-app/permissionsets/Smoke_Test.permissionset-meta.xml
+
+  invalid-mode-failure-path-local:
+    name: invalid mode failure path (local checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Action source
+        uses: actions/checkout@v7
+        with:
+          path: action-src
+
+      - name: Run with an invalid mode (expected to fail)
+        id: invalid-mode
+        continue-on-error: true
+        uses: ./action-src
+        with:
+          mode: bogus
+
+      - name: Confirm the step actually failed
+        run: |
+          if [ "${{ steps.invalid-mode.outcome }}" != "failure" ]; then
+            echo "Expected the invalid-mode step to fail (outcome was '${{ steps.invalid-mode.outcome }}')."
+            exit 1
+          fi
+          echo "Confirmed: an invalid mode correctly failed the step."
+
+  missing-metadata-and-manifest-failure-path-local:
+    name: missing metadata-type/manifest failure path (local checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Action source
+        uses: actions/checkout@v7
+        with:
+          path: action-src
+
+      - name: Write a synthetic SFDX project into the workspace
+        run: |
+          mkdir -p force-app
+          cat > sfdx-project.json <<'EOF'
+          {
+            "packageDirectories": [{ "path": "force-app", "default": true }],
+            "namespace": "",
+            "sourceApiVersion": "62.0"
+          }
+          EOF
+
+      - name: Decompose with neither metadata-type nor manifest set (expected to fail)
+        id: decompose-missing-input
+        continue-on-error: true
+        uses: ./action-src
+        with:
+          mode: decompose
+
+      - name: Confirm the step actually failed
+        run: |
+          if [ "${{ steps.decompose-missing-input.outcome }}" != "failure" ]; then
+            echo "Expected the step to fail (outcome was '${{ steps.decompose-missing-input.outcome }}')."
+            exit 1
+          fi
+          echo "Confirmed: missing metadata-type/manifest correctly failed the step."

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -1,12 +1,14 @@
-# Manual smoke test: exercises the GitHub Action end to end (decompose, recompose, verify)
-# against a synthetic SFDX project, on real GitHub Actions infra.
+# Manual smoke test: exercises the GitHub Action's container end to end (decompose, recompose,
+# verify) against a synthetic SFDX project, on real GitHub Actions infra.
 #
-# The Action's core functions require the working directory to be inside an SFDX project
-# (an sfdx-project.json ancestor) -- this repo's own checkout is not one, so unlike a
-# single-file-path tool this can't just point `uses: ./` at a bare checkout. Instead: the
-# Action's own source is checked out into `action-src/` (so `uses: ./action-src` builds this
-# PR's actual Dockerfile), while the job's primary workspace root is a synthetic SFDX project
-# written directly by this workflow -- that's where the container's cwd actually lands.
+# This builds and runs the Dockerfile directly with `docker build`/`docker run` instead of
+# `uses: ./` -- action.yml's `runs.image` now points at a published ghcr.io image (for fast
+# consumer cold starts; see release.yml's publish-image job), and a container action's
+# `runs.image` is either a Dockerfile path or a registry reference, never both. Testing via
+# `uses: ./` would validate the *last published image*, not this PR's actual Dockerfile changes.
+# Driving `docker run` directly re-creates just enough of what the real runner does (see the
+# INPUT_* env var convention and the GITHUB_OUTPUT file @actions/core writes to) to test this
+# PR's container for real.
 name: Smoke test (GitHub Action)
 
 on:
@@ -16,6 +18,7 @@ on:
       - '.github/workflows/smoke-test-action.yml'
       - 'action.yml'
       - 'Dockerfile'
+      - 'docker/**'
       - 'src/action/**'
       - 'src/core/**'
       - 'src/metadata/**'
@@ -27,13 +30,188 @@ permissions:
 
 jobs:
   decompose-recompose-verify-local:
-    name: decompose -> recompose -> verify round trip (local checkout)
+    name: decompose -> recompose -> verify round trip (this PR's Dockerfile)
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Action source
+      - name: Checkout
         uses: actions/checkout@v7
-        with:
-          path: action-src
+
+      - name: Build the Action image from this PR's Dockerfile
+        run: docker build -t sf-decomposer-action:pr .
+
+      - name: Write a synthetic SFDX project into the workspace
+        run: |
+          mkdir -p fixture/force-app/permissionsets
+          cat > fixture/sfdx-project.json <<'EOF'
+          {
+            "packageDirectories": [{ "path": "force-app", "default": true }],
+            "namespace": "",
+            "sourceApiVersion": "62.0"
+          }
+          EOF
+          cat > fixture/force-app/permissionsets/Smoke_Test.permissionset-meta.xml <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+              <label>Smoke Test</label>
+              <hasActivationRequired>false</hasActivationRequired>
+              <userLicense>Salesforce</userLicense>
+              <objectPermissions>
+                  <object>Account</object>
+                  <allowRead>true</allowRead>
+                  <allowCreate>false</allowCreate>
+                  <allowEdit>false</allowEdit>
+                  <allowDelete>false</allowDelete>
+                  <viewAllRecords>false</viewAllRecords>
+                  <modifyAllRecords>false</modifyAllRecords>
+              </objectPermissions>
+          </PermissionSet>
+          EOF
+
+      - name: Decompose
+        run: |
+          : > /tmp/decompose-output.txt
+          docker run --rm \
+            -e INPUT_MODE=decompose \
+            -e "INPUT_METADATA-TYPE=permissionset" \
+            -e GITHUB_OUTPUT=/github/output.txt \
+            -v /tmp/decompose-output.txt:/github/output.txt \
+            -v "$PWD/fixture":/github/workspace \
+            -w /github/workspace \
+            sf-decomposer-action:pr
+          cat /tmp/decompose-output.txt
+
+      - name: Confirm decompose processed the type
+        run: |
+          TYPES_COUNT=$(grep '^types-count=' /tmp/decompose-output.txt | cut -d= -f2)
+          echo "types-count: $TYPES_COUNT"
+          if [ "$TYPES_COUNT" != "1" ]; then
+            echo "Expected types-count 1, got '$TYPES_COUNT'."
+            exit 1
+          fi
+          if [ ! -d fixture/force-app/permissionsets/Smoke_Test ]; then
+            echo "Expected a decomposed force-app/permissionsets/Smoke_Test directory."
+            ls -la fixture/force-app/permissionsets/
+            exit 1
+          fi
+
+      - name: Verify (no drift expected after a fresh decompose)
+        run: |
+          : > /tmp/verify-output.txt
+          docker run --rm \
+            -e INPUT_MODE=verify \
+            -e "INPUT_METADATA-TYPE=permissionset" \
+            -e GITHUB_OUTPUT=/github/output.txt \
+            -v /tmp/verify-output.txt:/github/output.txt \
+            -v "$PWD/fixture":/github/workspace \
+            -w /github/workspace \
+            sf-decomposer-action:pr
+          cat /tmp/verify-output.txt
+
+      - name: Confirm verify reported zero drift
+        run: |
+          DRIFT_COUNT=$(grep '^drift-count=' /tmp/verify-output.txt | cut -d= -f2)
+          echo "drift-count: $DRIFT_COUNT"
+          if [ "$DRIFT_COUNT" != "0" ]; then
+            echo "Expected drift-count 0, got '$DRIFT_COUNT'."
+            exit 1
+          fi
+
+      - name: Recompose
+        run: |
+          : > /tmp/recompose-output.txt
+          docker run --rm \
+            -e INPUT_MODE=recompose \
+            -e "INPUT_METADATA-TYPE=permissionset" \
+            -e INPUT_POSTPURGE=true \
+            -e GITHUB_OUTPUT=/github/output.txt \
+            -v /tmp/recompose-output.txt:/github/output.txt \
+            -v "$PWD/fixture":/github/workspace \
+            -w /github/workspace \
+            sf-decomposer-action:pr
+          cat /tmp/recompose-output.txt
+
+      - name: Confirm recompose restored the original single file
+        run: |
+          if [ ! -f fixture/force-app/permissionsets/Smoke_Test.permissionset-meta.xml ]; then
+            echo "Expected the recomposed force-app/permissionsets/Smoke_Test.permissionset-meta.xml file."
+            ls -la fixture/force-app/permissionsets/
+            exit 1
+          fi
+          if [ -d fixture/force-app/permissionsets/Smoke_Test ]; then
+            echo "postpurge should have removed the decomposed directory."
+            exit 1
+          fi
+          # Not a byte-for-byte comparison against the original: attribute/sibling reordering is
+          # an expected, non-failing outcome of a round trip (see the tool's own "reordered" vs
+          # "drift" distinction) -- the earlier verify step already confirmed zero semantic drift.
+          grep -q '<PermissionSet ' fixture/force-app/permissionsets/Smoke_Test.permissionset-meta.xml
+          grep -q '<object>Account</object>' fixture/force-app/permissionsets/Smoke_Test.permissionset-meta.xml
+
+  invalid-mode-failure-path-local:
+    name: invalid mode failure path (this PR's Dockerfile)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build the Action image from this PR's Dockerfile
+        run: docker build -t sf-decomposer-action:pr .
+
+      - name: Run with an invalid mode (expected to exit non-zero)
+        run: |
+          mkdir -p fixture
+          if docker run --rm \
+            -e INPUT_MODE=bogus \
+            -v "$PWD/fixture":/github/workspace \
+            -w /github/workspace \
+            sf-decomposer-action:pr; then
+            echo "Expected the container to exit non-zero for an invalid mode."
+            exit 1
+          fi
+          echo "Confirmed: an invalid mode correctly exited non-zero."
+
+  missing-metadata-and-manifest-failure-path-local:
+    name: missing metadata-type/manifest failure path (this PR's Dockerfile)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build the Action image from this PR's Dockerfile
+        run: docker build -t sf-decomposer-action:pr .
+
+      - name: Write a synthetic SFDX project into the workspace
+        run: |
+          mkdir -p fixture/force-app
+          cat > fixture/sfdx-project.json <<'EOF'
+          {
+            "packageDirectories": [{ "path": "force-app", "default": true }],
+            "namespace": "",
+            "sourceApiVersion": "62.0"
+          }
+          EOF
+
+      - name: Decompose with neither metadata-type nor manifest set (expected to exit non-zero)
+        run: |
+          if docker run --rm \
+            -e INPUT_MODE=decompose \
+            -v "$PWD/fixture":/github/workspace \
+            -w /github/workspace \
+            sf-decomposer-action:pr; then
+            echo "Expected the container to exit non-zero when neither metadata-type nor manifest is set."
+            exit 1
+          fi
+          echo "Confirmed: missing metadata-type/manifest correctly exited non-zero."
+
+  published-image-round-trip:
+    # Only runs on-demand (post-release), since the ghcr.io image action.yml now points at
+    # doesn't exist until the first release publishes it. Validates what consumers actually pull.
+    name: decompose -> verify round trip (published @v7)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
       - name: Write a synthetic SFDX project into the workspace
         run: |
@@ -65,12 +243,12 @@ jobs:
 
       - name: Decompose
         id: decompose
-        uses: ./action-src
+        uses: mcarvin8/sf-decomposer@v7
         with:
           mode: decompose
           metadata-type: permissionset
 
-      - name: Confirm decompose processed the type
+      - name: Show outputs and confirm the type processed
         run: |
           echo "metadata: ${{ steps.decompose.outputs.metadata }}"
           echo "types-count: ${{ steps.decompose.outputs.types-count }}"
@@ -78,108 +256,18 @@ jobs:
             echo "Expected types-count 1, got '${{ steps.decompose.outputs.types-count }}'."
             exit 1
           fi
-          if [ ! -d force-app/permissionsets/Smoke_Test ]; then
-            echo "Expected a decomposed force-app/permissionsets/Smoke_Test directory."
-            ls -la force-app/permissionsets/
-            exit 1
-          fi
 
-      - name: Verify (no drift expected after a fresh decompose)
-        id: verify-clean
-        uses: ./action-src
+      - name: Verify
+        id: verify
+        uses: mcarvin8/sf-decomposer@v7
         with:
           mode: verify
           metadata-type: permissionset
 
       - name: Confirm verify reported zero drift
         run: |
-          echo "drift-count: ${{ steps.verify-clean.outputs.drift-count }}"
-          if [ "${{ steps.verify-clean.outputs.drift-count }}" != "0" ]; then
-            echo "Expected drift-count 0, got '${{ steps.verify-clean.outputs.drift-count }}'."
+          echo "drift-count: ${{ steps.verify.outputs.drift-count }}"
+          if [ "${{ steps.verify.outputs.drift-count }}" != "0" ]; then
+            echo "Expected drift-count 0, got '${{ steps.verify.outputs.drift-count }}'."
             exit 1
           fi
-
-      - name: Recompose
-        id: recompose
-        uses: ./action-src
-        with:
-          mode: recompose
-          metadata-type: permissionset
-          postpurge: 'true'
-
-      - name: Confirm recompose restored the original single file
-        run: |
-          echo "metadata: ${{ steps.recompose.outputs.metadata }}"
-          if [ ! -f force-app/permissionsets/Smoke_Test.permissionset-meta.xml ]; then
-            echo "Expected the recomposed force-app/permissionsets/Smoke_Test.permissionset-meta.xml file."
-            ls -la force-app/permissionsets/
-            exit 1
-          fi
-          if [ -d force-app/permissionsets/Smoke_Test ]; then
-            echo "postpurge should have removed the decomposed directory."
-            exit 1
-          fi
-          # Not a byte-for-byte comparison against the original: attribute/sibling reordering is
-          # an expected, non-failing outcome of a round trip (see the tool's own "reordered" vs
-          # "drift" distinction) -- the earlier verify step already confirmed zero semantic drift.
-          grep -q '<PermissionSet ' force-app/permissionsets/Smoke_Test.permissionset-meta.xml
-          grep -q '<object>Account</object>' force-app/permissionsets/Smoke_Test.permissionset-meta.xml
-
-  invalid-mode-failure-path-local:
-    name: invalid mode failure path (local checkout)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Action source
-        uses: actions/checkout@v7
-        with:
-          path: action-src
-
-      - name: Run with an invalid mode (expected to fail)
-        id: invalid-mode
-        continue-on-error: true
-        uses: ./action-src
-        with:
-          mode: bogus
-
-      - name: Confirm the step actually failed
-        run: |
-          if [ "${{ steps.invalid-mode.outcome }}" != "failure" ]; then
-            echo "Expected the invalid-mode step to fail (outcome was '${{ steps.invalid-mode.outcome }}')."
-            exit 1
-          fi
-          echo "Confirmed: an invalid mode correctly failed the step."
-
-  missing-metadata-and-manifest-failure-path-local:
-    name: missing metadata-type/manifest failure path (local checkout)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Action source
-        uses: actions/checkout@v7
-        with:
-          path: action-src
-
-      - name: Write a synthetic SFDX project into the workspace
-        run: |
-          mkdir -p force-app
-          cat > sfdx-project.json <<'EOF'
-          {
-            "packageDirectories": [{ "path": "force-app", "default": true }],
-            "namespace": "",
-            "sourceApiVersion": "62.0"
-          }
-          EOF
-
-      - name: Decompose with neither metadata-type nor manifest set (expected to fail)
-        id: decompose-missing-input
-        continue-on-error: true
-        uses: ./action-src
-        with:
-          mode: decompose
-
-      - name: Confirm the step actually failed
-        run: |
-          if [ "${{ steps.decompose-missing-input.outcome }}" != "failure" ]; then
-            echo "Expected the step to fail (outcome was '${{ steps.decompose-missing-input.outcome }}')."
-            exit 1
-          fi
-          echo "Confirmed: missing metadata-type/manifest correctly failed the step."

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -68,11 +68,23 @@ jobs:
           EOF
 
       - name: Decompose
+        # A real `uses:` invocation has GitHub Actions inject every action.yml `default:` value
+        # automatically, even when a workflow's `with:` block omits that input. Driving `docker
+        # run` directly bypasses that, so every default-valued input must be set explicitly here
+        # -- @actions/core.getBooleanInput throws (not "defaults to false") on a missing value.
         run: |
           : > /tmp/decompose-output.txt
           docker run --rm \
             -e INPUT_MODE=decompose \
             -e "INPUT_METADATA-TYPE=permissionset" \
+            -e INPUT_CONFIG=false \
+            -e INPUT_FORMAT=xml \
+            -e INPUT_STRATEGY=unique-id \
+            -e "INPUT_DECOMPOSE-NESTED-PERMISSIONS=false" \
+            -e INPUT_PREPURGE=false \
+            -e INPUT_POSTPURGE=false \
+            -e "INPUT_UPDATE-FORCEIGNORE=false" \
+            -e "INPUT_UPDATE-GITATTRIBUTES=false" \
             -e GITHUB_OUTPUT=/github/output.txt \
             -v /tmp/decompose-output.txt:/github/output.txt \
             -v "$PWD/fixture":/github/workspace \
@@ -100,6 +112,10 @@ jobs:
           docker run --rm \
             -e INPUT_MODE=verify \
             -e "INPUT_METADATA-TYPE=permissionset" \
+            -e INPUT_CONFIG=false \
+            -e INPUT_FORMAT=xml \
+            -e INPUT_STRATEGY=unique-id \
+            -e "INPUT_DECOMPOSE-NESTED-PERMISSIONS=false" \
             -e GITHUB_OUTPUT=/github/output.txt \
             -v /tmp/verify-output.txt:/github/output.txt \
             -v "$PWD/fixture":/github/workspace \
@@ -122,6 +138,7 @@ jobs:
           docker run --rm \
             -e INPUT_MODE=recompose \
             -e "INPUT_METADATA-TYPE=permissionset" \
+            -e INPUT_CONFIG=false \
             -e INPUT_POSTPURGE=true \
             -e GITHUB_OUTPUT=/github/output.txt \
             -v /tmp/recompose-output.txt:/github/output.txt \
@@ -195,6 +212,14 @@ jobs:
         run: |
           if docker run --rm \
             -e INPUT_MODE=decompose \
+            -e INPUT_CONFIG=false \
+            -e INPUT_FORMAT=xml \
+            -e INPUT_STRATEGY=unique-id \
+            -e "INPUT_DECOMPOSE-NESTED-PERMISSIONS=false" \
+            -e INPUT_PREPURGE=false \
+            -e INPUT_POSTPURGE=false \
+            -e "INPUT_UPDATE-FORCEIGNORE=false" \
+            -e "INPUT_UPDATE-GITATTRIBUTES=false" \
             -v "$PWD/fixture":/github/workspace \
             -w /github/workspace \
             sf-decomposer-action:pr; then

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -93,8 +93,11 @@ jobs:
           cat /tmp/decompose-output.txt
 
       - name: Confirm decompose processed the type
+        # @actions/core.setOutput always writes the `KEY<<DELIM / VALUE / DELIM` heredoc format
+        # (even for a plain single-line value like "1"), not `KEY=VALUE` -- extract the line
+        # right after the `types-count<<...` marker.
         run: |
-          TYPES_COUNT=$(grep '^types-count=' /tmp/decompose-output.txt | cut -d= -f2)
+          TYPES_COUNT=$(awk '/^types-count<</{f=1;next} f{print;exit}' /tmp/decompose-output.txt)
           echo "types-count: $TYPES_COUNT"
           if [ "$TYPES_COUNT" != "1" ]; then
             echo "Expected types-count 1, got '$TYPES_COUNT'."
@@ -125,7 +128,7 @@ jobs:
 
       - name: Confirm verify reported zero drift
         run: |
-          DRIFT_COUNT=$(grep '^drift-count=' /tmp/verify-output.txt | cut -d= -f2)
+          DRIFT_COUNT=$(awk '/^drift-count<</{f=1;next} f{print;exit}' /tmp/verify-output.txt)
           echo "drift-count: $DRIFT_COUNT"
           if [ "$DRIFT_COUNT" != "0" ]; then
             echo "Expected drift-count 0, got '$DRIFT_COUNT'."

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -62,9 +62,6 @@ jobs:
               </objectPermissions>
           </PermissionSet>
           EOF
-          git init -q
-          git add -A
-          git commit -q -m "synthetic fixture" --author="smoke-test <noreply@example.com>"
 
       - name: Decompose
         id: decompose
@@ -122,7 +119,11 @@ jobs:
             echo "postpurge should have removed the decomposed directory."
             exit 1
           fi
-          git diff --exit-code force-app/permissionsets/Smoke_Test.permissionset-meta.xml
+          # Not a byte-for-byte comparison against the original: attribute/sibling reordering is
+          # an expected, non-failing outcome of a round trip (see the tool's own "reordered" vs
+          # "drift" distinction) -- the earlier verify step already confirmed zero semantic drift.
+          grep -q '<PermissionSet ' force-app/permissionsets/Smoke_Test.permissionset-meta.xml
+          grep -q '<object>Account</object>' force-app/permissionsets/Smoke_Test.permissionset-meta.xml
 
   invalid-mode-failure-path-local:
     name: invalid mode failure path (local checkout)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# GitHub Action runtime image. Built fresh per run from this Dockerfile (action.yml points
+# `runs.image` at it directly) rather than a prebuilt/published image -- keeps this branch's
+# scope to a working Action; publishing a prebuilt image to a registry for faster cold starts
+# is a follow-up, not required for correctness.
+#
+# Two stages so the shipped image only carries production dependencies -- config-disassembler's
+# native addon is the reason this can't be a plain esbuild-bundled JS action: it ships
+# platform-specific prebuilt binaries as optional dependencies, resolved by npm at install time
+# for whatever platform actually runs `npm install`. Building (and installing) on the same
+# node:22-slim (glibc, linux/amd64) image the Action itself runs on guarantees the right one
+# (config-disassembler-linux-x64-gnu) lands in node_modules.
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npx tsc -p . --pretty \
+    && mkdir -p lib/metadata/registry \
+    && cp src/metadata/registry/metadataRegistry.json lib/metadata/registry/metadataRegistry.json
+
+# The runtime stage does NOT `npm ci` the repo's own package.json -- that lists
+# @oclif/core/@salesforce/core/@salesforce/sf-plugins-core as production dependencies too
+# (needed for the sf CLI plugin), which the Action's code never imports at runtime (verified:
+# nothing compiled from src/action, src/core, src/metadata, src/service, or src/helpers requires
+# any @oclif/@salesforce package -- the one @oclif/core import in helpers/types.ts is type-only
+# and is erased by tsc). Installing a standalone manifest with just the two packages the Action
+# actually needs keeps that CLI-plugin toolchain out of the image entirely.
+FROM node:22-slim
+WORKDIR /app
+# Keep these two versions in sync with root package.json's "config-disassembler" dependency
+# and "@actions/core" devDependency.
+COPY docker/action-runtime-package.json ./package.json
+RUN npm install --omit=dev
+COPY --from=build /app/lib ./lib
+
+ENTRYPOINT ["node", "lib/action/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,7 @@ COPY docker/action-runtime-package.json ./package.json
 RUN npm install --omit=dev
 COPY --from=build /app/lib ./lib
 
-ENTRYPOINT ["node", "lib/action/index.js"]
+# Absolute path: GitHub Actions runs container actions with `--workdir /github/workspace`
+# (the caller's checkout), overriding this image's own WORKDIR -- a relative path here would
+# resolve against the caller's workspace instead of /app and fail with MODULE_NOT_FOUND.
+ENTRYPOINT ["node", "/app/lib/action/index.js"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A Salesforce CLI plugin that **decomposes** large metadata XML files into smalle
   - [4. Configure Hooks](#4-configure-hooks-recommended)
 - [Daily Workflow](#daily-workflow)
 - [Commands](#commands)
+- [GitHub Action](#github-action)
 - [Reference](#reference)
   - [Decompose Strategies](#decompose-strategies)
   - [Supported Metadata](#supported-metadata)
@@ -215,7 +216,7 @@ EXAMPLES
   `sf decomposer decompose -x "manifest/package.xml" -m "flow"`
 ```
 
-_See code: [src/commands/decomposer/decompose.ts](https://github.com/mcarvin8/sf-decomposer/blob/v7.1.1/src/commands/decomposer/decompose.ts)_
+_See code: [src/commands/decomposer/decompose.ts](https://github.com/mcarvin8/sf-decomposer/blob/v7.2.0/src/commands/decomposer/decompose.ts)_
 
 ## `sf decomposer recompose`
 
@@ -261,7 +262,7 @@ EXAMPLES
   `sf decomposer recompose -x "manifest/package.xml" -m "flow"`
 ```
 
-_See code: [src/commands/decomposer/recompose.ts](https://github.com/mcarvin8/sf-decomposer/blob/v7.1.1/src/commands/decomposer/recompose.ts)_
+_See code: [src/commands/decomposer/recompose.ts](https://github.com/mcarvin8/sf-decomposer/blob/v7.2.0/src/commands/decomposer/recompose.ts)_
 
 ## `sf decomposer verify`
 
@@ -325,8 +326,56 @@ EXAMPLES
   `sf decomposer verify -x "manifest/package.xml" --config`
 ```
 
-_See code: [src/commands/decomposer/verify.ts](https://github.com/mcarvin8/sf-decomposer/blob/v7.1.1/src/commands/decomposer/verify.ts)_
+_See code: [src/commands/decomposer/verify.ts](https://github.com/mcarvin8/sf-decomposer/blob/v7.2.0/src/commands/decomposer/verify.ts)_
 <!-- commandsstop -->
+
+---
+
+## GitHub Action
+
+`decompose`, `recompose`, and `verify` are also available as a GitHub Action — a container action, so it needs **no Salesforce CLI and no `sf-decomposer` plugin install**. One action, dispatched by a `mode` input, mirrors the three CLI commands one-for-one: same flags (as inputs), same `.sfdecomposer.config.json` support via `config: true`.
+
+```yaml
+- uses: actions/checkout@v7
+
+- name: Decompose retrieved metadata
+  uses: mcarvin8/sf-decomposer@v1
+  with:
+    mode: decompose
+    metadata-type: |
+      permissionset
+      flow
+    postpurge: 'true'
+
+- name: Verify the round trip before merging
+  uses: mcarvin8/sf-decomposer@v1
+  with:
+    mode: verify
+    config: 'true'
+```
+
+Or point it at an existing `.sfdecomposer.config.json` for either step instead of listing flags: `with: { mode: decompose, config: 'true' }`.
+
+**Inputs** (all optional except `mode`; multi-value inputs are newline-separated, matching `actions/checkout`'s own multiline convention):
+
+| Input                           | Used by                  | Description                                                                          |
+| -------------------------------- | ------------------------- | -------------------------------------------------------------------------------------- |
+| `mode`                           | all                        | `decompose`, `recompose`, or `verify`.                                                 |
+| `metadata-type`                  | all                        | Metadata suffix(es) to process, one per line.                                          |
+| `manifest`                       | all                        | Path to a package.xml manifest to scope the run to.                                    |
+| `ignore-package-directory`       | all                        | Package director(y/ies) to skip, one per line.                                         |
+| `config`                         | all                        | Read settings from `.sfdecomposer.config.json`, same as the CLI's `--config`.          |
+| `format`                         | decompose, verify          | `xml`, `json`, `json5`, or `yaml`. Default `xml`.                                      |
+| `strategy`                       | decompose, verify          | `unique-id` or `grouped-by-tag`. Default `unique-id`.                                  |
+| `decompose-nested-permissions`   | decompose, verify          | With `grouped-by-tag`, further decompose permission set object/field permissions.      |
+| `prepurge`                       | decompose                  | Remove existing decomposed files before decomposing.                                   |
+| `postpurge`                      | decompose, recompose       | After decompose, remove originals; after recompose, remove decomposed files.           |
+| `update-forceignore`             | decompose                  | Append decomposed file patterns to `.forceignore`.                                     |
+| `update-gitattributes`           | decompose                  | Mark decomposed files as generated in `.gitattributes`.                                |
+
+**Outputs:** `metadata` (newline-separated list of processed suffixes), `types-count`; `verify` additionally sets `drift-count` and `reordered-count`, and fails the step when `drift-count` is greater than 0.
+
+See [`action.yml`](action.yml) for the full input/output reference.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ _See code: [src/commands/decomposer/verify.ts](https://github.com/mcarvin8/sf-de
 - uses: actions/checkout@v7
 
 - name: Decompose retrieved metadata
-  uses: mcarvin8/sf-decomposer@v1
+  uses: mcarvin8/sf-decomposer@v7
   with:
     mode: decompose
     metadata-type: |
@@ -351,7 +351,7 @@ _See code: [src/commands/decomposer/verify.ts](https://github.com/mcarvin8/sf-de
     postpurge: 'true'
 
 - name: Verify the round trip before merging
-  uses: mcarvin8/sf-decomposer@v1
+  uses: mcarvin8/sf-decomposer@v7
   with:
     mode: verify
     config: 'true'

--- a/README.md
+++ b/README.md
@@ -361,20 +361,20 @@ Or point it at an existing `.sfdecomposer.config.json` for either step instead o
 
 **Inputs** (all optional except `mode`; multi-value inputs are newline-separated, matching `actions/checkout`'s own multiline convention):
 
-| Input                           | Used by                  | Description                                                                          |
-| -------------------------------- | ------------------------- | -------------------------------------------------------------------------------------- |
-| `mode`                           | all                        | `decompose`, `recompose`, or `verify`.                                                 |
-| `metadata-type`                  | all                        | Metadata suffix(es) to process, one per line.                                          |
-| `manifest`                       | all                        | Path to a package.xml manifest to scope the run to.                                    |
-| `ignore-package-directory`       | all                        | Package director(y/ies) to skip, one per line.                                         |
-| `config`                         | all                        | Read settings from `.sfdecomposer.config.json`, same as the CLI's `--config`.          |
-| `format`                         | decompose, verify          | `xml`, `json`, `json5`, or `yaml`. Default `xml`.                                      |
-| `strategy`                       | decompose, verify          | `unique-id` or `grouped-by-tag`. Default `unique-id`.                                  |
-| `decompose-nested-permissions`   | decompose, verify          | With `grouped-by-tag`, further decompose permission set object/field permissions.      |
-| `prepurge`                       | decompose                  | Remove existing decomposed files before decomposing.                                   |
-| `postpurge`                      | decompose, recompose       | After decompose, remove originals; after recompose, remove decomposed files.           |
-| `update-forceignore`             | decompose                  | Append decomposed file patterns to `.forceignore`.                                     |
-| `update-gitattributes`           | decompose                  | Mark decomposed files as generated in `.gitattributes`.                                |
+| Input                          | Used by              | Description                                                                       |
+|--------------------------------|----------------------|-----------------------------------------------------------------------------------|
+| `mode`                         | all                  | `decompose`, `recompose`, or `verify`.                                            |
+| `metadata-type`                | all                  | Metadata suffix(es) to process, one per line.                                     |
+| `manifest`                     | all                  | Path to a package.xml manifest to scope the run to.                               |
+| `ignore-package-directory`     | all                  | Package director(y/ies) to skip, one per line.                                    |
+| `config`                       | all                  | Read settings from `.sfdecomposer.config.json`, same as the CLI's `--config`.     |
+| `format`                       | decompose, verify    | `xml`, `json`, `json5`, or `yaml`. Default `xml`.                                 |
+| `strategy`                     | decompose, verify    | `unique-id` or `grouped-by-tag`. Default `unique-id`.                             |
+| `decompose-nested-permissions` | decompose, verify    | With `grouped-by-tag`, further decompose permission set object/field permissions. |
+| `prepurge`                     | decompose            | Remove existing decomposed files before decomposing.                              |
+| `postpurge`                    | decompose, recompose | After decompose, remove originals; after recompose, remove decomposed files.      |
+| `update-forceignore`           | decompose            | Append decomposed file patterns to `.forceignore`.                                |
+| `update-gitattributes`         | decompose            | Mark decomposed files as generated in `.gitattributes`.                           |
 
 **Outputs:** `metadata` (newline-separated list of processed suffixes), `types-count`; `verify` additionally sets `drift-count` and `reordered-count`, and fails the step when `drift-count` is greater than 0.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fmcarvin8%2Fsf-decomposer%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/mcarvin8/sf-decomposer/main)
 [![Performance](https://img.shields.io/badge/Performance-Dashboard-58a6ff)](https://mcarvin8.github.io/sf-decomposer/dev/bench/runtime/)
 
-A Salesforce CLI plugin that **decomposes** large metadata XML files into smaller, version-control–friendly files (XML, JSON, YAML, JSON5), and **recomposes** them back into deployment-ready metadata.
+**Decomposes** large Salesforce metadata XML files into smaller, version-control–friendly files (XML, JSON, YAML, JSON5), and **recomposes** them back into deployment-ready metadata — as a Salesforce CLI plugin, or as a GitHub Action that needs neither the CLI nor a plugin install.
+
+- Using the Salesforce CLI? Start at [Setup](#setup).
+- Running this in CI without the CLI? Skip straight to [GitHub Action](#github-action).
 
 <!-- TABLE OF CONTENTS -->
 <details>

--- a/action.yml
+++ b/action.yml
@@ -63,4 +63,8 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  # Pinned to the current major version's floating tag (moved to the latest release within v7 by
+  # .github/workflows/release.yml's publish-image job on every release) so consumers pull a
+  # prebuilt image instead of every run building one from the Dockerfile. Only needs a commit
+  # here when the major version bumps, not on every patch/minor release.
+  image: 'docker://ghcr.io/mcarvin8/sf-decomposer:v7'

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,66 @@
+name: 'SF Decomposer'
+description: 'Decompose, recompose, and verify Salesforce metadata XML without the Salesforce CLI.'
+author: 'Matt Carvin'
+branding:
+  icon: 'scissors'
+  color: 'blue'
+
+inputs:
+  mode:
+    description: "Command to run: 'decompose', 'recompose', or 'verify'."
+    required: true
+  metadata-type:
+    description: 'Metadata suffix(es) to process, one per line (e.g. "permissionset").'
+    required: false
+  manifest:
+    description: 'Path to a package.xml manifest to scope the run to.'
+    required: false
+  ignore-package-directory:
+    description: 'Package director(y/ies) to skip, one per line.'
+    required: false
+  config:
+    description: 'Read settings from .sfdecomposer.config.json in the repo root, same as the CLI --config flag.'
+    required: false
+    default: 'false'
+  format:
+    description: "Decomposed file format: 'xml', 'json', 'json5', or 'yaml'. Ignored in 'recompose' mode."
+    required: false
+    default: 'xml'
+  strategy:
+    description: "Decompose strategy: 'unique-id' or 'grouped-by-tag'. Ignored in 'recompose' mode."
+    required: false
+    default: 'unique-id'
+  decompose-nested-permissions:
+    description: 'With grouped-by-tag, further decompose permission set/muting permission set object and field permissions. Only used in decompose and verify mode.'
+    required: false
+    default: 'false'
+  prepurge:
+    description: 'Remove existing decomposed files before decomposing. Only used in decompose mode.'
+    required: false
+    default: 'false'
+  postpurge:
+    description: 'After decompose, remove originals; after recompose, remove decomposed files.'
+    required: false
+    default: 'false'
+  update-forceignore:
+    description: 'Append decomposed file patterns to .forceignore. Only used in decompose mode.'
+    required: false
+    default: 'false'
+  update-gitattributes:
+    description: 'Mark decomposed files as generated in .gitattributes. Only used in decompose mode.'
+    required: false
+    default: 'false'
+
+outputs:
+  metadata:
+    description: 'Newline-separated list of metadata suffixes that were processed.'
+  types-count:
+    description: 'Number of distinct metadata types processed.'
+  drift-count:
+    description: 'Verify mode only: number of files that drifted between the original tree and the round-tripped output.'
+  reordered-count:
+    description: 'Verify mode only: number of files whose only delta was sibling/attribute ordering.'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/docker/action-runtime-package.json
+++ b/docker/action-runtime-package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sf-decomposer-action-runtime",
+  "private": true,
+  "dependencies": {
+    "config-disassembler": "3.3.0",
+    "@actions/core": "3.0.1"
+  }
+}

--- a/docker/action-runtime-package.json
+++ b/docker/action-runtime-package.json
@@ -1,6 +1,7 @@
 {
   "name": "sf-decomposer-action-runtime",
   "private": true,
+  "type": "module",
   "dependencies": {
     "config-disassembler": "3.3.0",
     "@actions/core": "3.0.1"

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,6 +1,7 @@
 export default {
   entry: [
     'src/commands/decomposer/*.ts',
+    'src/action/*.ts',
     'src/hooks/*.ts',
     'bin/dev.js',
     'bin/run.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "config-disassembler": "3.3.0"
       },
       "devDependencies": {
+        "@actions/core": "3.0.1",
         "@biomejs/biome": "2.5.9",
         "@commitlint/cli": "21.2.2",
         "@commitlint/config-conventional": "21.2.2",
@@ -38,6 +39,55 @@
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alcalzone/ansi-tokenize": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "config-disassembler": "3.3.0"
   },
   "devDependencies": {
+    "@actions/core": "3.0.1",
     "@biomejs/biome": "2.5.9",
     "@commitlint/cli": "21.2.2",
     "@commitlint/config-conventional": "21.2.2",

--- a/src/action/decompose.ts
+++ b/src/action/decompose.ts
@@ -1,0 +1,69 @@
+'use strict';
+
+import * as core from '@actions/core';
+
+import { decomposeMetadataTypes } from '../core/decomposeMetadataTypes.js';
+import {
+  loadConfigFile,
+  parseConfigSuffixes,
+  resolveDefaultConfigPath,
+  validateConfigManifest,
+} from '../helpers/configOverrides.js';
+import { multilineInput, optionalInput, requireMetadataTypesOrManifest } from './inputs.js';
+
+export async function runDecompose(): Promise<void> {
+  let metadataTypes = multilineInput('metadata-type');
+  let manifest = optionalInput('manifest');
+  let ignoreDirs = multilineInput('ignore-package-directory');
+  let format = optionalInput('format') ?? 'xml';
+  let strategy = optionalInput('strategy') ?? 'unique-id';
+  let prepurge = core.getBooleanInput('prepurge');
+  let postpurge = core.getBooleanInput('postpurge');
+  let decomposeNestedPerms = core.getBooleanInput('decompose-nested-permissions');
+  let updateForceignore = core.getBooleanInput('update-forceignore');
+  let updateGitattributes = core.getBooleanInput('update-gitattributes');
+  let overrides;
+
+  if (core.getBooleanInput('config')) {
+    const config = await loadConfigFile(await resolveDefaultConfigPath());
+    metadataTypes ??= parseConfigSuffixes(config.metadataSuffixes);
+    const configManifest = !manifest ? config.manifest : undefined;
+    manifest ??= config.manifest;
+    ignoreDirs ??= parseConfigSuffixes(config.ignorePackageDirectories);
+    format = optionalInput('format') ?? config.decomposedFormat ?? 'xml';
+    strategy = optionalInput('strategy') ?? config.strategy ?? 'unique-id';
+    prepurge = prepurge || (config.prePurge ?? false);
+    postpurge = postpurge || (config.postPurge ?? false);
+    decomposeNestedPerms = decomposeNestedPerms || (config.decomposeNestedPermissions ?? false);
+    updateForceignore = updateForceignore || (config.updateForceignore ?? false);
+    updateGitattributes = updateGitattributes || (config.updateGitattributes ?? false);
+    overrides = config.overrides;
+
+    manifest = await validateConfigManifest({
+      configManifest,
+      metadataTypes,
+      manifest,
+      warn: (msg) => core.warning(msg),
+    });
+  }
+
+  requireMetadataTypesOrManifest(metadataTypes, manifest);
+
+  const result = await decomposeMetadataTypes({
+    metadataTypes,
+    prepurge,
+    postpurge,
+    format,
+    ignoreDirs,
+    strategy,
+    decomposeNestedPerms,
+    manifest,
+    overrides,
+    updateForceignore,
+    updateGitattributes,
+    log: (msg) => core.info(msg),
+  });
+
+  core.setOutput('metadata', result.metadata.join('\n'));
+  core.setOutput('types-count', result.metadata.length);
+}

--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+import { run } from './main.js';
+
+void run();

--- a/src/action/inputs.ts
+++ b/src/action/inputs.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+import * as core from '@actions/core';
+
+export function multilineInput(name: string): string[] | undefined {
+  const values = core
+    .getMultilineInput(name)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return values.length > 0 ? values : undefined;
+}
+
+export function optionalInput(name: string): string | undefined {
+  const value = core.getInput(name);
+  return value === '' ? undefined : value;
+}
+
+export function requireMetadataTypesOrManifest(
+  metadataTypes: string[] | undefined,
+  manifest: string | undefined,
+): void {
+  if (!metadataTypes?.length && !manifest) {
+    throw new Error(
+      "Either the 'metadata-type' or 'manifest' input must be set, or 'config' must be true with a config file that specifies metadataSuffixes or manifest.",
+    );
+  }
+}

--- a/src/action/main.ts
+++ b/src/action/main.ts
@@ -1,0 +1,25 @@
+'use strict';
+
+import * as core from '@actions/core';
+
+import { runDecompose } from './decompose.js';
+import { runRecompose } from './recompose.js';
+import { runVerify } from './verify.js';
+
+export async function run(): Promise<void> {
+  try {
+    const mode = core.getInput('mode', { required: true });
+
+    if (mode === 'decompose') {
+      await runDecompose();
+    } else if (mode === 'recompose') {
+      await runRecompose();
+    } else if (mode === 'verify') {
+      await runVerify();
+    } else {
+      core.setFailed(`Invalid mode "${mode}". Expected "decompose", "recompose", or "verify".`);
+    }
+  } catch (error) {
+    core.setFailed(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/action/recompose.ts
+++ b/src/action/recompose.ts
@@ -1,0 +1,48 @@
+'use strict';
+
+import * as core from '@actions/core';
+
+import { recomposeMetadataTypes } from '../core/recomposeMetadataTypes.js';
+import {
+  loadConfigFile,
+  parseConfigSuffixes,
+  resolveDefaultConfigPath,
+  validateConfigManifest,
+} from '../helpers/configOverrides.js';
+import { multilineInput, optionalInput, requireMetadataTypesOrManifest } from './inputs.js';
+
+export async function runRecompose(): Promise<void> {
+  let metadataTypes = multilineInput('metadata-type');
+  let manifest = optionalInput('manifest');
+  let ignoreDirs = multilineInput('ignore-package-directory');
+  let postpurge = core.getBooleanInput('postpurge');
+
+  if (core.getBooleanInput('config')) {
+    const config = await loadConfigFile(await resolveDefaultConfigPath());
+    metadataTypes ??= parseConfigSuffixes(config.metadataSuffixes);
+    const configManifest = !manifest ? config.manifest : undefined;
+    manifest ??= config.manifest;
+    ignoreDirs ??= parseConfigSuffixes(config.ignorePackageDirectories);
+    postpurge = postpurge || (config.postPurge ?? false);
+
+    manifest = await validateConfigManifest({
+      configManifest,
+      metadataTypes,
+      manifest,
+      warn: (msg) => core.warning(msg),
+    });
+  }
+
+  requireMetadataTypesOrManifest(metadataTypes, manifest);
+
+  const result = await recomposeMetadataTypes({
+    metadataTypes,
+    postpurge,
+    ignoreDirs,
+    manifest,
+    log: (msg) => core.info(msg),
+  });
+
+  core.setOutput('metadata', result.metadata.join('\n'));
+  core.setOutput('types-count', result.metadata.length);
+}

--- a/src/action/verify.ts
+++ b/src/action/verify.ts
@@ -1,0 +1,68 @@
+'use strict';
+
+import * as core from '@actions/core';
+
+import { verifyMetadataTypes } from '../core/verifyMetadataTypes.js';
+import {
+  loadConfigFile,
+  parseConfigSuffixes,
+  resolveDefaultConfigPath,
+  validateConfigManifest,
+} from '../helpers/configOverrides.js';
+import { multilineInput, optionalInput, requireMetadataTypesOrManifest } from './inputs.js';
+
+export async function runVerify(): Promise<void> {
+  let metadataTypes = multilineInput('metadata-type');
+  let manifest = optionalInput('manifest');
+  let ignoreDirs = multilineInput('ignore-package-directory');
+  let format = optionalInput('format') ?? 'xml';
+  let strategy = optionalInput('strategy') ?? 'unique-id';
+  let decomposeNestedPerms = core.getBooleanInput('decompose-nested-permissions');
+  let overrides;
+
+  if (core.getBooleanInput('config')) {
+    const config = await loadConfigFile(await resolveDefaultConfigPath());
+    metadataTypes ??= parseConfigSuffixes(config.metadataSuffixes);
+    const configManifest = !manifest ? config.manifest : undefined;
+    manifest ??= config.manifest;
+    ignoreDirs ??= parseConfigSuffixes(config.ignorePackageDirectories);
+    format = optionalInput('format') ?? config.decomposedFormat ?? 'xml';
+    strategy = optionalInput('strategy') ?? config.strategy ?? 'unique-id';
+    decomposeNestedPerms = decomposeNestedPerms || (config.decomposeNestedPermissions ?? false);
+    overrides = config.overrides;
+
+    manifest = await validateConfigManifest({
+      configManifest,
+      metadataTypes,
+      manifest,
+      warn: (msg) => core.warning(msg),
+    });
+  }
+
+  requireMetadataTypesOrManifest(metadataTypes, manifest);
+
+  const result = await verifyMetadataTypes({
+    metadataTypes,
+    format,
+    ignoreDirs,
+    strategy,
+    decomposeNestedPerms,
+    manifest,
+    overrides,
+    log: (msg) => core.info(msg),
+  });
+
+  core.setOutput('metadata', result.metadata.join('\n'));
+  core.setOutput('types-count', result.metadata.length);
+  core.setOutput('drift-count', result.drift.length);
+  core.setOutput('reordered-count', result.reordered.length);
+
+  if (result.drift.length > 0) {
+    for (const { path, reason } of result.drift) {
+      core.error(`${path}: ${reason}`);
+    }
+    core.setFailed(
+      `Round-trip verify failed: ${result.drift.length} file(s) drifted between the original tree and the round-tripped output. See the log above for the offending paths.`,
+    );
+  }
+}

--- a/test/units/actionDecompose.test.ts
+++ b/test/units/actionDecompose.test.ts
@@ -1,0 +1,154 @@
+'use strict';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getInputSpy,
+  getMultilineInputSpy,
+  getBooleanInputSpy,
+  setOutputSpy,
+  warningSpy,
+  decomposeMetadataTypesSpy,
+  loadConfigFileSpy,
+  resolveDefaultConfigPathSpy,
+  validateConfigManifestSpy,
+} = vi.hoisted(() => ({
+  getInputSpy: vi.fn(),
+  getMultilineInputSpy: vi.fn(),
+  getBooleanInputSpy: vi.fn(),
+  setOutputSpy: vi.fn(),
+  warningSpy: vi.fn(),
+  decomposeMetadataTypesSpy: vi.fn(),
+  loadConfigFileSpy: vi.fn(),
+  resolveDefaultConfigPathSpy: vi.fn(),
+  validateConfigManifestSpy: vi.fn(),
+}));
+
+vi.mock('@actions/core', () => ({
+  getInput: getInputSpy,
+  getMultilineInput: getMultilineInputSpy,
+  getBooleanInput: getBooleanInputSpy,
+  setOutput: setOutputSpy,
+  warning: warningSpy,
+}));
+
+vi.mock('../../src/core/decomposeMetadataTypes.js', () => ({
+  decomposeMetadataTypes: decomposeMetadataTypesSpy,
+}));
+
+vi.mock('../../src/helpers/configOverrides.js', () => ({
+  loadConfigFile: loadConfigFileSpy,
+  resolveDefaultConfigPath: resolveDefaultConfigPathSpy,
+  validateConfigManifest: validateConfigManifestSpy,
+  parseConfigSuffixes: (value: string | undefined) =>
+    value && value.trim() !== '.' ? value.split(',').map((s) => s.trim()) : undefined,
+}));
+
+const { runDecompose } = await import('../../src/action/decompose.js');
+
+type Inputs = {
+  strings?: Record<string, string>;
+  multiline?: Record<string, string[]>;
+  booleans?: Record<string, boolean>;
+};
+
+function setInputs({ strings = {}, multiline = {}, booleans = {} }: Inputs): void {
+  getInputSpy.mockImplementation((name: string) => strings[name] ?? '');
+  getMultilineInputSpy.mockImplementation((name: string) => multiline[name] ?? []);
+  getBooleanInputSpy.mockImplementation((name: string) => booleans[name] ?? false);
+}
+
+describe('runDecompose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    decomposeMetadataTypesSpy.mockResolvedValue({ metadata: ['permissionset'] });
+  });
+
+  it('throws when neither metadata-type nor manifest is set', async () => {
+    setInputs({});
+    await expect(runDecompose()).rejects.toThrow("Either the 'metadata-type' or 'manifest' input must be set");
+    expect(decomposeMetadataTypesSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls decomposeMetadataTypes with the given inputs and sets outputs on success', async () => {
+    setInputs({
+      multiline: { 'metadata-type': ['permissionset'] },
+      booleans: { prepurge: true, postpurge: false },
+      strings: { format: 'json', strategy: 'grouped-by-tag' },
+    });
+
+    await runDecompose();
+
+    expect(decomposeMetadataTypesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadataTypes: ['permissionset'],
+        prepurge: true,
+        postpurge: false,
+        format: 'json',
+        strategy: 'grouped-by-tag',
+      }),
+    );
+    expect(setOutputSpy).toHaveBeenCalledWith('metadata', 'permissionset');
+    expect(setOutputSpy).toHaveBeenCalledWith('types-count', 1);
+  });
+
+  it('defaults format to xml and strategy to unique-id when not provided', async () => {
+    setInputs({ multiline: { 'metadata-type': ['workflow'] } });
+
+    await runDecompose();
+
+    expect(decomposeMetadataTypesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'xml', strategy: 'unique-id' }),
+    );
+  });
+
+  it('merges config file values when config is true, without overriding explicit inputs', async () => {
+    setInputs({
+      booleans: { config: true, postpurge: true },
+    });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({
+      metadataSuffixes: 'permissionset,workflow',
+      prePurge: true,
+      postPurge: false,
+      decomposedFormat: 'yaml',
+      strategy: 'grouped-by-tag',
+      decomposeNestedPermissions: true,
+      updateForceignore: true,
+      updateGitattributes: true,
+      overrides: [{ metadataTypes: ['permissionset'] }],
+    });
+    validateConfigManifestSpy.mockResolvedValue(undefined);
+
+    await runDecompose();
+
+    expect(decomposeMetadataTypesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadataTypes: ['permissionset', 'workflow'],
+        prepurge: true,
+        // postpurge input (true) wins over config.postPurge (false) via `||`
+        postpurge: true,
+        format: 'yaml',
+        strategy: 'grouped-by-tag',
+        decomposeNestedPerms: true,
+        updateForceignore: true,
+        updateGitattributes: true,
+        overrides: [{ metadataTypes: ['permissionset'] }],
+      }),
+    );
+  });
+
+  it('forwards a warning from validateConfigManifest via core.warning', async () => {
+    setInputs({ booleans: { config: true } });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', manifest: 'manifest.xml' });
+    validateConfigManifestSpy.mockImplementation(async ({ warn }: { warn: (msg: string) => void }) => {
+      warn('manifest missing, falling back');
+      return undefined;
+    });
+
+    await runDecompose();
+
+    expect(warningSpy).toHaveBeenCalledWith('manifest missing, falling back');
+  });
+});

--- a/test/units/actionInputs.test.ts
+++ b/test/units/actionInputs.test.ts
@@ -1,0 +1,78 @@
+'use strict';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { multilineInput, optionalInput, requireMetadataTypesOrManifest } from '../../src/action/inputs.js';
+
+// These read directly from process.env using @actions/core's own INPUT_<NAME> convention
+// (uppercased, spaces -> underscores, hyphens preserved) rather than mocking @actions/core, so
+// the test doubles as a check that the convention itself is followed correctly.
+
+function envKey(name: string): string {
+  return `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
+}
+
+function setInput(name: string, value: string): void {
+  process.env[envKey(name)] = value;
+}
+
+function clearInput(name: string): void {
+  delete process.env[envKey(name)];
+}
+
+describe('multilineInput', () => {
+  afterEach(() => {
+    clearInput('metadata-type');
+  });
+
+  it('returns undefined when the input is unset', () => {
+    expect(multilineInput('metadata-type')).toBeUndefined();
+  });
+
+  it('returns undefined when the input is only whitespace/blank lines', () => {
+    setInput('metadata-type', '  \n\n  ');
+    expect(multilineInput('metadata-type')).toBeUndefined();
+  });
+
+  it('splits on newlines, trims each line, and drops blank lines', () => {
+    setInput('metadata-type', 'permissionset\n  flow  \n\nworkflow\n');
+    expect(multilineInput('metadata-type')).toEqual(['permissionset', 'flow', 'workflow']);
+  });
+});
+
+describe('optionalInput', () => {
+  afterEach(() => {
+    clearInput('manifest');
+  });
+
+  it('returns undefined when the input is unset', () => {
+    expect(optionalInput('manifest')).toBeUndefined();
+  });
+
+  it('returns the value when set', () => {
+    setInput('manifest', 'manifest/package.xml');
+    expect(optionalInput('manifest')).toBe('manifest/package.xml');
+  });
+});
+
+describe('requireMetadataTypesOrManifest', () => {
+  it('throws when both metadataTypes and manifest are absent', () => {
+    expect(() => requireMetadataTypesOrManifest(undefined, undefined)).toThrow(
+      "Either the 'metadata-type' or 'manifest' input must be set",
+    );
+  });
+
+  it('throws when metadataTypes is an empty array and manifest is absent', () => {
+    expect(() => requireMetadataTypesOrManifest([], undefined)).toThrow(
+      "Either the 'metadata-type' or 'manifest' input must be set",
+    );
+  });
+
+  it('does not throw when metadataTypes has at least one entry', () => {
+    expect(() => requireMetadataTypesOrManifest(['permissionset'], undefined)).not.toThrow();
+  });
+
+  it('does not throw when manifest is set, even with no metadataTypes', () => {
+    expect(() => requireMetadataTypesOrManifest(undefined, 'manifest/package.xml')).not.toThrow();
+  });
+});

--- a/test/units/actionMain.test.ts
+++ b/test/units/actionMain.test.ts
@@ -1,0 +1,79 @@
+'use strict';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getInputSpy, setFailedSpy, runDecomposeSpy, runRecomposeSpy, runVerifySpy } = vi.hoisted(() => ({
+  getInputSpy: vi.fn(),
+  setFailedSpy: vi.fn(),
+  runDecomposeSpy: vi.fn(),
+  runRecomposeSpy: vi.fn(),
+  runVerifySpy: vi.fn(),
+}));
+
+vi.mock('@actions/core', () => ({
+  getInput: getInputSpy,
+  setFailed: setFailedSpy,
+}));
+
+vi.mock('../../src/action/decompose.js', () => ({ runDecompose: runDecomposeSpy }));
+vi.mock('../../src/action/recompose.js', () => ({ runRecompose: runRecomposeSpy }));
+vi.mock('../../src/action/verify.js', () => ({ runVerify: runVerifySpy }));
+
+const { run } = await import('../../src/action/main.js');
+
+describe('run', () => {
+  beforeEach(() => {
+    getInputSpy.mockReset();
+    setFailedSpy.mockReset();
+    runDecomposeSpy.mockReset().mockResolvedValue(undefined);
+    runRecomposeSpy.mockReset().mockResolvedValue(undefined);
+    runVerifySpy.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('dispatches to runDecompose for mode "decompose"', async () => {
+    getInputSpy.mockReturnValue('decompose');
+    await run();
+    expect(runDecomposeSpy).toHaveBeenCalledOnce();
+    expect(runRecomposeSpy).not.toHaveBeenCalled();
+    expect(runVerifySpy).not.toHaveBeenCalled();
+    expect(setFailedSpy).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to runRecompose for mode "recompose"', async () => {
+    getInputSpy.mockReturnValue('recompose');
+    await run();
+    expect(runRecomposeSpy).toHaveBeenCalledOnce();
+    expect(runDecomposeSpy).not.toHaveBeenCalled();
+    expect(setFailedSpy).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to runVerify for mode "verify"', async () => {
+    getInputSpy.mockReturnValue('verify');
+    await run();
+    expect(runVerifySpy).toHaveBeenCalledOnce();
+    expect(setFailedSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails with a clear message for an unrecognized mode', async () => {
+    getInputSpy.mockReturnValue('bogus');
+    await run();
+    expect(setFailedSpy).toHaveBeenCalledWith('Invalid mode "bogus". Expected "decompose", "recompose", or "verify".');
+    expect(runDecomposeSpy).not.toHaveBeenCalled();
+    expect(runRecomposeSpy).not.toHaveBeenCalled();
+    expect(runVerifySpy).not.toHaveBeenCalled();
+  });
+
+  it('catches an Error thrown by the handler and calls setFailed with its message', async () => {
+    getInputSpy.mockReturnValue('decompose');
+    runDecomposeSpy.mockRejectedValue(new Error('boom'));
+    await run();
+    expect(setFailedSpy).toHaveBeenCalledWith('boom');
+  });
+
+  it('catches a non-Error thrown value and stringifies it for setFailed', async () => {
+    getInputSpy.mockReturnValue('decompose');
+    runDecomposeSpy.mockRejectedValue('not an Error instance');
+    await run();
+    expect(setFailedSpy).toHaveBeenCalledWith('not an Error instance');
+  });
+});

--- a/test/units/actionRecompose.test.ts
+++ b/test/units/actionRecompose.test.ts
@@ -1,0 +1,98 @@
+'use strict';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getInputSpy,
+  getMultilineInputSpy,
+  getBooleanInputSpy,
+  setOutputSpy,
+  recomposeMetadataTypesSpy,
+  loadConfigFileSpy,
+  resolveDefaultConfigPathSpy,
+  validateConfigManifestSpy,
+} = vi.hoisted(() => ({
+  getInputSpy: vi.fn(),
+  getMultilineInputSpy: vi.fn(),
+  getBooleanInputSpy: vi.fn(),
+  setOutputSpy: vi.fn(),
+  recomposeMetadataTypesSpy: vi.fn(),
+  loadConfigFileSpy: vi.fn(),
+  resolveDefaultConfigPathSpy: vi.fn(),
+  validateConfigManifestSpy: vi.fn(),
+}));
+
+vi.mock('@actions/core', () => ({
+  getInput: getInputSpy,
+  getMultilineInput: getMultilineInputSpy,
+  getBooleanInput: getBooleanInputSpy,
+  setOutput: setOutputSpy,
+  warning: vi.fn(),
+}));
+
+vi.mock('../../src/core/recomposeMetadataTypes.js', () => ({
+  recomposeMetadataTypes: recomposeMetadataTypesSpy,
+}));
+
+vi.mock('../../src/helpers/configOverrides.js', () => ({
+  loadConfigFile: loadConfigFileSpy,
+  resolveDefaultConfigPath: resolveDefaultConfigPathSpy,
+  validateConfigManifest: validateConfigManifestSpy,
+  parseConfigSuffixes: (value: string | undefined) =>
+    value && value.trim() !== '.' ? value.split(',').map((s) => s.trim()) : undefined,
+}));
+
+const { runRecompose } = await import('../../src/action/recompose.js');
+
+type Inputs = {
+  strings?: Record<string, string>;
+  multiline?: Record<string, string[]>;
+  booleans?: Record<string, boolean>;
+};
+
+function setInputs({ strings = {}, multiline = {}, booleans = {} }: Inputs): void {
+  getInputSpy.mockImplementation((name: string) => strings[name] ?? '');
+  getMultilineInputSpy.mockImplementation((name: string) => multiline[name] ?? []);
+  getBooleanInputSpy.mockImplementation((name: string) => booleans[name] ?? false);
+}
+
+describe('runRecompose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recomposeMetadataTypesSpy.mockResolvedValue({ metadata: ['permissionset', 'workflow'] });
+  });
+
+  it('throws when neither metadata-type nor manifest is set', async () => {
+    setInputs({});
+    await expect(runRecompose()).rejects.toThrow("Either the 'metadata-type' or 'manifest' input must be set");
+    expect(recomposeMetadataTypesSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls recomposeMetadataTypes with the given inputs and sets outputs on success', async () => {
+    setInputs({
+      multiline: { 'metadata-type': ['permissionset', 'workflow'] },
+      booleans: { postpurge: true },
+    });
+
+    await runRecompose();
+
+    expect(recomposeMetadataTypesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataTypes: ['permissionset', 'workflow'], postpurge: true }),
+    );
+    expect(setOutputSpy).toHaveBeenCalledWith('metadata', 'permissionset\nworkflow');
+    expect(setOutputSpy).toHaveBeenCalledWith('types-count', 2);
+  });
+
+  it('merges config file values when config is true', async () => {
+    setInputs({ booleans: { config: true } });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', postPurge: true });
+    validateConfigManifestSpy.mockResolvedValue(undefined);
+
+    await runRecompose();
+
+    expect(recomposeMetadataTypesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataTypes: ['permissionset'], postpurge: true }),
+    );
+  });
+});

--- a/test/units/actionRuntimeDeps.test.ts
+++ b/test/units/actionRuntimeDeps.test.ts
@@ -1,0 +1,35 @@
+'use strict';
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// docker/action-runtime-package.json pins the *only* two packages the GitHub Action's runtime
+// image installs (see Dockerfile) -- deliberately not the repo's own package.json, which also
+// lists the sf CLI plugin's @oclif/@salesforce dependencies. If those two versions drift from
+// what the repo actually depends on, the Action would silently ship a stale/mismatched
+// config-disassembler or @actions/core.
+
+const rootPackageJson = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+};
+const runtimePackageJson = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'docker/action-runtime-package.json'), 'utf-8'),
+) as { dependencies: Record<string, string> };
+
+describe('docker/action-runtime-package.json', () => {
+  it('pins config-disassembler to the same version as the repo dependency', () => {
+    expect(runtimePackageJson.dependencies['config-disassembler']).toBe(
+      rootPackageJson.dependencies['config-disassembler'],
+    );
+  });
+
+  it('pins @actions/core to the same version as the repo devDependency', () => {
+    expect(runtimePackageJson.dependencies['@actions/core']).toBe(rootPackageJson.devDependencies['@actions/core']);
+  });
+
+  it('declares no dependencies beyond config-disassembler and @actions/core', () => {
+    expect(Object.keys(runtimePackageJson.dependencies).sort()).toEqual(['@actions/core', 'config-disassembler']);
+  });
+});

--- a/test/units/actionVerify.test.ts
+++ b/test/units/actionVerify.test.ts
@@ -1,0 +1,137 @@
+'use strict';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getInputSpy,
+  getMultilineInputSpy,
+  getBooleanInputSpy,
+  setOutputSpy,
+  setFailedSpy,
+  errorSpy,
+  verifyMetadataTypesSpy,
+  loadConfigFileSpy,
+  resolveDefaultConfigPathSpy,
+  validateConfigManifestSpy,
+} = vi.hoisted(() => ({
+  getInputSpy: vi.fn(),
+  getMultilineInputSpy: vi.fn(),
+  getBooleanInputSpy: vi.fn(),
+  setOutputSpy: vi.fn(),
+  setFailedSpy: vi.fn(),
+  errorSpy: vi.fn(),
+  verifyMetadataTypesSpy: vi.fn(),
+  loadConfigFileSpy: vi.fn(),
+  resolveDefaultConfigPathSpy: vi.fn(),
+  validateConfigManifestSpy: vi.fn(),
+}));
+
+vi.mock('@actions/core', () => ({
+  getInput: getInputSpy,
+  getMultilineInput: getMultilineInputSpy,
+  getBooleanInput: getBooleanInputSpy,
+  setOutput: setOutputSpy,
+  setFailed: setFailedSpy,
+  error: errorSpy,
+  warning: vi.fn(),
+}));
+
+vi.mock('../../src/core/verifyMetadataTypes.js', () => ({
+  verifyMetadataTypes: verifyMetadataTypesSpy,
+}));
+
+vi.mock('../../src/helpers/configOverrides.js', () => ({
+  loadConfigFile: loadConfigFileSpy,
+  resolveDefaultConfigPath: resolveDefaultConfigPathSpy,
+  validateConfigManifest: validateConfigManifestSpy,
+  parseConfigSuffixes: (value: string | undefined) =>
+    value && value.trim() !== '.' ? value.split(',').map((s) => s.trim()) : undefined,
+}));
+
+const { runVerify } = await import('../../src/action/verify.js');
+
+type Inputs = {
+  strings?: Record<string, string>;
+  multiline?: Record<string, string[]>;
+  booleans?: Record<string, boolean>;
+};
+
+function setInputs({ strings = {}, multiline = {}, booleans = {} }: Inputs): void {
+  getInputSpy.mockImplementation((name: string) => strings[name] ?? '');
+  getMultilineInputSpy.mockImplementation((name: string) => multiline[name] ?? []);
+  getBooleanInputSpy.mockImplementation((name: string) => booleans[name] ?? false);
+}
+
+describe('runVerify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws when neither metadata-type nor manifest is set', async () => {
+    setInputs({});
+    await expect(runVerify()).rejects.toThrow("Either the 'metadata-type' or 'manifest' input must be set");
+    expect(verifyMetadataTypesSpy).not.toHaveBeenCalled();
+  });
+
+  it('sets outputs and does not fail when there is no drift', async () => {
+    setInputs({ multiline: { 'metadata-type': ['permissionset'] } });
+    verifyMetadataTypesSpy.mockResolvedValue({ metadata: ['permissionset'], drift: [], reordered: [] });
+
+    await runVerify();
+
+    expect(setOutputSpy).toHaveBeenCalledWith('metadata', 'permissionset');
+    expect(setOutputSpy).toHaveBeenCalledWith('types-count', 1);
+    expect(setOutputSpy).toHaveBeenCalledWith('drift-count', 0);
+    expect(setOutputSpy).toHaveBeenCalledWith('reordered-count', 0);
+    expect(setFailedSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs each drift path and fails the step when drift is found', async () => {
+    setInputs({ multiline: { 'metadata-type': ['permissionset'] } });
+    verifyMetadataTypesSpy.mockResolvedValue({
+      metadata: ['permissionset'],
+      drift: [
+        { path: 'force-app/permissionsets/A.permissionset-meta.xml', reason: 'content drift' },
+        { path: 'force-app/permissionsets/B.permissionset-meta.xml', reason: 'missing in round-trip output' },
+      ],
+      reordered: ['force-app/permissionsets/C.permissionset-meta.xml'],
+    });
+
+    await runVerify();
+
+    expect(setOutputSpy).toHaveBeenCalledWith('drift-count', 2);
+    expect(setOutputSpy).toHaveBeenCalledWith('reordered-count', 1);
+    expect(errorSpy).toHaveBeenCalledWith('force-app/permissionsets/A.permissionset-meta.xml: content drift');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'force-app/permissionsets/B.permissionset-meta.xml: missing in round-trip output',
+    );
+    expect(setFailedSpy).toHaveBeenCalledWith(
+      'Round-trip verify failed: 2 file(s) drifted between the original tree and the round-tripped output. See the log above for the offending paths.',
+    );
+  });
+
+  it('merges config file values when config is true', async () => {
+    setInputs({ booleans: { config: true } });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({
+      metadataSuffixes: 'permissionset',
+      decomposedFormat: 'json5',
+      strategy: 'grouped-by-tag',
+      decomposeNestedPermissions: true,
+    });
+    validateConfigManifestSpy.mockResolvedValue(undefined);
+    verifyMetadataTypesSpy.mockResolvedValue({ metadata: ['permissionset'], drift: [], reordered: [] });
+
+    await runVerify();
+
+    expect(verifyMetadataTypesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadataTypes: ['permissionset'],
+        format: 'json5',
+        strategy: 'grouped-by-tag',
+        decomposeNestedPerms: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- New GitHub Action (container action) wrapping `decompose`/`recompose`/`verify` behind one `mode`-dispatched action, mirroring `mcarvin8/sf-package-list`'s `action.yml` + `src/action/main.ts` pattern. Each mode's handler mirrors its CLI command closely: same flags (as inputs), same `.sfdecomposer.config.json` support via `config: true`.
- Runs as a **Docker container action**, not a bundled JS action like `sf-package-list`/`sf-package-combiner`:
  - `config-disassembler` ships a native (Rust/NAPI) per-platform binary — a single bundled JS file can only carry one platform's binary. Building the image on the same `node:22-slim` (glibc/linux-amd64) it runs on lets npm resolve the right one (`config-disassembler-linux-x64-gnu`) at image-build time.
  - The repo's own `package.json` also lists `@oclif/core`/`@salesforce/core`/`@salesforce/sf-plugins-core` as production deps (for the CLI plugin) that the Action never imports at runtime (verified against compiled output — the one `@oclif/core` import, in `helpers/types.ts`, is type-only and erased by `tsc`). A plain `npm ci --omit=dev` against that manifest would still drag the whole CLI toolchain into the image. The runtime stage instead installs a standalone two-package manifest (`docker/action-runtime-package.json`: `config-disassembler` + `@actions/core` only), kept in sync with the root manifest by `actionRuntimeDeps.test.ts`.
- New `smoke-test-action.yml`: decompose → verify → recompose round trip against a synthetic SFDX project, plus invalid-mode and missing-input failure-path checks. Runs on this PR.
- README: documents the Action (inputs/outputs/example), plus a light-touch pointer near the top so Action-only readers don't have to read CLI setup first.

## Scope notes
- Docker was unavailable in the environment this was built in — the image has not been built/run locally. `smoke-test-action.yml` is the first real validation and will run on this PR.
- Not included: publishing a prebuilt image to a registry (GHCR) for faster cold starts. `action.yml` currently builds from the `Dockerfile` on every run — a correct, complete container action on its own; the registry publish is a follow-up speed optimization.

## Test plan
- [x] `npx tsc -p . --noEmit`, `biome check src test`, `knip`, full unit suite (580 tests) all clean locally.
- [ ] `smoke-test-action.yml` (decompose/verify/recompose round trip + failure paths) — pending this PR's CI run.