### PR TITLE
fix(rust): add XML round-trip fuzz harness, bump config-disassembler to 3.4.7

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.5",
+    "config-disassembler": "3.4.6",
     "@actions/core": "3.0.1"
   }
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.4",
+    "config-disassembler": "3.4.5",
     "@actions/core": "3.0.1"
   }
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.2",
+    "config-disassembler": "3.4.3",
     "@actions/core": "3.0.1"
   }
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.6",
+    "config-disassembler": "3.4.7",
     "@actions/core": "3.0.1"
   }
 }

--- a/docker/package.json
+++ b/docker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "config-disassembler": "3.4.3",
+    "config-disassembler": "3.4.4",
     "@actions/core": "3.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.3"
+        "config-disassembler": "3.4.4"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7941,29 +7941,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.3.tgz",
-      "integrity": "sha512-tfKxKDczU7SQ6OMJNMFZBG83Kh96zHWisK/y6uC5wuHBkRGLa29EUXnEisxOLvbmaXPl+3s8s9y119ia0GPPww==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.4.tgz",
+      "integrity": "sha512-kK3sWhOoZe9muAEdDxMbGvcQIR+pXgGnCy0lHgOVaZiFlXJLZ/hyf2Qm2/oPcnK66EOzylhfFnPP9pRsqy9qrA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.3",
-        "config-disassembler-darwin-x64": "3.4.3",
-        "config-disassembler-linux-arm64-gnu": "3.4.3",
-        "config-disassembler-linux-arm64-musl": "3.4.3",
-        "config-disassembler-linux-x64-gnu": "3.4.3",
-        "config-disassembler-linux-x64-musl": "3.4.3",
-        "config-disassembler-win32-arm64-msvc": "3.4.3",
-        "config-disassembler-win32-ia32-msvc": "3.4.3",
-        "config-disassembler-win32-x64-msvc": "3.4.3"
+        "config-disassembler-darwin-arm64": "3.4.4",
+        "config-disassembler-darwin-x64": "3.4.4",
+        "config-disassembler-linux-arm64-gnu": "3.4.4",
+        "config-disassembler-linux-arm64-musl": "3.4.4",
+        "config-disassembler-linux-x64-gnu": "3.4.4",
+        "config-disassembler-linux-x64-musl": "3.4.4",
+        "config-disassembler-win32-arm64-msvc": "3.4.4",
+        "config-disassembler-win32-ia32-msvc": "3.4.4",
+        "config-disassembler-win32-x64-msvc": "3.4.4"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.3.tgz",
-      "integrity": "sha512-hEyb7qL1x48LGzgYi9lcUUrEOX7y+dBVKUkYDqBY3fZwQ0TyRZNF7fukkZmYualg1i/fRDiHggY6J7O3eiT8Cg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.4.tgz",
+      "integrity": "sha512-HrDHmIjnbR7RAbCLW0aFPJi5E7OPNfVKEucyMoPn9VcYCzuAPSDIioHbTaPKSZNcokPO5FSRMTpNaxdC24l9MQ==",
       "cpu": [
         "arm64"
       ],
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.3.tgz",
-      "integrity": "sha512-m2+qFBOtPkD+Zy+RtHGJncWUVeIf8F4GSKlPU+fwl8miC+knWlZ1xA4E8pk2IpBeU1w9X7zWZfemAnrMFVGonw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.4.tgz",
+      "integrity": "sha512-QEPtXd2GMuKaI3ReK1QxFmBWgPMUHYiDR75WEUogNO6J9/dynQh6mPQrAQXnMHLy9rrXnQrnXJJwHBXkTgthnw==",
       "cpu": [
         "x64"
       ],
@@ -7993,9 +7993,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.3.tgz",
-      "integrity": "sha512-IN8q2KSzBveKtGgTF9qSJzFp3JUm4wk279P6PZgpXthriayqjkW/BdXZHnjMJ5V3sWghptgtbx+fL3a9Zsu/3w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.4.tgz",
+      "integrity": "sha512-OMnyUYYeeNTEBjwKpn7h7GymJ0UA6npkDeNdanOv+SWY5tChk82sVobmDb02MVuR21FEJ79/6QhKuf5gDq82ww==",
       "cpu": [
         "arm64"
       ],
@@ -8012,9 +8012,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.3.tgz",
-      "integrity": "sha512-CMgqlK6moRrGyZ/oTkUMnaqheBZwZO6KEVa9Q3cxs9LelHAKJiDhgfFesLn7V/i9E9EZYwqbCTIgnbj5bRFAEA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.4.tgz",
+      "integrity": "sha512-yKLzHy7zLDPCp8RRw3t8uGsmegBSlF22BQSZ6eZJW3eI0rqxTPjfon4CmsrLOo7EdcFkFhXNxwfMIgzYbV5vHQ==",
       "cpu": [
         "arm64"
       ],
@@ -8031,9 +8031,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.3.tgz",
-      "integrity": "sha512-ZcE8DDukp3MhBdL0Tam8VxAU30z1Gah+WIoRpzO8/4tpGy/+Ass/Umi/gzuSwlQh/PZH2WMfikg+6/iT+Uy/6Q==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.4.tgz",
+      "integrity": "sha512-q9eAaFWpI2U91ktO2J7ypJEgwCqMloliWijTPs6kcvPDGPuS0PGBX0j32YLBVN+cExYuaYEN0FuKk7YObw0SLw==",
       "cpu": [
         "x64"
       ],
@@ -8050,9 +8050,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.3.tgz",
-      "integrity": "sha512-D6T3GouBUsRfBXm9cVRsGtwvf56qrO19f+oui2tBdHNPmho8lukz7QqjNZ7bFZ2XxMk2vmmTDOqHbPDmZYrhtg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.4.tgz",
+      "integrity": "sha512-rpxZQ+Tyef8pA8hLqz9++fe7gI6XXcmbVGBTuALj7Jpfga0juWtqI3ZNgtwqWE7p7cmT2rCTGPcP3dS6l9qtog==",
       "cpu": [
         "x64"
       ],
