### PR TITLE
fix(deps): bump config-disassembler to 3.4.2

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.1",
+    "config-disassembler": "3.4.2",
     "@actions/core": "3.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8010,6 +8010,25 @@
         "node": ">=20"
       }
     },
+    "node_modules/config-disassembler-linux-arm64-musl": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.2.tgz",
+      "integrity": "sha512-BdcRscyCHJmTk69kTXiYRseL/izhEZK/3Lf9j0qr3l4s2hwJG0CF0Ai/Zxf7C9LdwrY6vbzDCfhPT8QrPkjv2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/config-disassembler-linux-x64-gnu": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.1"
+        "config-disassembler": "3.4.2"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7940,29 +7940,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.1.tgz",
-      "integrity": "sha512-aaH8DA0MHAAjdnTh9ioNbG3rwNk9zQDizzrlucsh1Rc4jM0nDej4LyH7ZvLMQ9e002/4h3ZTO1wyH8SUDPQ+qQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.2.tgz",
+      "integrity": "sha512-XSMyjcaKJgw5NpqfCGyxrVo6m2DOaom9FBs9qWoOUwcZ7pqDiD3CX2HTbW9fy0LsT7k/UFiTf6TI1kfN/bCTYw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.1",
-        "config-disassembler-darwin-x64": "3.4.1",
-        "config-disassembler-linux-arm64-gnu": "3.4.1",
-        "config-disassembler-linux-arm64-musl": "3.4.1",
-        "config-disassembler-linux-x64-gnu": "3.4.1",
-        "config-disassembler-linux-x64-musl": "3.4.1",
-        "config-disassembler-win32-arm64-msvc": "3.4.1",
-        "config-disassembler-win32-ia32-msvc": "3.4.1",
-        "config-disassembler-win32-x64-msvc": "3.4.1"
+        "config-disassembler-darwin-arm64": "3.4.2",
+        "config-disassembler-darwin-x64": "3.4.2",
+        "config-disassembler-linux-arm64-gnu": "3.4.2",
+        "config-disassembler-linux-arm64-musl": "3.4.2",
+        "config-disassembler-linux-x64-gnu": "3.4.2",
+        "config-disassembler-linux-x64-musl": "3.4.2",
+        "config-disassembler-win32-arm64-msvc": "3.4.2",
+        "config-disassembler-win32-ia32-msvc": "3.4.2",
+        "config-disassembler-win32-x64-msvc": "3.4.2"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.1.tgz",
-      "integrity": "sha512-CtTrfXxov8sF1C+qycvdt5COs5Sz39X9j550cpj1RPTRuj6Yz89SG5ufcW6RBGMnnCCEfyY/LsoIaVIuGjk7XA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.2.tgz",
+      "integrity": "sha512-i1zmoQsaY4XFjBaMuBm4trZK2M0exlhvWHCpjiMUjEvIVLEVza6ZWnRoqy3Usv4rYP1zOBB1TnxOP0KvImPN2Q==",
       "cpu": [
         "arm64"
       ],
@@ -7976,9 +7976,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.1.tgz",
-      "integrity": "sha512-PjqbcfAMYXgJt3NIpQVMJIvRm+AyAAZmZAfZEonHY/DDxMbq0sgvopQw9bP9C2lzH+grJrlCmrUEoj3bPViaGQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.2.tgz",
+      "integrity": "sha512-lu5DfllkRaQ+/nG+Sy9edJ+KDQes74lzlVfAyprhR9ckUJpj7UWhWcaUbaQsU4no7z5Y+u1CZVmA3m6sdY9ZkQ==",
       "cpu": [
         "x64"
       ],
@@ -7992,9 +7992,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.1.tgz",
-      "integrity": "sha512-7rQDn1yOe3Py6plT5pgB5zO9pNZm5oxhVexw4iFwA7IXYZ+zYPd8nsWRfQWR8+WOe3s/wpxuGfjCplb4AddAOQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.2.tgz",
+      "integrity": "sha512-BDh4VpWP43AfGVCJyla8ORjbaP88Wp73Wa+IvAh+QRBsQ6HPVIT56FZeZVJxeNjf+3EZtcPGu1p95Qwcvg7LdA==",
       "cpu": [
         "arm64"
       ],
@@ -8010,29 +8010,10 @@
         "node": ">=20"
       }
     },
-    "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.1.tgz",
-      "integrity": "sha512-pDKh6O7/oZGV3yDC5lv7u7kcty2GyFR5SlUqNaQSX9Ch5VHCltHYl6JU6scGqVmJRDpZojmn5e0s4iU+QZ3JMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.1.tgz",
-      "integrity": "sha512-nX/GCs/a55FhTPVfnGz8+vHgfVrdNECbzl6JUEzS9aEu9n8V3ujvC0JfvQ3kup3GjQnoIsd2FpjblLEMssG1uw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.2.tgz",
+      "integrity": "sha512-usYdFkq9hCKQKuKBpv4GAdxaDEsCn30aF1QSyksQ7JY89KWzRk55JQ+bSnfw2S1SPAREfVgz10OWapk3pVOmrg==",
       "cpu": [
         "x64"
       ],
