### PR TITLE
feat(metadata): refresh SDR registry to 13.3.1

### DIFF
--- a/src/metadata/registry/metadataRegistry.json
+++ b/src/metadata/registry/metadataRegistry.json
@@ -788,6 +788,7 @@
             "directoryName": "aiAgentDefinitionVersions",
             "inFolder": false,
             "strictDirectoryName": true,
+            "versionSeparator": "#",
             "strategies": { "adapter": "bundle" }
         },
         "aiagentscorerdefinition": {


### PR DESCRIPTION
Refreshes the vendored metadata registry (`src/metadata/registry/metadataRegistry.json`) from [@salesforce/source-deploy-retrieve@13.3.1](https://github.com/forcedotcom/source-deploy-retrieve).

This plugin doesn't depend on SDR at runtime — this is a periodic snapshot, synced weekly by [.github/workflows/sync-metadata-registry.yml](.github/workflows/sync-metadata-registry.yml).

