### PR TITLE
test: restore 100% coverage on action callbacks and registry edge cases

### DIFF
--- a/src/metadata/getRegistryValuesBySuffix.ts
+++ b/src/metadata/getRegistryValuesBySuffix.ts
@@ -32,8 +32,8 @@ function getChildSuffixMap(registryAccess: RegistryAccess): Map<string, Metadata
       // is guaranteed (by the vendored registry's own invariants) to resolve to a real parentType
       // with a children.types entry for that key.
       const childEntry = parentType?.children?.types[childXmlNameLower];
-      /* v8 ignore next -- defensive guard; SDR registry always provides a suffix for child types */
       // Stryker disable next-line ConditionalExpression, OptionalChaining -- same registry invariant.
+      /* v8 ignore next -- defensive guard; SDR registry always provides a suffix for child types */
       if (childEntry?.suffix) {
         childSuffixMap.set(childEntry.suffix, childEntry);
       }

--- a/src/metadata/parseManifest.ts
+++ b/src/metadata/parseManifest.ts
@@ -82,10 +82,13 @@ export async function parseManifest(
   const resolvedPerGroup = await Promise.all(
     groupedEntries.map(async ({ parentType, parentMembers, wildcard }) => {
       const suffix = parentType.suffix;
-      /* istanbul ignore next -- @preserve: parent metadata types always declare a suffix in SDR's registry. */
       // Stryker disable next-line all
+      /* v8 ignore next -- @preserve: parent metadata types always declare a suffix in SDR's registry. */
       if (!suffix) return undefined;
 
+      /* v8 ignore next -- @preserve: `directoryNames` (built above from these same groups'
+         directoryName values) always seeds every key buildPackageDirectoryIndex returns, so
+         `.get()` here can never miss. */
       const typeDirs = directoryPathsByName.get(`${parentType.directoryName}`) ?? [];
       // Stryker disable next-line ConditionalExpression
       if (typeDirs.length === 0) {
@@ -129,8 +132,8 @@ export async function parseManifest(
   const unresolvedComponents: Array<{ type: string; member: string }> = [];
 
   for (const entry of resolvedPerGroup) {
-    /* istanbul ignore next -- @preserve: undefined only reachable via the suffix-less branch already ignored above. */
     // Stryker disable next-line ConditionalExpression
+    /* v8 ignore next -- @preserve: undefined only reachable via the suffix-less branch already ignored above. */
     if (!entry) continue;
     const { suffix, xmlPaths, unresolvedMembers } = entry;
 
@@ -140,8 +143,9 @@ export async function parseManifest(
 
     if (xmlPaths.size === 0) continue;
 
-    /* istanbul ignore else -- @preserve: multiple parent types sharing a suffix is not produced by SDR's registry. */
-    // Stryker disable next-line ConditionalExpression
+    // Multiple distinct parent types can share the same suffix in SDR's registry (e.g.
+    // AppointmentAssignmentPolicy and AppointmentSchedulingPolicy both use `.policy`), so a later
+    // group's xmlPaths must merge into the suffix's existing Set rather than overwrite it.
     if (!parentXmlsBySuffix.has(suffix)) {
       parentXmlsBySuffix.set(suffix, xmlPaths);
       orderedSuffixes.push(suffix);
@@ -203,8 +207,8 @@ async function resolveMemberXml(
   member: string,
 ): Promise<string | undefined> {
   const { suffix, strictDirectoryName, folderType } = parentType;
-  /* istanbul ignore next -- @preserve: types reaching this point always have a suffix. */
   // Stryker disable next-line all
+  /* v8 ignore next -- @preserve: types reaching this point always have a suffix. */
   if (!suffix) return undefined;
 
   // Labels type has a single file regardless of member name.
@@ -233,8 +237,8 @@ async function resolveMemberXml(
 
 async function listParentXmlPaths(typeDir: string, parentType: MetadataType): Promise<string[]> {
   const { suffix, strictDirectoryName } = parentType;
-  /* istanbul ignore next -- @preserve: types reaching this point always have a suffix. */
   // Stryker disable next-line all
+  /* v8 ignore next -- @preserve: types reaching this point always have a suffix. */
   if (!suffix) return [];
 
   const metaEnding = `.${suffix}-meta.xml`;

--- a/src/metadata/registry/registryAccess.ts
+++ b/src/metadata/registry/registryAccess.ts
@@ -31,8 +31,8 @@ export class RegistryAccess {
       // is guaranteed (by the vendored registry's own invariants) to resolve to a real parentType
       // with a children.types entry for that key.
       const childType = registry.types[parentTypeId]?.children?.types[lower];
-      /* v8 ignore next -- defensive guard; the vendored registry is always internally consistent */
       // Stryker disable next-line ConditionalExpression -- same registry invariant as above.
+      /* v8 ignore next 3 -- defensive guard; the vendored registry is always internally consistent */
       if (!childType) {
         throw new Error(`Metadata registry has no child type definition for '${lower}' under '${parentTypeId}'.`);
       }

--- a/src/metadata/registry/resolveManifestComponents.ts
+++ b/src/metadata/registry/resolveManifestComponents.ts
@@ -50,9 +50,9 @@ function resolveType(
   members: string[],
   parentType: MetadataType | undefined,
 ): MetadataType {
-  /* v8 ignore next 3 -- defensive guard; the only caller only invokes this once parentType and
-     type.folderType are both already known truthy (parentType is derived from type.folderType) */
   // Stryker disable next-line ConditionalExpression, LogicalOperator
+  /* v8 ignore next 2 -- defensive guard; the only caller only invokes this once parentType and
+     type.folderType are both already known truthy (parentType is derived from type.folderType) */
   if (!parentType || !type.folderType) {
     return type;
   }

--- a/test/units/actionDecompose.test.ts
+++ b/test/units/actionDecompose.test.ts
@@ -8,6 +8,7 @@ const {
   getBooleanInputSpy,
   setOutputSpy,
   warningSpy,
+  infoSpy,
   decomposeMetadataTypesSpy,
   loadConfigFileSpy,
   resolveDefaultConfigPathSpy,
@@ -18,6 +19,7 @@ const {
   getBooleanInputSpy: vi.fn(),
   setOutputSpy: vi.fn(),
   warningSpy: vi.fn(),
+  infoSpy: vi.fn(),
   decomposeMetadataTypesSpy: vi.fn(),
   loadConfigFileSpy: vi.fn(),
   resolveDefaultConfigPathSpy: vi.fn(),
@@ -30,6 +32,7 @@ vi.mock('@actions/core', () => ({
   getBooleanInput: getBooleanInputSpy,
   setOutput: setOutputSpy,
   warning: warningSpy,
+  info: infoSpy,
 }));
 
 vi.mock('../../src/core/decomposeMetadataTypes.js', () => ({
@@ -150,5 +153,33 @@ describe('runDecompose', () => {
     await runDecompose();
 
     expect(warningSpy).toHaveBeenCalledWith('manifest missing, falling back');
+  });
+
+  it('leaves configManifest undefined when an explicit manifest input is already provided', async () => {
+    setInputs({
+      strings: { manifest: 'explicit-manifest.xml' },
+      booleans: { config: true },
+    });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', manifest: 'config-manifest.xml' });
+    validateConfigManifestSpy.mockResolvedValue('explicit-manifest.xml');
+
+    await runDecompose();
+
+    expect(validateConfigManifestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ configManifest: undefined, manifest: 'explicit-manifest.xml' }),
+    );
+  });
+
+  it('forwards a log message from decomposeMetadataTypes via core.info', async () => {
+    setInputs({ multiline: { 'metadata-type': ['permissionset'] } });
+    decomposeMetadataTypesSpy.mockImplementation(async ({ log }: { log: (msg: string) => void }) => {
+      log('decomposing permissionset');
+      return { metadata: ['permissionset'] };
+    });
+
+    await runDecompose();
+
+    expect(infoSpy).toHaveBeenCalledWith('decomposing permissionset');
   });
 });

--- a/test/units/actionRecompose.test.ts
+++ b/test/units/actionRecompose.test.ts
@@ -7,6 +7,8 @@ const {
   getMultilineInputSpy,
   getBooleanInputSpy,
   setOutputSpy,
+  warningSpy,
+  infoSpy,
   recomposeMetadataTypesSpy,
   loadConfigFileSpy,
   resolveDefaultConfigPathSpy,
@@ -16,6 +18,8 @@ const {
   getMultilineInputSpy: vi.fn(),
   getBooleanInputSpy: vi.fn(),
   setOutputSpy: vi.fn(),
+  warningSpy: vi.fn(),
+  infoSpy: vi.fn(),
   recomposeMetadataTypesSpy: vi.fn(),
   loadConfigFileSpy: vi.fn(),
   resolveDefaultConfigPathSpy: vi.fn(),
@@ -27,7 +31,8 @@ vi.mock('@actions/core', () => ({
   getMultilineInput: getMultilineInputSpy,
   getBooleanInput: getBooleanInputSpy,
   setOutput: setOutputSpy,
-  warning: vi.fn(),
+  warning: warningSpy,
+  info: infoSpy,
 }));
 
 vi.mock('../../src/core/recomposeMetadataTypes.js', () => ({
@@ -94,5 +99,47 @@ describe('runRecompose', () => {
     expect(recomposeMetadataTypesSpy).toHaveBeenCalledWith(
       expect.objectContaining({ metadataTypes: ['permissionset'], postpurge: true }),
     );
+  });
+
+  it('leaves configManifest undefined when an explicit manifest input is already provided', async () => {
+    setInputs({
+      strings: { manifest: 'explicit-manifest.xml' },
+      booleans: { config: true },
+    });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', manifest: 'config-manifest.xml' });
+    validateConfigManifestSpy.mockResolvedValue('explicit-manifest.xml');
+
+    await runRecompose();
+
+    expect(validateConfigManifestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ configManifest: undefined, manifest: 'explicit-manifest.xml' }),
+    );
+  });
+
+  it('forwards a warning from validateConfigManifest via core.warning', async () => {
+    setInputs({ booleans: { config: true } });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', manifest: 'manifest.xml' });
+    validateConfigManifestSpy.mockImplementation(async ({ warn }: { warn: (msg: string) => void }) => {
+      warn('manifest missing, falling back');
+      return undefined;
+    });
+
+    await runRecompose();
+
+    expect(warningSpy).toHaveBeenCalledWith('manifest missing, falling back');
+  });
+
+  it('forwards a log message from recomposeMetadataTypes via core.info', async () => {
+    setInputs({ multiline: { 'metadata-type': ['permissionset'] } });
+    recomposeMetadataTypesSpy.mockImplementation(async ({ log }: { log: (msg: string) => void }) => {
+      log('recomposing permissionset');
+      return { metadata: ['permissionset'] };
+    });
+
+    await runRecompose();
+
+    expect(infoSpy).toHaveBeenCalledWith('recomposing permissionset');
   });
 });

--- a/test/units/actionVerify.test.ts
+++ b/test/units/actionVerify.test.ts
@@ -9,6 +9,8 @@ const {
   setOutputSpy,
   setFailedSpy,
   errorSpy,
+  warningSpy,
+  infoSpy,
   verifyMetadataTypesSpy,
   loadConfigFileSpy,
   resolveDefaultConfigPathSpy,
@@ -20,6 +22,8 @@ const {
   setOutputSpy: vi.fn(),
   setFailedSpy: vi.fn(),
   errorSpy: vi.fn(),
+  warningSpy: vi.fn(),
+  infoSpy: vi.fn(),
   verifyMetadataTypesSpy: vi.fn(),
   loadConfigFileSpy: vi.fn(),
   resolveDefaultConfigPathSpy: vi.fn(),
@@ -33,7 +37,8 @@ vi.mock('@actions/core', () => ({
   setOutput: setOutputSpy,
   setFailed: setFailedSpy,
   error: errorSpy,
-  warning: vi.fn(),
+  warning: warningSpy,
+  info: infoSpy,
 }));
 
 vi.mock('../../src/core/verifyMetadataTypes.js', () => ({
@@ -133,5 +138,49 @@ describe('runVerify', () => {
         decomposeNestedPerms: true,
       }),
     );
+  });
+
+  it('leaves configManifest undefined when an explicit manifest input is already provided', async () => {
+    setInputs({
+      strings: { manifest: 'explicit-manifest.xml' },
+      booleans: { config: true },
+    });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', manifest: 'config-manifest.xml' });
+    validateConfigManifestSpy.mockResolvedValue('explicit-manifest.xml');
+    verifyMetadataTypesSpy.mockResolvedValue({ metadata: ['permissionset'], drift: [], reordered: [] });
+
+    await runVerify();
+
+    expect(validateConfigManifestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ configManifest: undefined, manifest: 'explicit-manifest.xml' }),
+    );
+  });
+
+  it('forwards a warning from validateConfigManifest via core.warning', async () => {
+    setInputs({ booleans: { config: true } });
+    resolveDefaultConfigPathSpy.mockResolvedValue('/repo/.sfdecomposer.config.json');
+    loadConfigFileSpy.mockResolvedValue({ metadataSuffixes: 'permissionset', manifest: 'manifest.xml' });
+    validateConfigManifestSpy.mockImplementation(async ({ warn }: { warn: (msg: string) => void }) => {
+      warn('manifest missing, falling back');
+      return undefined;
+    });
+    verifyMetadataTypesSpy.mockResolvedValue({ metadata: ['permissionset'], drift: [], reordered: [] });
+
+    await runVerify();
+
+    expect(warningSpy).toHaveBeenCalledWith('manifest missing, falling back');
+  });
+
+  it('forwards a log message from verifyMetadataTypes via core.info', async () => {
+    setInputs({ multiline: { 'metadata-type': ['permissionset'] } });
+    verifyMetadataTypesSpy.mockImplementation(async ({ log }: { log: (msg: string) => void }) => {
+      log('verifying permissionset');
+      return { metadata: ['permissionset'], drift: [], reordered: [] };
+    });
+
+    await runVerify();
+
+    expect(infoSpy).toHaveBeenCalledWith('verifying permissionset');
   });
 });

--- a/test/units/getRegistryValuesBySuffix.test.ts
+++ b/test/units/getRegistryValuesBySuffix.test.ts
@@ -238,4 +238,15 @@ describe('getRegistryValuesBySuffix', () => {
       getRegistryValuesBySuffix('animationRule', 'decompose', undefined, undefined, undefined, pathIndex),
     ).rejects.toThrow('No directories named animationRules were found in any package directory.');
   });
+
+  it('falls back to an empty path list when the pathIndex has no entry at all for the type directory', async () => {
+    // A pathIndex built for a *different* set of directory names (unlike buildPackageDirectoryIndex's
+    // own always-seeded keys) has no `permissionsets` key whatsoever, exercising the `?? []` fallback
+    // rather than an existing-but-empty array.
+    const pathIndex = await buildPackageDirectoryIndex(['animationRules'], undefined);
+
+    await expect(
+      getRegistryValuesBySuffix('permissionset', 'decompose', undefined, undefined, undefined, pathIndex),
+    ).rejects.toThrow('No directories named permissionsets were found in any package directory.');
+  });
 });

--- a/test/units/parseManifest.test.ts
+++ b/test/units/parseManifest.test.ts
@@ -579,6 +579,27 @@ describe('parseManifest', () => {
     expect(result.unresolvedComponents).toEqual([]);
   });
 
+  it('merges xmlPaths from two distinct parent types that share the same registry suffix', async () => {
+    // AppointmentAssignmentPolicy and AppointmentSchedulingPolicy are distinct SDR registry types
+    // that both use the `.policy` suffix, so they land in separate `byParentType` groups but the
+    // same `parentXmlsBySuffix` entry -- exercising the else-branch merge (existing.add(xmlPath)).
+    const assignmentFile = join(project.forceAppDir, 'appointmentAssignmentPolicies', 'P1', 'P1.policy-meta.xml');
+    const schedulingFile = join(project.forceAppDir, 'appointmentSchedulingPolicies', 'P2', 'P2.policy-meta.xml');
+    await writeMetaFile(assignmentFile);
+    await writeMetaFile(schedulingFile);
+
+    const manifest = await writeManifest(project.root, [
+      { name: 'AppointmentAssignmentPolicy', members: ['P1'] },
+      { name: 'AppointmentSchedulingPolicy', members: ['P2'] },
+    ]);
+    const result = await parseManifest(manifest, undefined);
+
+    expect(result.suffixes).toEqual(['policy']);
+    expect(new Set(result.parentXmlsBySuffix.get('policy'))).toEqual(
+      new Set([resolve(assignmentFile), resolve(schedulingFile)]),
+    );
+  });
+
   it('reports only the member that failed to resolve when a group mixes a resolved and an unresolved member', async () => {
     const resolved = join(project.forceAppDir, 'permissionsets', 'Found.permissionset-meta.xml');
     await writeMetaFile(resolved);


### PR DESCRIPTION
## Summary
- Adds tests exercising the `log`/`warn` callback bodies in the decompose, recompose, and verify GitHub Actions
- Fixes several `v8-ignore`/`istanbul-ignore` comments that were misaligned (or using the wrong coverage provider's syntax) and weren't actually suppressing coverage on genuinely-unreachable registry-invariant guards
- One prior `istanbul-ignore` comment claimed a branch was unreachable when it wasn't (`AppointmentAssignmentPolicy` and `AppointmentSchedulingPolicy` both use the `.policy` suffix) — that branch is now covered by a real test instead of an ignore comment
- No source logic changed, only comment repositioning + new tests

Coverage: 100% statements/branches/functions/lines (was 98.85/97.54/98.03/99.2). 617 tests pass (was 607).

## Test plan
- [x] `npx vitest run --coverage` — 617 tests pass, 100/100/100/100 coverage
- [x] `tsc -p . --pretty --incremental` — clean
- [x] `biome check src test` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)