@@ -8069,9 +8069,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.3.tgz",
-      "integrity": "sha512-H76YNocovNGWjfWGj/tyqbBKJdnGjV7HvHXAYtlKNeoEGlS5JsQMNJ1XLoLYU6kN82Iw5/jqf0Q+RUJm7OydMQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.4.tgz",
+      "integrity": "sha512-GGDp66LJiLEMM10iP4BLlPAFRmnurWqLaptIg8+9qO43vE4sAsjr2au+R+XHq5gF8fEzKQhUIMmW4ivFQy4Zsw==",
       "cpu": [
         "arm64"
       ],
@@ -8085,9 +8085,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.3.tgz",
-      "integrity": "sha512-+jR6m2tzQo+GPqnY48X+hcVMGg64lagswALY9DShAoM+jRCBYCESjDJSP8ELypG2ZuQuMywdGwZdbUbH2ocT5g==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.4.tgz",
+      "integrity": "sha512-XsdwqgNxnWbKpD0mt3g1e6gx4bGtgWowo+JFtSM3UZCAMLU9G53XbYQqFVETTKvyLgaZRZeSCJZ39UU7S0/yUg==",
       "cpu": [
         "ia32"
       ],
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.3.tgz",
-      "integrity": "sha512-UKE4OYHnuecLvj8e4rj2nQqBBjCXrz4R3du3G0HUHZDhvSRGOcb19QtizoASTYXpIzQ802H37hxJF+bm97XDOg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.4.tgz",
+      "integrity": "sha512-7ahlw6TVWv0m0blZFMw2ysS+pbThtaZ7px80WZx/3CvPSfPhKBXvOzKV+DKKRtCB7ot7xRHh1Wu825YT9cHumQ==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.2"
+        "config-disassembler": "3.4.3"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7941,29 +7941,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.2.tgz",
-      "integrity": "sha512-XSMyjcaKJgw5NpqfCGyxrVo6m2DOaom9FBs9qWoOUwcZ7pqDiD3CX2HTbW9fy0LsT7k/UFiTf6TI1kfN/bCTYw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.3.tgz",
+      "integrity": "sha512-tfKxKDczU7SQ6OMJNMFZBG83Kh96zHWisK/y6uC5wuHBkRGLa29EUXnEisxOLvbmaXPl+3s8s9y119ia0GPPww==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.2",
-        "config-disassembler-darwin-x64": "3.4.2",
-        "config-disassembler-linux-arm64-gnu": "3.4.2",
-        "config-disassembler-linux-arm64-musl": "3.4.2",
-        "config-disassembler-linux-x64-gnu": "3.4.2",
-        "config-disassembler-linux-x64-musl": "3.4.2",
-        "config-disassembler-win32-arm64-msvc": "3.4.2",
-        "config-disassembler-win32-ia32-msvc": "3.4.2",
-        "config-disassembler-win32-x64-msvc": "3.4.2"
+        "config-disassembler-darwin-arm64": "3.4.3",
+        "config-disassembler-darwin-x64": "3.4.3",
+        "config-disassembler-linux-arm64-gnu": "3.4.3",
+        "config-disassembler-linux-arm64-musl": "3.4.3",
+        "config-disassembler-linux-x64-gnu": "3.4.3",
+        "config-disassembler-linux-x64-musl": "3.4.3",
+        "config-disassembler-win32-arm64-msvc": "3.4.3",
+        "config-disassembler-win32-ia32-msvc": "3.4.3",
+        "config-disassembler-win32-x64-msvc": "3.4.3"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.2.tgz",
-      "integrity": "sha512-i1zmoQsaY4XFjBaMuBm4trZK2M0exlhvWHCpjiMUjEvIVLEVza6ZWnRoqy3Usv4rYP1zOBB1TnxOP0KvImPN2Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.3.tgz",
+      "integrity": "sha512-hEyb7qL1x48LGzgYi9lcUUrEOX7y+dBVKUkYDqBY3fZwQ0TyRZNF7fukkZmYualg1i/fRDiHggY6J7O3eiT8Cg==",
       "cpu": [
         "arm64"
       ],
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.2.tgz",
-      "integrity": "sha512-lu5DfllkRaQ+/nG+Sy9edJ+KDQes74lzlVfAyprhR9ckUJpj7UWhWcaUbaQsU4no7z5Y+u1CZVmA3m6sdY9ZkQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.3.tgz",
+      "integrity": "sha512-m2+qFBOtPkD+Zy+RtHGJncWUVeIf8F4GSKlPU+fwl8miC+knWlZ1xA4E8pk2IpBeU1w9X7zWZfemAnrMFVGonw==",
       "cpu": [
         "x64"
       ],
@@ -7993,9 +7993,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.2.tgz",
-      "integrity": "sha512-BDh4VpWP43AfGVCJyla8ORjbaP88Wp73Wa+IvAh+QRBsQ6HPVIT56FZeZVJxeNjf+3EZtcPGu1p95Qwcvg7LdA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.3.tgz",
+      "integrity": "sha512-IN8q2KSzBveKtGgTF9qSJzFp3JUm4wk279P6PZgpXthriayqjkW/BdXZHnjMJ5V3sWghptgtbx+fL3a9Zsu/3w==",
       "cpu": [
         "arm64"
       ],
@@ -8012,9 +8012,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.2.tgz",
-      "integrity": "sha512-BdcRscyCHJmTk69kTXiYRseL/izhEZK/3Lf9j0qr3l4s2hwJG0CF0Ai/Zxf7C9LdwrY6vbzDCfhPT8QrPkjv2Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.3.tgz",
+      "integrity": "sha512-CMgqlK6moRrGyZ/oTkUMnaqheBZwZO6KEVa9Q3cxs9LelHAKJiDhgfFesLn7V/i9E9EZYwqbCTIgnbj5bRFAEA==",
       "cpu": [
         "arm64"
       ],
@@ -8031,9 +8031,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.2.tgz",
-      "integrity": "sha512-usYdFkq9hCKQKuKBpv4GAdxaDEsCn30aF1QSyksQ7JY89KWzRk55JQ+bSnfw2S1SPAREfVgz10OWapk3pVOmrg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.3.tgz",
+      "integrity": "sha512-ZcE8DDukp3MhBdL0Tam8VxAU30z1Gah+WIoRpzO8/4tpGy/+Ass/Umi/gzuSwlQh/PZH2WMfikg+6/iT+Uy/6Q==",
       "cpu": [
         "x64"
       ],