@@ -8049,9 +8030,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.1.tgz",
-      "integrity": "sha512-+841Vbrc+mnHKcIJO7UjKpkrTMlL6QaRs3DowPyI4rB0qNQACJ+zwulV10ZitGiMb0h8aTa5TNBZAOc0SmqlKw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.2.tgz",
+      "integrity": "sha512-Pl2vLrEZs8HD6wueplCe8RF23QCs96nnC6h3Mt+Uu0/f+xanLzhUk/34wsiw8RSRA8NxDTPyAB1r/QivzC0noQ==",
       "cpu": [
         "x64"
       ],
@@ -8068,9 +8049,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.1.tgz",
-      "integrity": "sha512-IT+t4knV1BBHyMIzHEHwFKW3gMDaCh4vX+TsXsj5yU1wH3o2AucIHgelxN8OUmfD0oDNT2Tn7UzAJmoWEQOstw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.2.tgz",
+      "integrity": "sha512-BvIaKI8gS3LLaHHukZnTOz4y4O7zLIfjHP5fvn+Tm4Th6ABiwATYgnl7OMXvYCZMfLdhKAq2CAysFumMNulqFg==",
       "cpu": [
         "arm64"
       ],
@@ -8084,9 +8065,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.1.tgz",
-      "integrity": "sha512-lp3O3Wy7UdfkwTe4rDysPlxLisXYmBY0r+0xIDtfRs1IsYTcPcPB+Fk/H3orsbyYoaJEtHnp4d8QgTu5pV0g/g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.2.tgz",
+      "integrity": "sha512-VPquAL8Abf8rX+UOLGTz+l8ECmIeATl8c4ALeekcc8JCDtfLIRJl1Q39hw2uDZh5obVGXlaV8qntbfxozZr13A==",
       "cpu": [
         "ia32"
       ],
@@ -8100,9 +8081,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.1.tgz",
-      "integrity": "sha512-A3CC4lbCiUNw0EBYlJzOYarWmf00uwD3boe5jihiffDhc5a8mL0bdJouG9FwXrzRuuyRYGY/xqfmn2nPFW6Cqg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.2.tgz",
+      "integrity": "sha512-8qlvxd8lOTP+Sv5ZFo3RbguvwIyGmV4hEgOR1n8XX/1kau3iEdEtnSAvKWA4DJt34tRyNhS/uBKuo145Iy/WzA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.1"
+    "config-disassembler": "3.4.2"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/scripts/audit/audit.ts
+++ b/scripts/audit/audit.ts
@@ -31,9 +31,9 @@ import { fileURLToPath } from 'node:url';
 
 import {
   type AuditRow,
+  countHashFiles,
   DEFAULT_PLUGIN_ROOT,
   DEFAULT_WORK_ROOT,
-  countHashFiles,
   formatTable,
   listFlatXml,
   listSubdirs,

--- a/scripts/audit/lib.ts
+++ b/scripts/audit/lib.ts
@@ -14,7 +14,7 @@
  * harness can run in any CI environment without an extra install step.
  */
 
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { type SpawnSyncReturns, spawnSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';

--- a/scripts/audit/roundtrip.ts
+++ b/scripts/audit/roundtrip.ts
@@ -18,7 +18,7 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
+import { runAudit } from './audit.js';
 import {
   type AuditRow,
   DEFAULT_PLUGIN_ROOT,
@@ -28,7 +28,6 @@ import {
   parseFlags,
   requireString,
 } from './lib.js';
-import { runAudit } from './audit.js';
 import { ROUNDTRIP_PAIRS } from './type-pairs.js';
 
 const HELP_TEXT = `Usage: npm run audit:roundtrip -- [options]

--- a/scripts/audit/sweep.ts
+++ b/scripts/audit/sweep.ts
@@ -18,10 +18,9 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  type SweepRow,
+  countHashFiles,
   DEFAULT_PLUGIN_ROOT,
   DEFAULT_WORK_ROOT,
-  countHashFiles,
   formatTable,
   listSubdirs,
   listXmlFilesRecursive,
@@ -29,6 +28,7 @@ import {
   parseFlags,
   requireString,
   runCli,
+  type SweepRow,
   stageProject,
   topHashDirs,
 } from './lib.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,11 +13,6 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true
   },
-  "include": [
-    "./src/**/*.ts",
-    "./src/metadata/registry/metadataRegistry.json"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["./src/**/*.ts", "./src/metadata/registry/metadataRegistry.json"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Bumps `config-disassembler` 3.4.1 → 3.4.2 (root `package.json` and `docker/package.json`, kept in sync per the Dockerfile's own comment).
- Pulls in mcarvin8/config-disassembler-node#70, which bumps the underlying Rust crate to 0.10.3 (mcarvin8/config-disassembler#123): reassembled XML now renders single-child "compact" wrapper elements with no internal whitespace (e.g. Salesforce Flow's `<connector><targetReference>X</targetReference></connector>`) on one line instead of always block-formatting them, closing the byte-retention gap the perf suite measured on `Mega_Flow.flow-meta.xml` (103.52% → 100.00%).
- Backward compatible — directories already disassembled by older crate versions have no such formatting on disk and continue to reassemble block-formatted exactly as before.

## Test plan
- [x] `npx vitest run` (forced, bypassing wireit's stale cache since this is a dependency-only change) — 617/617 tests pass
- [x] `npx biome check src test` clean
- [x] `npx tsc -p ./test --pretty` clean
- [x] Confirmed `package-lock.json` resolves the full `config-disassembler` optional-platform-binary set for 3.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4hK4DbmkU523ubHnubjcC