### PR TITLE
fix(deps): bump config-disassembler to 3.4.1

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.0",
+    "config-disassembler": "3.4.1",
     "@actions/core": "3.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.0"
+        "config-disassembler": "3.4.1"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7940,29 +7940,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.0.tgz",
-      "integrity": "sha512-1Uqc+f9ELtiPsnpuoUAOXJ5vRLUFowARV/wtmh3a964yePGbodcjEFQskD9vcsHNWerVQDGLplYn5fj1TGcJtA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.1.tgz",
+      "integrity": "sha512-aaH8DA0MHAAjdnTh9ioNbG3rwNk9zQDizzrlucsh1Rc4jM0nDej4LyH7ZvLMQ9e002/4h3ZTO1wyH8SUDPQ+qQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.0",
-        "config-disassembler-darwin-x64": "3.4.0",
-        "config-disassembler-linux-arm64-gnu": "3.4.0",
-        "config-disassembler-linux-arm64-musl": "3.4.0",
-        "config-disassembler-linux-x64-gnu": "3.4.0",
-        "config-disassembler-linux-x64-musl": "3.4.0",
-        "config-disassembler-win32-arm64-msvc": "3.4.0",
-        "config-disassembler-win32-ia32-msvc": "3.4.0",
-        "config-disassembler-win32-x64-msvc": "3.4.0"
+        "config-disassembler-darwin-arm64": "3.4.1",
+        "config-disassembler-darwin-x64": "3.4.1",
+        "config-disassembler-linux-arm64-gnu": "3.4.1",
+        "config-disassembler-linux-arm64-musl": "3.4.1",
+        "config-disassembler-linux-x64-gnu": "3.4.1",
+        "config-disassembler-linux-x64-musl": "3.4.1",
+        "config-disassembler-win32-arm64-msvc": "3.4.1",
+        "config-disassembler-win32-ia32-msvc": "3.4.1",
+        "config-disassembler-win32-x64-msvc": "3.4.1"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.0.tgz",
-      "integrity": "sha512-a8v1iStwVTykiLcncDP8rFdri70xaqa+kKDZ06/CUB3FLYjxRyt3xuqjwRJIk7anGcJZwJfhQ69E21Kg7LEryQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.1.tgz",
+      "integrity": "sha512-CtTrfXxov8sF1C+qycvdt5COs5Sz39X9j550cpj1RPTRuj6Yz89SG5ufcW6RBGMnnCCEfyY/LsoIaVIuGjk7XA==",
       "cpu": [
         "arm64"
       ],
@@ -7976,9 +7976,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.0.tgz",
-      "integrity": "sha512-JKbroZmgUBwM8tnHjySIgQp3BUohgznNMjZqHvnVv9uNJ4gJ6k6WjS5M/fiDR6ibIHnR/cMhBa4GlC4o+b0ZCg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.1.tgz",
+      "integrity": "sha512-PjqbcfAMYXgJt3NIpQVMJIvRm+AyAAZmZAfZEonHY/DDxMbq0sgvopQw9bP9C2lzH+grJrlCmrUEoj3bPViaGQ==",
       "cpu": [
         "x64"
       ],
@@ -7992,9 +7992,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.0.tgz",
-      "integrity": "sha512-esXjuvqgjMPUqNWP3pQWPTFjqu2slFpoFCIxb5mCxlJgsggti/PsTq2ukdCBfeiAr1SvonXtr/5dxX7DDRICmw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.1.tgz",
+      "integrity": "sha512-7rQDn1yOe3Py6plT5pgB5zO9pNZm5oxhVexw4iFwA7IXYZ+zYPd8nsWRfQWR8+WOe3s/wpxuGfjCplb4AddAOQ==",
       "cpu": [
         "arm64"
       ],
@@ -8011,9 +8011,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.0.tgz",
-      "integrity": "sha512-FP2WxwjbDjigYPlgjNDBZ33dTHZTLRngfdnoA6yKey5Q7N/d+fQPeyziIz6Kkhr/riVzT+ZlDU2ynMAzA2ysjQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.1.tgz",
+      "integrity": "sha512-pDKh6O7/oZGV3yDC5lv7u7kcty2GyFR5SlUqNaQSX9Ch5VHCltHYl6JU6scGqVmJRDpZojmn5e0s4iU+QZ3JMQ==",
       "cpu": [
         "arm64"
       ],
@@ -8030,9 +8030,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.0.tgz",
-      "integrity": "sha512-erW/QA6+c89XFIVftSkIOGuwKEFzK5qt8p4FzeJiUOa46bglb2ZV65tIxqNqGLRn3ozE5S/MU+ZJgftGK3Mnnw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.1.tgz",
+      "integrity": "sha512-nX/GCs/a55FhTPVfnGz8+vHgfVrdNECbzl6JUEzS9aEu9n8V3ujvC0JfvQ3kup3GjQnoIsd2FpjblLEMssG1uw==",
       "cpu": [
         "x64"
       ],