@@ -8050,9 +8050,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.2.tgz",
-      "integrity": "sha512-Pl2vLrEZs8HD6wueplCe8RF23QCs96nnC6h3Mt+Uu0/f+xanLzhUk/34wsiw8RSRA8NxDTPyAB1r/QivzC0noQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.3.tgz",
+      "integrity": "sha512-D6T3GouBUsRfBXm9cVRsGtwvf56qrO19f+oui2tBdHNPmho8lukz7QqjNZ7bFZ2XxMk2vmmTDOqHbPDmZYrhtg==",
       "cpu": [
         "x64"
       ],
@@ -8069,9 +8069,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.2.tgz",
-      "integrity": "sha512-BvIaKI8gS3LLaHHukZnTOz4y4O7zLIfjHP5fvn+Tm4Th6ABiwATYgnl7OMXvYCZMfLdhKAq2CAysFumMNulqFg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.3.tgz",
+      "integrity": "sha512-H76YNocovNGWjfWGj/tyqbBKJdnGjV7HvHXAYtlKNeoEGlS5JsQMNJ1XLoLYU6kN82Iw5/jqf0Q+RUJm7OydMQ==",
       "cpu": [
         "arm64"
       ],
@@ -8085,9 +8085,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.2.tgz",
-      "integrity": "sha512-VPquAL8Abf8rX+UOLGTz+l8ECmIeATl8c4ALeekcc8JCDtfLIRJl1Q39hw2uDZh5obVGXlaV8qntbfxozZr13A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.3.tgz",
+      "integrity": "sha512-+jR6m2tzQo+GPqnY48X+hcVMGg64lagswALY9DShAoM+jRCBYCESjDJSP8ELypG2ZuQuMywdGwZdbUbH2ocT5g==",
       "cpu": [
         "ia32"
       ],
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.2.tgz",
-      "integrity": "sha512-8qlvxd8lOTP+Sv5ZFo3RbguvwIyGmV4hEgOR1n8XX/1kau3iEdEtnSAvKWA4DJt34tRyNhS/uBKuo145Iy/WzA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.3.tgz",
+      "integrity": "sha512-UKE4OYHnuecLvj8e4rj2nQqBBjCXrz4R3du3G0HUHZDhvSRGOcb19QtizoASTYXpIzQ802H37hxJF+bm97XDOg==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.6"
+        "config-disassembler": "3.4.7"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7941,29 +7941,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.6.tgz",
-      "integrity": "sha512-Ho9VEIE2rL8Sfs+7LKdRMLASsOF1BGn49sWxgdnpsm83jDqx84Snmo840oBIbuGX2FGfyjtWcpXAAYk/a0L/ew==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.7.tgz",
+      "integrity": "sha512-4j/AEkON3FuGr5DYiLtwQW0OILkwS3pljErZf1Td7quZ6c8yzivDlvdXH8kPfG4BL4EnnQKJaooIUkYTQ9m+Aw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.6",
-        "config-disassembler-darwin-x64": "3.4.6",
-        "config-disassembler-linux-arm64-gnu": "3.4.6",
-        "config-disassembler-linux-arm64-musl": "3.4.6",
-        "config-disassembler-linux-x64-gnu": "3.4.6",
-        "config-disassembler-linux-x64-musl": "3.4.6",
-        "config-disassembler-win32-arm64-msvc": "3.4.6",
-        "config-disassembler-win32-ia32-msvc": "3.4.6",
-        "config-disassembler-win32-x64-msvc": "3.4.6"
+        "config-disassembler-darwin-arm64": "3.4.7",
+        "config-disassembler-darwin-x64": "3.4.7",
+        "config-disassembler-linux-arm64-gnu": "3.4.7",
+        "config-disassembler-linux-arm64-musl": "3.4.7",
+        "config-disassembler-linux-x64-gnu": "3.4.7",
+        "config-disassembler-linux-x64-musl": "3.4.7",
+        "config-disassembler-win32-arm64-msvc": "3.4.7",
+        "config-disassembler-win32-ia32-msvc": "3.4.7",
+        "config-disassembler-win32-x64-msvc": "3.4.7"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.6.tgz",
-      "integrity": "sha512-WlLKf3SCzTMdydIL80tkKTHCyVpq9MDEswyaOGkNgkhu4OBX2CG2MyocV4m8N0s040Y7Afjrg89ALcwyTyd9wA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.7.tgz",
+      "integrity": "sha512-PITE1cbumqirs52nkyL8gunmfzXnl+QKvrjlF3vas4Jq5Mpwa4/+ydMqA9HIrw15sxWueKg8UhSip2MjWol4tg==",
       "cpu": [
         "arm64"
       ],
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.6.tgz",
-      "integrity": "sha512-bFcs5aBeIDovxicQJqUDjMniYmWfMFZGxIqJUdqL3xYEpFbQQqC/MR4L6Ew1TvZq51p1vFeo4dL7gZ0dphK3Eg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.7.tgz",
+      "integrity": "sha512-mFdrYWcfhUq703QsY2e0hSQOse1Gctcv+CHDJI/Rne6J+hwgeTiAdyxddUVNR1aRu90LV36xMUT7hyA6435MZg==",
       "cpu": [
         "x64"
       ],
@@ -7993,9 +7993,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.6.tgz",
-      "integrity": "sha512-XOwH/9MQEvYJISbkq9NPHmx1tLej+B/aIwvGpOQeAEuHf3DLBooH237sY/555ob0GE0Y5+jv8iramK4pehBhow==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.7.tgz",
+      "integrity": "sha512-4D9sxQgkHEoNCLh9MuYdIT2QsdKXfoqWIczlhSr+78119K81rcWYPSUTlfXG4zukqu8Lc2DVCmXityjO72ZRjw==",
       "cpu": [
         "arm64"
       ],
@@ -8012,9 +8012,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.6.tgz",
-      "integrity": "sha512-Br3Rm1c6d+BQlMxU7rCYA5AIc2KJ+YqsLA27jAgMGDFS7lJSs4bANV7+lO+ILjbQYcd8xKzGop52oareJ6tYcQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.7.tgz",
+      "integrity": "sha512-iEEAhjWJHdT8MVtzVIbj0FpiWU+qzFJpFbe3t4hDP146RQ+oKe/R7NBvtKSyn5JanRD2a6ei9Hlq/sVYlxcY9A==",
       "cpu": [
         "arm64"
       ],
