### PR TITLE
chore(ci): move a floating major git tag on release, not just the image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,19 @@ jobs:
           NODE_AUTH_TOKEN="" npm publish --access public --tag latest --provenance
           echo "published=true" >> "$GITHUB_OUTPUT"
 
+      # release-please only ever creates the exact vX.Y.Z tag. action.yml pins the GitHub Action
+      # to a floating major-version tag (docker://ghcr.io/.../vX) so consumers using
+      # `uses: mcarvin8/sf-decomposer@vX` don't need to bump on every release -- but `@vX` only
+      # resolves if a real git tag vX exists and points at the latest vX.Y.Z. Move it here.
+      - name: Move floating major version tag
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          MAJOR="v$(node -p "require('./package.json').version.split('.')[0]")"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "$MAJOR"
+          git push origin "$MAJOR" --force
+
       # `npm publish` runs the `prepack` script (oclif manifest && oclif readme),
       # which regenerates README.md's Command Reference against the version
       # release-please just bumped. Push that back to main so the repo's README


### PR DESCRIPTION
## Summary
`action.yml` pins the GitHub Action to a floating major-version tag (`docker://ghcr.io/mcarvin8/sf-decomposer:v7`) so `uses: mcarvin8/sf-decomposer@v7` doesn't need bumping on every release. The `publish-image` job already moved that floating tag on the **image** side, but a `uses:` clause resolves `@v7` against a **git** tag on the repo first (to fetch `action.yml` at that ref) — and release-please only ever creates the exact `vX.Y.Z` tag, never a floating major one.

First real use of the published Action (triggered manually via `smoke-test-action.yml`'s `workflow_dispatch` job) failed:
```
Unable to resolve action `mcarvin8/sf-decomposer@v7`, unable to find version `v7`
```

Manually created and pushed the `v7` git tag (pointing at `v7.3.0`, the just-published release) to unblock immediately — this PR adds the automated step so it keeps moving on every future release, mirroring `mcarvin8/sf-package-list`'s existing "Move floating major version tag" step.

## Test plan
- [x] `v7` git tag manually pushed; re-running `smoke-test-action.yml`'s `workflow_dispatch` job now to confirm `uses: mcarvin8/sf-decomposer@v7` resolves.