@@ -8049,9 +8049,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.0.tgz",
-      "integrity": "sha512-Mh3OavzXeUzrD/VPJajTvvEIn+/kMYcc0HTsMbakpEKYMORWMiStAX0pzFrwLIx7I31sEANVGuG+JfT9TZ/syQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.1.tgz",
+      "integrity": "sha512-+841Vbrc+mnHKcIJO7UjKpkrTMlL6QaRs3DowPyI4rB0qNQACJ+zwulV10ZitGiMb0h8aTa5TNBZAOc0SmqlKw==",
       "cpu": [
         "x64"
       ],
@@ -8068,9 +8068,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.0.tgz",
-      "integrity": "sha512-72DZHar22R6anHfyA+QvbSAUByc6G85KlPykG4iMWi74nC2nCr5dS0H+wN1AtV2tuQ5l5oAngtWb2zoYZRmZVQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.1.tgz",
+      "integrity": "sha512-IT+t4knV1BBHyMIzHEHwFKW3gMDaCh4vX+TsXsj5yU1wH3o2AucIHgelxN8OUmfD0oDNT2Tn7UzAJmoWEQOstw==",
       "cpu": [
         "arm64"
       ],
@@ -8084,9 +8084,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.0.tgz",
-      "integrity": "sha512-ZZ+5wfeklqb9WU5akxIyE+VjK7SmtcpR4huSXb2QOQXJn0dXcasBFZLonQgxsLRSoRXIn9zdkX/iSrFh+9FKzQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.1.tgz",
+      "integrity": "sha512-lp3O3Wy7UdfkwTe4rDysPlxLisXYmBY0r+0xIDtfRs1IsYTcPcPB+Fk/H3orsbyYoaJEtHnp4d8QgTu5pV0g/g==",
       "cpu": [
         "ia32"
       ],
@@ -8100,9 +8100,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.0.tgz",
-      "integrity": "sha512-IIvc2xXZoC8gWI3YdM99iIj37geIfOSjR09S+8a/rvZTn4eFalKEJX3uwhrcuMF4gWnNR55RWSjEf4tjGBS4SQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.1.tgz",
+      "integrity": "sha512-A3CC4lbCiUNw0EBYlJzOYarWmf00uwD3boe5jihiffDhc5a8mL0bdJouG9FwXrzRuuyRYGY/xqfmn2nPFW6Cqg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.0"
+    "config-disassembler": "3.4.1"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/test/commands/decomposer/overrides.test.ts
+++ b/test/commands/decomposer/overrides.test.ts
@@ -373,10 +373,11 @@ describe('decomposer per-component overrides', () => {
       log: logMock,
     });
 
-    // Filter out the `.config-disassembler.json` metadata sidecar and the `.key_order.json`
-    // helper file (both are always JSON regardless of decomposed format and would confuse
-    // the per-format assertions below).
-    const isSidecar = (f: string): boolean => f.endsWith('.config-disassembler.json') || f.endsWith('.key_order.json');
+    // Filter out the `.config-disassembler.json` metadata sidecar and the `.key_order.json` /
+    // `.trailing_newline.json` helper files (all are always JSON regardless of decomposed
+    // format and would confuse the per-format assertions below).
+    const isSidecar = (f: string): boolean =>
+      f.endsWith('.config-disassembler.json') || f.endsWith('.key_order.json') || f.endsWith('.trailing_newline.json');
     const hrAdminFiles = (await collectFiles(join(permissionsetsDir, 'HR_Admin'))).filter((f) => !isSidecar(f));
     const bigPermSetFiles = (await collectFiles(join(permissionsetsDir, 'Big_PermSet'))).filter((f) => !isSidecar(f));
 


### PR DESCRIPTION
## Summary
- Bumps `config-disassembler` 3.4.0 → 3.4.1 (root `package.json` and `docker/package.json`, kept in sync per the Dockerfile's own comment).
- Pulls in mcarvin8/config-disassembler-node#68, which bumps the underlying Rust crate to 0.10.2 (mcarvin8/config-disassembler#121): `reassemble` no longer drops a source file's trailing newline, which previously made `verify` mislabel byte-identical-but-for-that-newline round trips as `"reordered"` even when nothing was actually reordered.
- This is the fix for the behavior investigated starting from the `Smoke_Test.permissionset-meta.xml` "reordered" note in `.github/workflows/smoke-test-action.yml`'s `published-image-round-trip` job.
- Updated `test/commands/decomposer/overrides.test.ts`'s local `isSidecar` allowlist to also exclude the new `.trailing_newline.json` sidecar file the crate now writes alongside `.key_order.json` — without it, one per-component-override test misread that internal control file as a real decomposed JSON component.

## Test plan
- [x] `npm test` (compile + lint + full vitest suite) — 617/617 tests pass
- [x] `npx biome check src test` clean
- [x] Confirmed `package-lock.json` resolves the full `config-disassembler` optional-platform-binary set for 3.4.1 (including `linux-arm64-musl`, which needed a retry — npm's registry propagation lagged briefly after publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rACXu2cWXXPiFomUEfHgT