@@ -8031,9 +8031,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.6.tgz",
-      "integrity": "sha512-iELSJ5H1HpOZLwpAPp7c23IWVoRYVICrROQ49qg3X5L/wh59cWPcbLsAjRtY034fFyMc5KTrlbMAWSuJ7kRK1g==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.7.tgz",
+      "integrity": "sha512-+keSBKeq16UL0vXqaO54ewD+xka2nwuVFpvdEQs5mJiDeCCmhwgXUpGTw+fSq3wFhvyvlt9gdDmfFPgVHHYW1A==",
       "cpu": [
         "x64"
       ],
@@ -8050,9 +8050,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.6.tgz",
-      "integrity": "sha512-tCu9T41Xsc/kyj5V1LmqMV87wTEcqbC2+dqfVGOn/pXw6dXvB0kP6ZxGEobw2DTrz6MpabYDYzzrzg1FXqa54g==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.7.tgz",
+      "integrity": "sha512-vePgya/JqfmU4lfy7fMHXDUF7pINKfUs2Bc4ptQsvn5CtkfuD2caiqlhJpHrVCcYWYdpIadpIIkhj7VXOHcfgA==",
       "cpu": [
         "x64"
       ],
@@ -8069,9 +8069,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.6.tgz",
-      "integrity": "sha512-OhAvq/zmZnbqKXC2OSPZAQil9Ofh8O26TfANTbTpjjVzopSVI/0vbbYYyfjAcO5Fb8/PcgWd7WW4YXjMfMb2yQ==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.7.tgz",
+      "integrity": "sha512-KdnkmypOuJPgyCYUki96wN0X9j0VFa71cKaVhefVdKsx+0KJtwQ1oZMV7wyKDU7Scd+Sx6WmTtHnn9NQhXrJlw==",
       "cpu": [
         "arm64"
       ],
@@ -8085,9 +8085,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.6.tgz",
-      "integrity": "sha512-dBpBIXWgPlLYYqeb+BbXxHGQFfwf3BD036VrVncv+l/EZ/NRT5AlGeZZP2VItetF+oIolTD5RjgyMreohWbUAw==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.7.tgz",
+      "integrity": "sha512-+KGnvEU/BwsQz6+Obm17LYONYurhye7DG3Lhv10AjS5ZMS6fjzcRAhS0PRSe3dYgexeMsqe+98wbFuMmB6B8vw==",
       "cpu": [
         "ia32"
       ],
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.6.tgz",
-      "integrity": "sha512-c0SbEwpMuGShHVNn90P8M/JBvWyH34lmJnL5CsZsRHXzF15Yw1EjaogqENM5UZrvgEjwGW+D4SshcaW+Tb4xRA==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.7.tgz",
+      "integrity": "sha512-QLcgcgrkj63Va2JLt/pZQ3PGHIv5ehaAmePRBbqd/1wAowhILGv0TX8mO3bswdK+WD97mXJdacRjuGQMs4J6Fw==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.4"
+        "config-disassembler": "3.4.5"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7941,29 +7941,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.4.tgz",
-      "integrity": "sha512-kK3sWhOoZe9muAEdDxMbGvcQIR+pXgGnCy0lHgOVaZiFlXJLZ/hyf2Qm2/oPcnK66EOzylhfFnPP9pRsqy9qrA==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.5.tgz",
+      "integrity": "sha512-vui5bLy0ch/2e5d+Yv1MaNMuProBGSYu+g39Pg8sPgQfDkXNBgqOjntpGgPHpu1fofDKUKmMQZt6fxBIEQQ44g==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.4",
-        "config-disassembler-darwin-x64": "3.4.4",
-        "config-disassembler-linux-arm64-gnu": "3.4.4",
-        "config-disassembler-linux-arm64-musl": "3.4.4",
-        "config-disassembler-linux-x64-gnu": "3.4.4",
-        "config-disassembler-linux-x64-musl": "3.4.4",
-        "config-disassembler-win32-arm64-msvc": "3.4.4",
-        "config-disassembler-win32-ia32-msvc": "3.4.4",
-        "config-disassembler-win32-x64-msvc": "3.4.4"
+        "config-disassembler-darwin-arm64": "3.4.5",
+        "config-disassembler-darwin-x64": "3.4.5",
+        "config-disassembler-linux-arm64-gnu": "3.4.5",
+        "config-disassembler-linux-arm64-musl": "3.4.5",
+        "config-disassembler-linux-x64-gnu": "3.4.5",
+        "config-disassembler-linux-x64-musl": "3.4.5",
+        "config-disassembler-win32-arm64-msvc": "3.4.5",
+        "config-disassembler-win32-ia32-msvc": "3.4.5",
+        "config-disassembler-win32-x64-msvc": "3.4.5"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.4.tgz",
-      "integrity": "sha512-HrDHmIjnbR7RAbCLW0aFPJi5E7OPNfVKEucyMoPn9VcYCzuAPSDIioHbTaPKSZNcokPO5FSRMTpNaxdC24l9MQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.5.tgz",
+      "integrity": "sha512-kplMsQAzS9Jc8vjlupfqTpXKzlv/6AcS6nWi/Kk+GzbKhAInpzUkx1ChE9Ou5KXW8McslNUyJEO31XRNqvr2lQ==",
       "cpu": [
         "arm64"
       ],
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.4.tgz",
-      "integrity": "sha512-QEPtXd2GMuKaI3ReK1QxFmBWgPMUHYiDR75WEUogNO6J9/dynQh6mPQrAQXnMHLy9rrXnQrnXJJwHBXkTgthnw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.5.tgz",
+      "integrity": "sha512-JYFlbhh66XfFT2eQD+VNQk1IKV803mFnzbhvcmbyD2MLpfw/GEsBN4x9dkQ38l/4VZZ1+1nym/Bjv9T4b2TdhQ==",
       "cpu": [
         "x64"
       ],
@@ -7993,9 +7993,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.4.tgz",
-      "integrity": "sha512-OMnyUYYeeNTEBjwKpn7h7GymJ0UA6npkDeNdanOv+SWY5tChk82sVobmDb02MVuR21FEJ79/6QhKuf5gDq82ww==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.5.tgz",
+      "integrity": "sha512-I7xk81434vT4xWyuqf8PfuCkcLBLg/k00boVAtWvVYEskHnJ9k5tyCS3D5/jiMg03cPmk8JS1si7b3SuNmgHwQ==",
       "cpu": [
         "arm64"
       ],
@@ -8012,9 +8012,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.4.tgz",
-      "integrity": "sha512-yKLzHy7zLDPCp8RRw3t8uGsmegBSlF22BQSZ6eZJW3eI0rqxTPjfon4CmsrLOo7EdcFkFhXNxwfMIgzYbV5vHQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.5.tgz",
+      "integrity": "sha512-Sua/xHaUoPoD8s8ogBwp9cPAIjEFWEdF6zM0x8OPLmB2eh0Y6ms+RJ7BP0slNafuI+SQhgJamqz1LlRnkvnmYA==",
       "cpu": [
         "arm64"
       ],
@@ -8031,9 +8031,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.4.tgz",
-      "integrity": "sha512-q9eAaFWpI2U91ktO2J7ypJEgwCqMloliWijTPs6kcvPDGPuS0PGBX0j32YLBVN+cExYuaYEN0FuKk7YObw0SLw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.5.tgz",
+      "integrity": "sha512-wHSshoXPLlw1VXsSaDHTNYIOnEUTXlGdK5fjvygpgnEoFSbjb+wr1axzQd9kQJq9SOWUjZGApsLUX68UnRWEqw==",
       "cpu": [
         "x64"
       ],
@@ -8050,9 +8050,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.4.tgz",
-      "integrity": "sha512-rpxZQ+Tyef8pA8hLqz9++fe7gI6XXcmbVGBTuALj7Jpfga0juWtqI3ZNgtwqWE7p7cmT2rCTGPcP3dS6l9qtog==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.5.tgz",
+      "integrity": "sha512-WpJgwjPuEBwA+XfD5CBaXQWqblBqc2w+7Zwn7KdT/qXsJ6OMNuoptjXj9PsbFu8ZhWR0JaUH1/qH7wg9uwhU8g==",
       "cpu": [
         "x64"
       ],
@@ -8069,9 +8069,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.4.tgz",
-      "integrity": "sha512-GGDp66LJiLEMM10iP4BLlPAFRmnurWqLaptIg8+9qO43vE4sAsjr2au+R+XHq5gF8fEzKQhUIMmW4ivFQy4Zsw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.5.tgz",
+      "integrity": "sha512-Qcv5ecVlfoDKIt2o6PpryQEJqQNmlV2xTLJzOsos7M9kk3G2ek9VdERF14JJfyU7BgG3/kONHH1IgR5HsPiQdQ==",
       "cpu": [
         "arm64"
       ],
@@ -8085,9 +8085,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.4.tgz",
-      "integrity": "sha512-XsdwqgNxnWbKpD0mt3g1e6gx4bGtgWowo+JFtSM3UZCAMLU9G53XbYQqFVETTKvyLgaZRZeSCJZ39UU7S0/yUg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.5.tgz",
+      "integrity": "sha512-PjjDC+2d/8E0iBZbxhovZM8f+Mm21w1gyJnth3VnGQYkO2qT14GMoILwzi1gU33lxIeBvhTpfwTbCJdoYdzY+Q==",
       "cpu": [
         "ia32"
       ],
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.4.tgz",
-      "integrity": "sha512-7ahlw6TVWv0m0blZFMw2ysS+pbThtaZ7px80WZx/3CvPSfPhKBXvOzKV+DKKRtCB7ot7xRHh1Wu825YT9cHumQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.5.tgz",
+      "integrity": "sha512-PSIszJsalYjrFe7cr26ZZxPAeLly2nfJlhHvvW1/pIbctrgu+tgeWmZA2+4mh/Jl1CSU4Q2g1FJ5ojszx4i80g==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@stryker-mutator/vitest-runner": "10.0.0",
         "@types/node": "26.4.0",
         "@vitest/coverage-v8": "4.1.11",
+        "fast-check": "4.9.0",
         "husky": "9.1.7",
         "knip": "6.34.0",
         "lint-staged": "17.4.1",
@@ -8986,6 +8987,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
@@ -13291,6 +13315,23 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "5.0.0",
         "@salesforce/core": "9.1.9",
         "@salesforce/sf-plugins-core": "13.0.4",
-        "config-disassembler": "3.4.5"
+        "config-disassembler": "3.4.6"
       },
       "devDependencies": {
         "@actions/core": "3.0.1",
@@ -7941,29 +7941,29 @@
       "license": "ISC"
     },
     "node_modules/config-disassembler": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.5.tgz",
-      "integrity": "sha512-vui5bLy0ch/2e5d+Yv1MaNMuProBGSYu+g39Pg8sPgQfDkXNBgqOjntpGgPHpu1fofDKUKmMQZt6fxBIEQQ44g==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler/-/config-disassembler-3.4.6.tgz",
+      "integrity": "sha512-Ho9VEIE2rL8Sfs+7LKdRMLASsOF1BGn49sWxgdnpsm83jDqx84Snmo840oBIbuGX2FGfyjtWcpXAAYk/a0L/ew==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "optionalDependencies": {
-        "config-disassembler-darwin-arm64": "3.4.5",
-        "config-disassembler-darwin-x64": "3.4.5",
-        "config-disassembler-linux-arm64-gnu": "3.4.5",
-        "config-disassembler-linux-arm64-musl": "3.4.5",
-        "config-disassembler-linux-x64-gnu": "3.4.5",
-        "config-disassembler-linux-x64-musl": "3.4.5",
-        "config-disassembler-win32-arm64-msvc": "3.4.5",
-        "config-disassembler-win32-ia32-msvc": "3.4.5",
-        "config-disassembler-win32-x64-msvc": "3.4.5"
+        "config-disassembler-darwin-arm64": "3.4.6",
+        "config-disassembler-darwin-x64": "3.4.6",
+        "config-disassembler-linux-arm64-gnu": "3.4.6",
+        "config-disassembler-linux-arm64-musl": "3.4.6",
+        "config-disassembler-linux-x64-gnu": "3.4.6",
+        "config-disassembler-linux-x64-musl": "3.4.6",
+        "config-disassembler-win32-arm64-msvc": "3.4.6",
+        "config-disassembler-win32-ia32-msvc": "3.4.6",
+        "config-disassembler-win32-x64-msvc": "3.4.6"
       }
     },
     "node_modules/config-disassembler-darwin-arm64": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.5.tgz",
-      "integrity": "sha512-kplMsQAzS9Jc8vjlupfqTpXKzlv/6AcS6nWi/Kk+GzbKhAInpzUkx1ChE9Ou5KXW8McslNUyJEO31XRNqvr2lQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-arm64/-/config-disassembler-darwin-arm64-3.4.6.tgz",
+      "integrity": "sha512-WlLKf3SCzTMdydIL80tkKTHCyVpq9MDEswyaOGkNgkhu4OBX2CG2MyocV4m8N0s040Y7Afjrg89ALcwyTyd9wA==",
       "cpu": [
         "arm64"
       ],
@@ -7977,9 +7977,9 @@
       }
     },
     "node_modules/config-disassembler-darwin-x64": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.5.tgz",
-      "integrity": "sha512-JYFlbhh66XfFT2eQD+VNQk1IKV803mFnzbhvcmbyD2MLpfw/GEsBN4x9dkQ38l/4VZZ1+1nym/Bjv9T4b2TdhQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-darwin-x64/-/config-disassembler-darwin-x64-3.4.6.tgz",
+      "integrity": "sha512-bFcs5aBeIDovxicQJqUDjMniYmWfMFZGxIqJUdqL3xYEpFbQQqC/MR4L6Ew1TvZq51p1vFeo4dL7gZ0dphK3Eg==",
       "cpu": [
         "x64"
       ],
@@ -7993,9 +7993,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-gnu": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.5.tgz",
-      "integrity": "sha512-I7xk81434vT4xWyuqf8PfuCkcLBLg/k00boVAtWvVYEskHnJ9k5tyCS3D5/jiMg03cPmk8JS1si7b3SuNmgHwQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-gnu/-/config-disassembler-linux-arm64-gnu-3.4.6.tgz",
+      "integrity": "sha512-XOwH/9MQEvYJISbkq9NPHmx1tLej+B/aIwvGpOQeAEuHf3DLBooH237sY/555ob0GE0Y5+jv8iramK4pehBhow==",
       "cpu": [
         "arm64"
       ],
@@ -8012,9 +8012,9 @@
       }
     },
     "node_modules/config-disassembler-linux-arm64-musl": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.5.tgz",
-      "integrity": "sha512-Sua/xHaUoPoD8s8ogBwp9cPAIjEFWEdF6zM0x8OPLmB2eh0Y6ms+RJ7BP0slNafuI+SQhgJamqz1LlRnkvnmYA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-arm64-musl/-/config-disassembler-linux-arm64-musl-3.4.6.tgz",
+      "integrity": "sha512-Br3Rm1c6d+BQlMxU7rCYA5AIc2KJ+YqsLA27jAgMGDFS7lJSs4bANV7+lO+ILjbQYcd8xKzGop52oareJ6tYcQ==",
       "cpu": [
         "arm64"
       ],
@@ -8031,9 +8031,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-gnu": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.5.tgz",
-      "integrity": "sha512-wHSshoXPLlw1VXsSaDHTNYIOnEUTXlGdK5fjvygpgnEoFSbjb+wr1axzQd9kQJq9SOWUjZGApsLUX68UnRWEqw==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-gnu/-/config-disassembler-linux-x64-gnu-3.4.6.tgz",
+      "integrity": "sha512-iELSJ5H1HpOZLwpAPp7c23IWVoRYVICrROQ49qg3X5L/wh59cWPcbLsAjRtY034fFyMc5KTrlbMAWSuJ7kRK1g==",
       "cpu": [
         "x64"
       ],
@@ -8050,9 +8050,9 @@
       }
     },
     "node_modules/config-disassembler-linux-x64-musl": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.5.tgz",
-      "integrity": "sha512-WpJgwjPuEBwA+XfD5CBaXQWqblBqc2w+7Zwn7KdT/qXsJ6OMNuoptjXj9PsbFu8ZhWR0JaUH1/qH7wg9uwhU8g==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-linux-x64-musl/-/config-disassembler-linux-x64-musl-3.4.6.tgz",
+      "integrity": "sha512-tCu9T41Xsc/kyj5V1LmqMV87wTEcqbC2+dqfVGOn/pXw6dXvB0kP6ZxGEobw2DTrz6MpabYDYzzrzg1FXqa54g==",
       "cpu": [
         "x64"
       ],
@@ -8069,9 +8069,9 @@
       }
     },
     "node_modules/config-disassembler-win32-arm64-msvc": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.5.tgz",
-      "integrity": "sha512-Qcv5ecVlfoDKIt2o6PpryQEJqQNmlV2xTLJzOsos7M9kk3G2ek9VdERF14JJfyU7BgG3/kONHH1IgR5HsPiQdQ==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-arm64-msvc/-/config-disassembler-win32-arm64-msvc-3.4.6.tgz",
+      "integrity": "sha512-OhAvq/zmZnbqKXC2OSPZAQil9Ofh8O26TfANTbTpjjVzopSVI/0vbbYYyfjAcO5Fb8/PcgWd7WW4YXjMfMb2yQ==",
       "cpu": [
         "arm64"
       ],
@@ -8085,9 +8085,9 @@
       }
     },
     "node_modules/config-disassembler-win32-ia32-msvc": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.5.tgz",
-      "integrity": "sha512-PjjDC+2d/8E0iBZbxhovZM8f+Mm21w1gyJnth3VnGQYkO2qT14GMoILwzi1gU33lxIeBvhTpfwTbCJdoYdzY+Q==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-ia32-msvc/-/config-disassembler-win32-ia32-msvc-3.4.6.tgz",
+      "integrity": "sha512-dBpBIXWgPlLYYqeb+BbXxHGQFfwf3BD036VrVncv+l/EZ/NRT5AlGeZZP2VItetF+oIolTD5RjgyMreohWbUAw==",
       "cpu": [
         "ia32"
       ],
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/config-disassembler-win32-x64-msvc": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.5.tgz",
-      "integrity": "sha512-PSIszJsalYjrFe7cr26ZZxPAeLly2nfJlhHvvW1/pIbctrgu+tgeWmZA2+4mh/Jl1CSU4Q2g1FJ5ojszx4i80g==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/config-disassembler-win32-x64-msvc/-/config-disassembler-win32-x64-msvc-3.4.6.tgz",
+      "integrity": "sha512-c0SbEwpMuGShHVNn90P8M/JBvWyH34lmJnL5CsZsRHXzF15Yw1EjaogqENM5UZrvgEjwGW+D4SshcaW+Tb4xRA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.3"
+    "config-disassembler": "3.4.4"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@stryker-mutator/vitest-runner": "10.0.0",
     "@types/node": "26.4.0",
     "@vitest/coverage-v8": "4.1.11",
+    "fast-check": "4.9.0",
     "husky": "9.1.7",
     "knip": "6.34.0",
     "lint-staged": "17.4.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.6"
+    "config-disassembler": "3.4.7"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.2"
+    "config-disassembler": "3.4.3"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.5"
+    "config-disassembler": "3.4.6"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "5.0.0",
     "@salesforce/core": "9.1.9",
     "@salesforce/sf-plugins-core": "13.0.4",
-    "config-disassembler": "3.4.4"
+    "config-disassembler": "3.4.5"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",

--- a/test/units/xmlRoundtripFuzz.test.ts
+++ b/test/units/xmlRoundtripFuzz.test.ts
@@ -54,7 +54,10 @@ const ILLEGAL_XML_CHARS_PATTERN = new RegExp(
 
 const stripIllegalControlChars = (raw: string): string => raw.replace(ILLEGAL_XML_CHARS_PATTERN, '');
 
-const sanitizeText = (raw: string): string => stripIllegalControlChars(raw).replace(/[<&>]/g, ' ');
+// Quotes are legal, unescaped XML text but get entity-encoded (&quot;/&apos;)
+// by the writer same as `<`/`&`/`>` - stripped here too so the literal-value
+// substring check below isn't comparing against the wrong (escaped) form.
+const sanitizeText = (raw: string): string => stripIllegalControlChars(raw).replace(/[<&>"']/g, ' ');
 
 const sanitizeCdata = (raw: string): string => stripIllegalControlChars(raw).replace(/]]>/g, '] ]>');
 

--- a/test/units/xmlRoundtripFuzz.test.ts
+++ b/test/units/xmlRoundtripFuzz.test.ts
@@ -1,0 +1,177 @@
+'use strict';
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DisassembleXMLFileHandler, ReassembleXMLFileHandler } from 'config-disassembler';
+import fc from 'fast-check';
+import { describe, expect, it } from 'vitest';
+
+// Property-based fuzzing of the decompose/recompose round trip against
+// arbitrary nested XML shapes, complementing the curated fixtures in
+// decomposer.test.ts. Curated fixtures only catch regressions in shapes we
+// already thought to write down (see the CDATA/indentation investigation
+// that led to this file); a fuzzer explores shapes nobody hand-authored.
+//
+// Two properties are checked, matching the same tolerance model as the perf
+// suite's byte-retention + idempotence guards (test/perf/README.md):
+//   1. No content loss: every non-whitespace leaf value in the generated
+//      document must still appear verbatim after one round trip.
+//   2. Idempotence: a second round trip must produce byte-identical output
+//      to the first. The first round trip is allowed to reformat (e.g.
+//      normalize CDATA indentation) - only the *second* is required to be
+//      stable, exactly as documented for the perf suite.
+//
+// Deliberately NOT asserting original-bytes-equal-first-round-trip-bytes:
+// that's a stricter bar than this project holds itself to anywhere else,
+// and an early draft of this test built on config-disassembler's own
+// verifyXmlRoundtrip() helper (which does compare against the original)
+// flagged benign first-pass reformatting as "drift" for tightly-packed
+// CDATA. That's a real gap in that helper's canonicalization, not a data
+// loss bug in the actual disassemble/reassemble pipeline. This test
+// intentionally checks the two properties this project actually promises
+// instead.
+
+const MAX_DEPTH = 3;
+const TAGS = ['alpha', 'beta', 'gamma', 'wrapper', 'group', 'entry', 'node'] as const;
+
+type FuzzNode =
+  | { kind: 'text'; value: string }
+  | { kind: 'cdata'; value: string }
+  | { kind: 'comment'; value: string }
+  | { kind: 'element'; tag: string; children: FuzzNode[] };
+
+// XML 1.0 forbids most C0 control characters. Built from char codes at
+// runtime (rather than \u escapes in a regex literal) so no raw control
+// bytes ever need to appear in this source file.
+const ILLEGAL_XML_CHAR_CODES = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+];
+const ILLEGAL_XML_CHARS_PATTERN = new RegExp(
+  `[${ILLEGAL_XML_CHAR_CODES.map((code) => String.fromCharCode(code)).join('')}]`,
+  'g',
+);
+
+const stripIllegalControlChars = (raw: string): string => raw.replace(ILLEGAL_XML_CHARS_PATTERN, '');
+
+const sanitizeText = (raw: string): string => stripIllegalControlChars(raw).replace(/[<&>]/g, ' ');
+
+const sanitizeCdata = (raw: string): string => stripIllegalControlChars(raw).replace(/]]>/g, '] ]>');
+
+const sanitizeComment = (raw: string): string => {
+  const s = stripIllegalControlChars(raw).replace(/--/g, '- -');
+  return s.endsWith('-') ? `${s} ` : s;
+};
+
+const tagArb = fc.constantFrom(...TAGS);
+const textLeafArb = fc.string({ maxLength: 24 }).map((v): FuzzNode => ({ kind: 'text', value: sanitizeText(v) }));
+const cdataLeafArb = fc.string({ maxLength: 24 }).map((v): FuzzNode => ({ kind: 'cdata', value: sanitizeCdata(v) }));
+const commentLeafArb = fc
+  .string({ maxLength: 24 })
+  .map((v): FuzzNode => ({ kind: 'comment', value: sanitizeComment(v) }));
+
+function nodeArb(depth: number): fc.Arbitrary<FuzzNode> {
+  const leaves = [textLeafArb, cdataLeafArb, commentLeafArb];
+  if (depth >= MAX_DEPTH) {
+    return fc.oneof(...leaves);
+  }
+  return fc.oneof(
+    { weight: 3, arbitrary: textLeafArb },
+    { weight: 1, arbitrary: cdataLeafArb },
+    { weight: 1, arbitrary: commentLeafArb },
+    {
+      weight: 2,
+      arbitrary: fc
+        .record({ tag: tagArb, children: fc.array(nodeArb(depth + 1), { maxLength: 3 }) })
+        .map((r): FuzzNode => ({ kind: 'element', ...r })),
+    },
+  );
+}
+
+// Each item is the child-node list wrapped in a synthetic, sequential
+// <fullName> at serialization time - keeps naming collision-free so we're
+// fuzzing content/structure, not the separate unique-id-fallback behavior.
+const documentArb = fc.array(fc.array(nodeArb(1), { minLength: 1, maxLength: 4 }), { minLength: 2, maxLength: 5 });
+
+function serializeNode(node: FuzzNode): string {
+  switch (node.kind) {
+    case 'text':
+      return node.value;
+    case 'cdata':
+      return `<![CDATA[${node.value}]]>`;
+    case 'comment':
+      return `<!--${node.value}-->`;
+    case 'element':
+      return `<${node.tag}>${node.children.map(serializeNode).join('')}</${node.tag}>`;
+  }
+}
+
+function buildDocument(items: FuzzNode[][]): string {
+  const itemsXml = items
+    .map((children, i) => `<item><fullName>Item${i}</fullName>${children.map(serializeNode).join('')}</item>`)
+    .join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<FuzzRoot xmlns="http://soap.sforce.com/2006/04/metadata">${itemsXml}</FuzzRoot>`;
+}
+
+function collectLeafValues(nodes: FuzzNode[], out: string[]): void {
+  for (const node of nodes) {
+    if (node.kind === 'element') {
+      collectLeafValues(node.children, out);
+    } else if (node.value.trim().length > 0) {
+      // Whitespace-only leaves are excluded: whether insignificant whitespace
+      // survives verbatim is exactly the ambiguous, tool-normalized case this
+      // suite already knows not to pin down byte-for-byte (see file header).
+      out.push(node.value);
+    }
+  }
+}
+
+async function roundTripOnce(dir: string, filePath: string): Promise<string> {
+  const disassembler = new DisassembleXMLFileHandler();
+  await disassembler.disassemble({
+    filePath,
+    strategy: 'unique-id',
+    uniqueIdElements: 'fullName',
+    prePurge: true,
+    postPurge: true,
+    format: 'xml',
+  });
+
+  const reassembler = new ReassembleXMLFileHandler();
+  await reassembler.reassemble({
+    filePath: join(dir, 'Fuzz'),
+    fileExtension: 'fuzz-meta.xml',
+    postPurge: true,
+  });
+
+  return readFile(filePath, 'utf-8');
+}
+
+describe('xml decompose/recompose fuzz', () => {
+  it('preserves every leaf value and stabilizes after one round trip, across arbitrary nested XML shapes', async () => {
+    await fc.assert(
+      fc.asyncProperty(documentArb, async (items) => {
+        const xml = buildDocument(items);
+        const leafValues: string[] = [];
+        for (const children of items) collectLeafValues(children, leafValues);
+
+        const dir = await mkdtemp(join(tmpdir(), 'xml-fuzz-'));
+        const filePath = join(dir, 'Fuzz.fuzz-meta.xml');
+        try {
+          await writeFile(filePath, xml, 'utf-8');
+
+          const pass1 = await roundTripOnce(dir, filePath);
+          for (const value of leafValues) {
+            expect(pass1.includes(value), `leaf value ${JSON.stringify(value)} missing after round trip`).toBe(true);
+          }
+
+          const pass2 = await roundTripOnce(dir, filePath);
+          expect(pass2, 'second round trip must be byte-identical to the first (idempotence)').toBe(pass1);
+        } finally {
+          await rm(dir, { recursive: true, force: true });
+        }
+      }),
+      { numRuns: 25 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a property-based fuzz test (`test/units/xmlRoundtripFuzz.test.ts`, `fast-check` devDependency) for the decompose/recompose round trip, complementing the curated fixtures in `decomposer.test.ts`. Checks two properties matching this project's own byte-retention/idempotence tolerance model: every non-whitespace leaf value must survive one round trip, and a second round trip must be byte-identical to the first.
- Bumps `config-disassembler` 3.4.2 -> 3.4.7 across `package.json` and `docker/package.json`, pulling in four rounds of upstream fixes this fuzz test found along the way:
  - **3.4.4** ([config-disassembler#127](https://github.com/mcarvin8/config-disassembler/pull/127)): an element with both a real child and direct mixed content (CDATA/comment) silently dropped that content.
  - **3.4.5** ([config-disassembler#128](https://github.com/mcarvin8/config-disassembler/pull/128)): a comment containing `&` gained an extra layer of escaping on every round trip, compounding forever.
  - **3.4.6** ([config-disassembler#130](https://github.com/mcarvin8/config-disassembler/pull/130)): multiple sibling comments under the same element - only the last survived.
  - **3.4.7** ([config-disassembler#134](https://github.com/mcarvin8/config-disassembler/pull/134)): four related bugs where text mixed with child elements or CDATA was lost or grew unbounded across round trips.
- The commit history on this branch documents each bump as it landed, holding the fuzz test back from `npm test` until the specific bug it had found was fixed and released - each intermediate commit's full suite run (618/619, the fuzz test itself failing on the then-still-open bug) is preserved for context.

## Test plan
- [x] `npx vitest run test/units/xmlRoundtripFuzz.test.ts` run independently 4 times with fresh random seeds - all green
- [x] `npx vitest run` (full suite) - 34/34 files, 619/619 tests passing
- [x] Verified `config-disassembler@3.4.7` and all 9 platform binaries published on npm before bumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ADqqfdwfnhTPJQp17sH3C